### PR TITLE
add Dockerfiles for container image that includes a (working) fuse-overlayfs

### DIFF
--- a/Dockerfile.fuse-overlay-debian10-aarch64
+++ b/Dockerfile.fuse-overlay-debian10-aarch64
@@ -12,7 +12,7 @@ RUN apt-get install -y debhelper autotools-dev cmake cpio libcap-dev libssl-dev 
   uuid adduser autofs psmisc curl attr openssl libcap2 libcap2-bin lsof rsync jq usbutils sqlite3 sudo \
   fuse libfuse-dev libfuse2 libfuse3-dev
 
-# build CervVM-FS from source (no aarch64 Debian packages available)
+# build CernVM-FS from source (no aarch64 Debian packages available)
 RUN apt-get install sudo && \
   wget https://github.com/cvmfs/cvmfs/archive/cvmfs-2.7.5.tar.gz && \
   tar xfz cvmfs-2.7.5.tar.gz && \

--- a/Dockerfile.fuse-overlay-debian10-aarch64
+++ b/Dockerfile.fuse-overlay-debian10-aarch64
@@ -29,7 +29,7 @@ RUN wget https://github.com/EESSI/filesystem-layer/releases/download/v0.2.3/cvmf
   dpkg -i cvmfs-config-eessi_0.2.3_all.deb && \
   rm -f cvmfs-config-eessi_0.2.3_all.deb
 
-# install fuse3 to Singularity's --fusemount works
+# install fuse3 so Singularity's --fusemount works
 # (can't be installed together with fuse)
 RUN apt-get remove -y fuse && apt-get install -y fuse3
 

--- a/Dockerfile.fuse-overlay-debian10-aarch64
+++ b/Dockerfile.fuse-overlay-debian10-aarch64
@@ -1,0 +1,41 @@
+FROM docker.io/arm64v8/debian:10.6
+
+RUN apt-get update -y && \
+  apt-get install -y wget lsb-release
+
+RUN wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb &&  \
+  dpkg -i cvmfs-release-latest_all.deb && \
+  rm -f cvmfs-release-latest_all.deb
+
+RUN apt-get install -y debhelper autotools-dev cmake cpio libcap-dev libssl-dev pkg-config libattr1-dev patch \
+  python-dev python-setuptools unzip uuid-dev valgrind libz-dev gawk psmisc autofs curl attr zlib1g gdb uuid-dev \
+  uuid adduser autofs psmisc curl attr openssl libcap2 libcap2-bin lsof rsync jq usbutils sqlite3 sudo \
+  fuse libfuse-dev libfuse2 libfuse3-dev
+
+# build CervVM-FS from source (no aarch64 Debian packages available)
+RUN apt-get install sudo && \
+  wget https://github.com/cvmfs/cvmfs/archive/cvmfs-2.7.5.tar.gz && \
+  tar xfz cvmfs-2.7.5.tar.gz && \
+  cd cvmfs*2.7.5/ && \
+  mkdir build && \
+  cd build && \
+  cmake .. -DBUILD_SERVER=no -DBUILD_SERVER_DEBUG=no -DDBUILD_SHRINKWRAP=no && \
+  make -j $(nproc) && \
+  sudo make install && \
+  cd / && \
+  rm -r cvmfs*2.7.5*
+
+RUN wget https://github.com/EESSI/filesystem-layer/releases/download/v0.2.3/cvmfs-config-eessi_0.2.3_all.deb && \
+  dpkg -i cvmfs-config-eessi_0.2.3_all.deb && \
+  rm -f cvmfs-config-eessi_0.2.3_all.deb
+
+# install fuse3 to Singularity's --fusemount works
+# (can't be installed together with fuse)
+RUN apt-get remove -y fuse && apt-get install -y fuse3
+
+RUN apt-get install -y fuse-overlayfs
+
+RUN echo 'CVMFS_QUOTA_LIMIT=10000' > /etc/cvmfs/default.local && \
+  echo 'CVMFS_HTTP_PROXY="DIRECT"' >> /etc/cvmfs/default.local
+
+ENV LC_ALL=C

--- a/Dockerfile.fuse-overlay-debian10-x86_64
+++ b/Dockerfile.fuse-overlay-debian10-x86_64
@@ -1,0 +1,22 @@
+FROM docker.io/debian:10.6
+
+RUN apt-get update -y && \
+  apt-get install -y wget lsb-release
+
+RUN wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb &&  \
+  dpkg -i cvmfs-release-latest_all.deb && \
+  rm -f cvmfs-release-latest_all.deb
+
+RUN apt-get update -y && \
+  apt-get install -y cvmfs cvmfs-config-default cvmfs-fuse3
+
+RUN wget https://github.com/EESSI/filesystem-layer/releases/download/v0.2.3/cvmfs-config-eessi_0.2.3_all.deb && \
+  dpkg -i cvmfs-config-eessi_0.2.3_all.deb && \
+  rm -f cvmfs-config-eessi_0.2.3_all.deb
+
+RUN apt-get install -y fuse-overlayfs
+
+RUN echo 'CVMFS_QUOTA_LIMIT=10000' > /etc/cvmfs/default.local && \
+  echo 'CVMFS_HTTP_PROXY="DIRECT"' >> /etc/cvmfs/default.local
+
+ENV LC_ALL=C


### PR DESCRIPTION
Resulting container images are available through Docker Hub, see https://hub.docker.com/r/eessi/fuse-overlay/tags

To use:

```bash
# create temporary directory
export EESSI_TMPDIR=/tmp/$USER
mkdir -p $EESSI_TMPDIR

# create scratch dirs for $HOME, overlayfs and CVMFS
mkdir -p $EESSI_TMPDIR/{home,overlay-upper,overlay-work}
mkdir -p $EESSI_TMPDIR/{var-lib-cvmfs,var-run-cvmfs}

# specify Singularity configuration
export SINGULARITY_HOME="$EESSI_TMPDIR/home:/home/$USER"
export SINGULARITY_BIND="$EESSI_TMPDIR/var-run-cvmfs:/var/run/cvmfs,$EESSI_TMPDIR/var-lib-cvmfs:/var/lib/cvmfs"
export SINGULARITY_CACHEDIR=$EESSI_TMPDIR/singularity_cache

# values to pass to --fusemount in singularity command
export EESSI_CONFIG="container:cvmfs2 cvmfs-config.eessi-hpc.org /cvmfs/cvmfs-config.eessi-hpc.org"
export EESSI_PILOT_READONLY="container:cvmfs2 pilot.eessi-hpc.org /cvmfs_ro/pilot.eessi-hpc.org"
export EESSI_PILOT_WRITABLE_OVERLAY="container:fuse-overlayfs -o lowerdir=/cvmfs_ro/pilot.eessi-hpc.org -o upperdir=$EESSI_TMPDIR/overlay-upper -o workdir=$EESSI_TMPDIR/overlay-work /cvmfs/pilot.eessi-hpc.org"

# start shell in container
singularity shell --fusemount "$EESSI_CONFIG" --fusemount "$EESSI_PILOT_READONLY" --fusemount "$EESSI_PILOT_WRITABLE_OVERLAY" docker://eessi/fuse-overlay:debian10-$(uname -m)
```