### PR TITLE
add location of commands provided by compat layer to $PATH

### DIFF
--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -23,6 +23,11 @@ if [ -d $EESSI_PREFIX ]; then
 
   # Set EPREFIX since that is basically a standard in Gentoo Prefix
   export EPREFIX=$EESSI_PREFIX/compat/$EESSI_OS_TYPE/$EESSI_CPU_FAMILY
+
+  # add location of commands provided by compat layer to $PATH;
+  # see https://github.com/EESSI/software-layer/issues/52
+  export PATH=$EPREFIX/usr/bin:$PATH
+
   export EESSI_EPREFIX=$EPREFIX
   if [ -d $EESSI_EPREFIX ]; then
 


### PR DESCRIPTION
fixes #26 and #52

Also relevant for #46 (as long as we only use `cURL` from compat layer, that problem shouldn't occur); in the `2020.12` revision we added `cURL` to `--filter-deps` (see #51)