### PR TITLE
Allow Lmod initialisation to also be silent

### DIFF
--- a/init/bash
+++ b/init/bash
@@ -17,7 +17,7 @@ if [ $? -eq 0 ]; then
 
     # init Lmod
     echo "Initializing Lmod..." >> $output
-    source $EESSI_EPREFIX/usr/lmod/*/init/bash >> $output
+    source $EESSI_EPREFIX/usr/lmod/*/init/bash
 
     # prepend location of modules for EESSI software stack to $MODULEPATH
     echo "Prepending $EESSI_MODULEPATH to \$MODULEPATH..." >> $output

--- a/init/bash
+++ b/init/bash
@@ -17,7 +17,7 @@ if [ $? -eq 0 ]; then
 
     # init Lmod
     echo "Initializing Lmod..." >> $output
-    source $EESSI_EPREFIX/usr/lmod/*/init/bash
+    source $EESSI_EPREFIX/usr/lmod/*/init/bash >> $output
 
     # prepend location of modules for EESSI software stack to $MODULEPATH
     echo "Prepending $EESSI_MODULEPATH to \$MODULEPATH..." >> $output

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -70,7 +70,7 @@ if [ -d $EESSI_PREFIX ]; then
 
           export LMOD_RC="$EESSI_SOFTWARE_PATH/.lmod/lmodrc.lua"
           if [ -f $LMOD_RC ]; then
-            echo "Found Lmod configuration file at $LMOD_RC"
+            echo "Found Lmod configuration file at $LMOD_RC" >> $output
           else
             error "Lmod configuration file not found at $LMOD_RC"
           fi


### PR DESCRIPTION
Currently we get a line on every login
```
Found Lmod configuration file at /cvmfs/pilot.eessi-hpc.org/2020.12/software/x86_64/amd/zen2/.lmod/lmodrc.lua
```
which I think comes from here