### PR TITLE
Reload modules when opening a subshell

### DIFF
--- a/init/Magic_Castle/bash
+++ b/init/Magic_Castle/bash
@@ -29,7 +29,7 @@ if [ -z "$__Init_Default_Modules" ]; then
      module --initial_load --no_redirect restore
    fi
 else
-   module refresh
+   module reload
 fi
 
 echo "Environment set up to use EESSI pilot software stack (${EESSI_PILOT_VERSION}), have fun!"


### PR DESCRIPTION
When a new shell is opened, if it is started from an initial shell there will be some modules already loaded, we need to do a `reload` to ensure that these modules take priority. A `refresh` means that (in the current configuration) the prefix `bin` get's priority in JupyterHub.

Not sure if I should instead be checking if Lmod is already initialized (and do nothing in that case)