### PR TITLE
fix init script on aarch64/graviton2

### DIFF
--- a/init/eessi_software_subdir_for_host.py
+++ b/init/eessi_software_subdir_for_host.py
@@ -89,7 +89,7 @@ def find_best_target(eessi_prefix):
     # last target is best pick for current host
     selected_uarch = str(compat_target_uarchs[-1])
 
-    if selected_uarch and selected_uarch != GENERIC:
+    if host_vendor and selected_uarch != GENERIC:
         parts = (host_cpu_family, host_vendor, selected_uarch)
     else:
         parts = (host_cpu_family, selected_uarch)


### PR DESCRIPTION
Fix for this crash that happens when sourcing the init script on a Graviton2 instance:

```
[EESSI pilot 2020.10] $ /cvmfs/pilot.eessi-hpc.org/2020.10/compat/aarch64/usr/bin/python3 /tmp/eessi_software_subdir_for_host.py /cvmfs/pilot.eessi-hpc.org/2020.10
Traceback (most recent call last):
  File "/tmp/eessi_software_subdir_for_host.py", line 114, in <module>
    main()
  File "/tmp/eessi_software_subdir_for_host.py", line 108, in main
    target = find_best_target(eessi_prefix)
  File "/tmp/eessi_software_subdir_for_host.py", line 97, in find_best_target
    return os.path.join(*parts)
  File "/cvmfs/pilot.eessi-hpc.org/2020.10/compat/aarch64/usr/lib/python-exec/python3.7/../../../lib/python3.7/posixpath.py", line 94, in join
    genericpath._check_arg_types('join', a, *p)
  File "/cvmfs/pilot.eessi-hpc.org/2020.10/compat/aarch64/usr/lib/python-exec/python3.7/../../../lib/python3.7/genericpath.py", line 153, in _check_arg_types
    (funcname, s.__class__.__name__)) from None
TypeError: join() argument must be str or bytes, not 'NoneType'
```