### PR TITLE
Add script to wrap pilot Python3 installation

### DIFF
--- a/init/eessi_pilot_python3
+++ b/init/eessi_pilot_python3
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+EESSI_PILOT_VERSION="2020.10"
+EESSI_PREFIX=/cvmfs/pilot.eessi-hpc.org/$EESSI_PILOT_VERSION
+
+if [ -d $EESSI_PREFIX ]; then
+  EPREFIX=$EESSI_PREFIX/compat/$(uname -m)
+  if [ -d $EPREFIX ]; then
+    # determine subdirectory in software layer
+    # note: eessi_software_subdir_for_host.py will pick up value from $EESSI_SOFTWARE_SUBDIR_OVERRIDE if it's defined!
+    EESSI_PYTHON=$EPREFIX/usr/bin/python3
+    EESSI_SOFTWARE_SUBDIR=$($EESSI_PYTHON ${EESSI_PREFIX}/init/eessi_software_subdir_for_host.py $EESSI_PREFIX)
+    if [ ! -z $EESSI_SOFTWARE_SUBDIR ]; then
+        EESSI_SOFTWARE_PATH=$EESSI_PREFIX/software/$EESSI_SOFTWARE_SUBDIR
+        if [ -d $EESSI_SOFTWARE_PATH ]; then
+          eessi_pilot_python=$(ls ${EESSI_SOFTWARE_PATH}/software/Python/3*/bin/python | sed 1q)
+          if [ -f "$eessi_pilot_python" ]; then
+            $eessi_pilot_python "$@"
+          else
+            echo "ERROR: No EESSI pilot python 3 available."
+            false
+          fi
+        else
+          echo "ERROR: EESSI software layer at $EESSI_SOFTWARE_PATH not found!" >&2
+          false
+        fi
+    else
+        echo "ERROR: no value set for \$EESSI_SOFTWARE_SUBDIR" >&2
+        false
+    fi
+  else
+    echo "ERROR: Compatibility layer directory %s not found!" >&2
+    false
+  fi
+else
+  echo "ERROR: EESSI pilot repository at $EESSI_PREFIX not found!" >&2
+  false
+fi


### PR DESCRIPTION
This is a straightforward (and hardware portable) way to be able to give Magic Castle the Python it needs to properly configure the JupyterHub service.