### PR TITLE
add init script for 2020.09 version of pilot repo

### DIFF
--- a/.github/workflows/tests_init.yml
+++ b/.github/workflows/tests_init.yml
@@ -19,7 +19,11 @@ jobs:
 
     - name: install Python packages
       run: |
-        pip install archspec
+        pip install archspec pytest
+
+    - name: unit tests for eessi_software_subdir_for_host.py script
+      run:
+          pytest -v init/test.py
 
     - name: test eessi_software_subdir_for_host.py script
       env:

--- a/.github/workflows/tests_init.yml
+++ b/.github/workflows/tests_init.yml
@@ -1,0 +1,30 @@
+# documentation: https://help.github.com/en/articles/workflow-syntax-for-github-actions
+name: Tests for init scripts
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python: [3.6, 3.7, 3.8]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{matrix.python}}
+        architecture: x64
+
+    - name: install Python packages
+      run: |
+        pip install archspec
+
+    - name: test eessi_software_subdir_for_host.py script
+      env:
+          EESSI_X86_64: /tmp/EESSI/software/x86_64
+      run: |
+          mkdir -p ${EESSI_X86_64}/intel/{sandybridge,haswell,skylake_avx512} ${EESSI_X86_64}/generic
+          python3 ./init/eessi_software_subdir_for_host.py /tmp/EESSI > out.txt
+          grep '^x86_64/' out.txt

--- a/init/bash-pilot-2020.09
+++ b/init/bash-pilot-2020.09
@@ -1,0 +1,56 @@
+export EESSI_PILOT_VERSION="2020.09"
+export PS1="[EESSI pilot $EESSI_PILOT_VERSION] $ "
+
+export EESSI_PREFIX=/cvmfs/pilot.eessi-hpc.org/$EESSI_PILOT_VERSION
+if [ -d $EESSI_PREFIX ]; then
+  echo "Found EESSI pilot repo @ $EESSI_PREFIX!"
+
+  export EPREFIX=$EESSI_PREFIX/compat/$(uname -m)
+  if [ -d $EPREFIX ]; then
+
+    # determine subdirectory in software layer
+    EESSI_PYTHON=$EPREFIX/usr/bin/python3
+    export EESSI_SOFTWARE_SUBDIR=$($EESSI_PYTHON ${EESSI_PREFIX}/init/eessi_software_subdir_for_host.py $EESSI_PREFIX)
+    if [ ! -z $EESSI_SOFTWARE_SUBDIR ]; then
+        echo "Derived subdirectory for software layer: $EESSI_SOFTWARE_SUBDIR"
+
+        export EESSI_SOFTWARE_PATH=$EESSI_PREFIX/software/$EESSI_SOFTWARE_SUBDIR
+        if [ -d $EESSI_SOFTWARE_PATH ]; then
+
+          # init Lmod
+          echo "Initializing Lmod..."
+          source $EPREFIX/usr/lmod/*/init/bash
+
+          # prepend location of modules for EESSI software stack to $MODULEPATH
+          export EESSI_MODULEPATH=$EESSI_SOFTWARE_PATH/modules/all
+          echo "Prepending $EESSI_MODULEPATH to \$MODULEPATH..."
+          module use $EESSI_MODULEPATH
+
+          echo
+          echo "*** Known problems in the ${EESSI_PILOT_VERSION} pilot software stack ***"
+          echo
+          echo "1) No Lmod cache has been generated yet for the module files included"
+          echo "   in the ${EESSI_PILOT_VERSION} pilot software stack."
+          echo "   As a result, 'module' commands may be somewhat slow."
+          echo "   (see also https://github.com/EESSI/software-layer/issues/10)"
+          echo
+          echo
+
+          echo "Environment set up to use EESSI pilot software stack, have fun!"
+
+        else
+          echo "ERROR: EESSI software layer at $EESSI_SOFTWARE_PATH not found!" >&2
+          false
+        fi
+    else
+        echo "ERROR: Failed to determine value for \$EESSI_SOFTWARE_SUBDIR" >*&2
+        false
+    fi
+  else
+    echo "ERROR: Compatibility layer directory %s not found!" >&2
+    false
+  fi
+else
+  echo "ERROR: EESSI pilot repository at $EESSI_PREFIX not found!" >&2
+  false
+fi

--- a/init/eessi_software_subdir_for_host.py
+++ b/init/eessi_software_subdir_for_host.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+#
+# Determine EESSI software subdirectory to use for current build host, using archspec
+#
+import glob
+import os
+import sys
+import archspec.cpu
+
+VENDOR_MAP = {
+    'GenuineIntel': 'intel',
+    'AuthenticAMD': 'amd',
+}
+
+GENERIC = 'generic'
+X86_64 = 'x86_64'
+
+KNOWN_CPU_UARCHS = archspec.cpu.TARGETS
+
+
+def error(msg):
+    sys.stderr.write('ERROR: ' + msg + '\n')
+    sys.exit(1)
+
+
+def warning(msg):
+    sys.stderr.write('WARNING: ' + msg + '\n')
+
+
+if len(sys.argv) == 2:
+    eessi_prefix = sys.argv[1]
+else:
+    error("Usage: %s <prefix path>" % sys.argv[0])
+
+eessi_software_layer_path = os.path.join(eessi_prefix, 'software')
+if not os.path.exists(eessi_software_layer_path):
+    error("Specified prefix '%s' does not exist!" % eessi_software_layer_path)
+
+# determine host CPU vendor/family/name
+host_cpu = archspec.cpu.host()
+host_vendor = VENDOR_MAP.get(host_cpu.vendor)
+host_cpu_family = host_cpu.family.name
+host_cpu_name = host_cpu.name
+
+# determine available targets in 'software' subdirectory of specified prefix (only for host CPU family/vendor)
+if host_cpu_family == X86_64:
+    paths = glob.glob(os.path.join(eessi_software_layer_path, host_cpu_family, host_vendor, '*'))
+    # also consider x86_64/generic
+    generic_path = os.path.join(eessi_software_layer_path, host_cpu_family, GENERIC)
+    if os.path.exists(generic_path):
+        paths.append(generic_path)
+else:
+    paths = glob.glob(os.path.join(eessi_software_layer_path, host_cpu_family, '*'))
+
+if not paths:
+    error("No targets found for " + host_cpu_family)
+
+targets = [os.path.basename(p) for p in paths]
+
+# retain only targets compatible with host, and sort them
+target_uarchs = []
+for uarch in targets:
+    if uarch == GENERIC:
+        continue
+    if uarch in KNOWN_CPU_UARCHS:
+        target_uarchs.append(KNOWN_CPU_UARCHS[uarch])
+    else:
+        warning("Ignoring unknown target '%s'" % uarch)
+
+host_uarch = KNOWN_CPU_UARCHS[host_cpu_name]
+compat_target_uarchs = sorted([x for x in target_uarchs if x <= host_uarch])
+
+if compat_target_uarchs:
+    compat_target_names = [x.name for x in compat_target_uarchs]
+    cnt = len(compat_target_uarchs)
+elif GENERIC in targets:
+    compat_target_uarchs = [GENERIC]
+else:
+    error("No targets compatible with %s found!" % host_uarch)
+
+# last target is best pick for current host
+selected_uarch = str(compat_target_uarchs[-1])
+
+if selected_uarch and selected_uarch != GENERIC:
+    parts = (host_cpu_family, host_vendor, selected_uarch)
+else:
+    parts = (host_cpu_family, selected_uarch)
+
+print(os.path.join(*parts))

--- a/init/eessi_software_subdir_for_host.py
+++ b/init/eessi_software_subdir_for_host.py
@@ -27,63 +27,80 @@ def warning(msg):
     sys.stderr.write('WARNING: ' + msg + '\n')
 
 
-if len(sys.argv) == 2:
-    eessi_prefix = sys.argv[1]
-else:
-    error("Usage: %s <prefix path>" % sys.argv[0])
+def det_host_triple():
+    """
+    Determine host triple: (<cpu_family>, <cpu_vendor>, <cpu_name>).
+    <cpu_vendor> may be None if there's no match in VENDOR_MAP.
+    """
+    host_cpu = archspec.cpu.host()
+    host_vendor = VENDOR_MAP.get(host_cpu.vendor)
+    host_cpu_family = host_cpu.family.name
+    host_cpu_name = host_cpu.name
 
-eessi_software_layer_path = os.path.join(eessi_prefix, 'software')
-if not os.path.exists(eessi_software_layer_path):
-    error("Specified prefix '%s' does not exist!" % eessi_software_layer_path)
+    return (host_cpu_family, host_vendor, host_cpu_name)
 
-# determine host CPU vendor/family/name
-host_cpu = archspec.cpu.host()
-host_vendor = VENDOR_MAP.get(host_cpu.vendor)
-host_cpu_family = host_cpu.family.name
-host_cpu_name = host_cpu.name
 
-# determine available targets in 'software' subdirectory of specified prefix (only for host CPU family/vendor)
-if host_cpu_family == X86_64:
-    paths = glob.glob(os.path.join(eessi_software_layer_path, host_cpu_family, host_vendor, '*'))
-    # also consider x86_64/generic
-    generic_path = os.path.join(eessi_software_layer_path, host_cpu_family, GENERIC)
-    if os.path.exists(generic_path):
-        paths.append(generic_path)
-else:
-    paths = glob.glob(os.path.join(eessi_software_layer_path, host_cpu_family, '*'))
+def find_best_target(eessi_prefix):
 
-if not paths:
-    error("No targets found for " + host_cpu_family)
+    eessi_software_layer_path = os.path.join(eessi_prefix, 'software')
+    if not os.path.exists(eessi_software_layer_path):
+        error('Specified prefix "%s" does not exist!' % eessi_software_layer_path)
 
-targets = [os.path.basename(p) for p in paths]
+    host_cpu_family, host_vendor, host_cpu_name = det_host_triple()
 
-# retain only targets compatible with host, and sort them
-target_uarchs = []
-for uarch in targets:
-    if uarch == GENERIC:
-        continue
-    if uarch in KNOWN_CPU_UARCHS:
-        target_uarchs.append(KNOWN_CPU_UARCHS[uarch])
+    # determine available targets in 'software' subdirectory of specified prefix (only for host CPU family/vendor)
+    if host_cpu_family == X86_64:
+        paths = glob.glob(os.path.join(eessi_software_layer_path, host_cpu_family, host_vendor, '*'))
+        # also consider x86_64/generic
+        generic_path = os.path.join(eessi_software_layer_path, host_cpu_family, GENERIC)
+        if os.path.exists(generic_path):
+            paths.append(generic_path)
     else:
-        warning("Ignoring unknown target '%s'" % uarch)
+        paths = glob.glob(os.path.join(eessi_software_layer_path, host_cpu_family, '*'))
 
-host_uarch = KNOWN_CPU_UARCHS[host_cpu_name]
-compat_target_uarchs = sorted([x for x in target_uarchs if x <= host_uarch])
+    if not paths:
+        error('No targets found for ' + host_cpu_name)
 
-if compat_target_uarchs:
-    compat_target_names = [x.name for x in compat_target_uarchs]
-    cnt = len(compat_target_uarchs)
-elif GENERIC in targets:
-    compat_target_uarchs = [GENERIC]
-else:
-    error("No targets compatible with %s found!" % host_uarch)
+    targets = [os.path.basename(p) for p in paths]
 
-# last target is best pick for current host
-selected_uarch = str(compat_target_uarchs[-1])
+    # retain only targets compatible with host, and sort them
+    target_uarchs = []
+    for uarch in targets:
+        if uarch == GENERIC:
+            continue
+        if uarch in KNOWN_CPU_UARCHS:
+            target_uarchs.append(KNOWN_CPU_UARCHS[uarch])
+        else:
+            warning('Ignoring unknown target "%s"' % uarch)
 
-if selected_uarch and selected_uarch != GENERIC:
-    parts = (host_cpu_family, host_vendor, selected_uarch)
-else:
-    parts = (host_cpu_family, selected_uarch)
+    host_uarch = KNOWN_CPU_UARCHS[host_cpu_name]
+    compat_target_uarchs = sorted([x for x in target_uarchs if x <= host_uarch])
 
-print(os.path.join(*parts))
+    if not compat_target_uarchs:
+        if GENERIC in targets:
+            compat_target_uarchs = [GENERIC]
+        else:
+            error('No targets compatible with %s found!' % host_uarch)
+
+    # last target is best pick for current host
+    selected_uarch = str(compat_target_uarchs[-1])
+
+    if selected_uarch and selected_uarch != GENERIC:
+        parts = (host_cpu_family, host_vendor, selected_uarch)
+    else:
+        parts = (host_cpu_family, selected_uarch)
+
+    return os.path.join(*parts)
+
+
+def main():
+    if len(sys.argv) == 2:
+        eessi_prefix = sys.argv[1]
+    else:
+        error('Usage: %s <prefix path>' % sys.argv[0])
+
+    print(find_best_target(eessi_prefix))
+
+
+if __name__ == '__main__':
+    main()

--- a/init/test.py
+++ b/init/test.py
@@ -1,0 +1,82 @@
+import os
+import pytest
+import re
+
+import eessi_software_subdir_for_host
+from eessi_software_subdir_for_host import find_best_target
+
+
+def prep_tmpdir(tmpdir, subdirs):
+    for subdir in subdirs:
+        os.makedirs(os.path.join(tmpdir, 'software', subdir), exist_ok=True)
+
+
+def test_prefix_does_not_exist(capsys, tmpdir):
+    """Test whether non-existing prefix results in error."""
+
+    with pytest.raises(SystemExit):
+        find_best_target(tmpdir)
+
+    captured = capsys.readouterr()
+    assert captured.out == ''
+    assert re.match('^ERROR: Specified prefix ".*/software" does not exist!$', captured.err)
+
+
+def test_no_targets(tmpdir, capsys):
+    """Test case where no compatible targets are found for host CPU."""
+    prep_tmpdir(tmpdir, [''])
+    with pytest.raises(SystemExit):
+        find_best_target(tmpdir)
+
+    captured = capsys.readouterr()
+    assert captured.out == ''
+    assert re.match('^ERROR: No targets found for .*', captured.err)
+
+
+def test_broadwell_host(tmpdir, capsys, monkeypatch):
+    """Test selecting of target on a Broadwell host."""
+
+    def broadwell_host_triple():
+        return ('x86_64', 'intel', 'broadwell')
+
+    monkeypatch.setattr(eessi_software_subdir_for_host, 'det_host_triple', broadwell_host_triple)
+
+    # if generic is there, that's always a match
+    prep_tmpdir(tmpdir, ['x86_64/generic'])
+    assert find_best_target(tmpdir) == 'x86_64/generic'
+
+    # targets from other CPU familues have no impact on target picked for Intel host CPU
+    prep_tmpdir(tmpdir, ['x86_64/amd/zen2', 'aarch64/graviton2', 'ppc64le/power9'])
+    assert find_best_target(tmpdir) == 'x86_64/generic'
+
+    # incompatible targets are not picked
+    prep_tmpdir(tmpdir, ['x86_64/intel/skylake', 'x86_64/intel/cascadelake'])
+    assert find_best_target(tmpdir) == 'x86_64/generic'
+
+    # compatible targets are picked if no better match is available
+    prep_tmpdir(tmpdir, ['x86_64/intel/nehalem'])
+    assert find_best_target(tmpdir) == 'x86_64/intel/nehalem'
+
+    prep_tmpdir(tmpdir, ['x86_64/intel/ivybridge'])
+    assert find_best_target(tmpdir) == 'x86_64/intel/ivybridge'
+
+    # unknown targets don't cause trouble (only warning)
+    prep_tmpdir(tmpdir, ['x86_64/intel/no_such_intel_cpu'])
+    assert find_best_target(tmpdir) == 'x86_64/intel/ivybridge'
+    captured = capsys.readouterr()
+    assert captured.out == ''
+    assert captured.err == 'WARNING: Ignoring unknown target "no_such_intel_cpu"\n'
+
+    # older targets have to no impact on best target (sandybridge < ivybridge)
+    prep_tmpdir(tmpdir, ['x86_64/intel/sandybridge'])
+    assert find_best_target(tmpdir) == 'x86_64/intel/ivybridge'
+
+    prep_tmpdir(tmpdir, ['x86_64/intel/haswell'])
+    assert find_best_target(tmpdir) == 'x86_64/intel/haswell'
+
+    expected = ['cascadelake', 'haswell', 'ivybridge', 'nehalem', 'no_such_intel_cpu', 'sandybridge', 'skylake']
+    assert sorted(os.listdir(os.path.join(tmpdir, 'software', 'x86_64', 'intel'))) == expected
+
+    # exact match, no better target than this
+    prep_tmpdir(tmpdir, ['x86_64/intel/broadwell'])
+    assert find_best_target(tmpdir) == 'x86_64/intel/broadwell'


### PR DESCRIPTION
Ideally we also test the init script itself, by mounting the EESSI pilot repo in a GitHub Actions workflow, and sourcing it...

@bedroge The `init/bash-pilot-2020.09` script should be copied to `/cvmfs/pilot.eessi-hpc.org/2020.09/init/bash`, the `init/eessi_software_subdir_for_host.py` script should be copied into `/cvmfs/pilot.eessi-hpc.org/2020.09/init/`.