### PR TITLE
Prevent use of EasyBuild GitHub integration.

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -31,6 +31,9 @@ fi
 
 TMPDIR=$(mktemp -d)
 
+# Prevent the script from trying to use git integration
+unset EASYBUILD_GITHUB_USER
+
 echo ">> Setting up environment..."
 export CVMFS_REPO="/cvmfs/pilot.eessi-hpc.org"
 export EESSI_PILOT_VERSION="2020.10"


### PR DESCRIPTION
If EASYBUILD_GITHUB_USER is set, we get stuff like this:

```
All set, let's start installing some software in /cvmfs/pilot.eessi-hpc.org/2020.10/software/aarch64/generic...
>> Starting slow with GCC-9.3.0.eb...
== temporary log file in case of crash /tmp/eb-btx0h0fc/easybuild-m_qvrcjb.log
Please enter password for encrypted keyring:
```

Whops?