### PR TITLE
update build script for 2020.12 pilot version

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -280,7 +280,7 @@ check_exit_code $? "${ok_msg}" "${fail_msg}"
 echo ">> Installing R 4.0.0 (better be patient)..."
 ok_msg="R installed, wow!"
 fail_msg="Installation of R failed, so sad..."
-$EB --from-pr 11616 R-4.0.0-foss-2020a.eb --robot
+$EB R-4.0.0-foss-2020a.eb --robot
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 echo ">> Installing Bioconductor 3.11 bundle..."
@@ -292,7 +292,7 @@ check_exit_code $? "${ok_msg}" "${fail_msg}"
 echo ">> Installing TensorFlow 2.3.1..."
 ok_msg="TensorFlow 2.3.1 installed, w00!"
 fail_msg="Installation of TensorFlow failed, why am I not surprised..."
-$EB --from-pr 11614 TensorFlow-2.3.1-foss-2020a-Python-3.8.2.eb --robot --include-easyblocks-from-pr 2218
+$EB TensorFlow-2.3.1-foss-2020a-Python-3.8.2.eb --robot --include-easyblocks-from-pr 2218
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 echo ">> Installing OSU-Micro-Benchmarks 5.6.3..."


### PR DESCRIPTION
Still WIP, because it needs an update for EasyBuild v4.3.2 which was released last week.

There's now a hard check that the EasyBuild version that gets installed via the bootstrap script is v4.3.1, that needs to be updated.

And the `--*from-pr` special cases need to be revised, some can be dropped if the corresponding PR got merged for EasyBuild v4.3.2 (not all of them were).