### PR TITLE
Make fontconfig aware of the compatibility layer's fonts directory

### DIFF
--- a/fontconfig-2.13.92-GCCcore-9.3.0.eb
+++ b/fontconfig-2.13.92-GCCcore-9.3.0.eb
@@ -1,0 +1,39 @@
+easyblock = 'ConfigureMake'
+
+name = 'fontconfig'
+version = '2.13.92'
+
+homepage = 'https://www.freedesktop.org/wiki/Software/fontconfig/'
+
+description = """
+ Fontconfig is a library designed to provide system-wide font configuration,
+ customization and application access.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://www.freedesktop.org/software/fontconfig/release/']
+sources = [SOURCE_TAR_GZ]
+checksums = ['3406a05b83a42231e3df68d02bc0a0cf47b3f2e8f11c8ede62267daf5f130016']
+
+builddependencies = [
+    ('binutils', '2.34'),
+    ('gperf', '3.1'),
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('expat', '2.2.9'),
+    ('freetype', '2.10.1'),
+    ('util-linux', '2.35'),
+]
+
+configopts = '--disable-docs --with-add-fonts=$EPREFIX/usr/share/fonts'
+
+sanity_check_paths = {
+    'files': ['include/fontconfig/fontconfig.h', 'lib/libfontconfig.%s' % SHLIB_EXT],
+    'dirs': []
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
See #29. This adds `--with-add-fonts=$EPREFIX/usr/share/fonts` to the `configopts`, to make sure that fontconfig will also look for fonts in the compatibility layer's fonts directory.

@boegel: does `eb` automatically pick up this file when Qt5 gets installed with `--robot`? Or should I add an explicit step that installs fontconfig using this local easyconfig file?