### PR TITLE
Make sure that /dev/stdout is writable if needed

### DIFF
--- a/init/bash
+++ b/init/bash
@@ -1,5 +1,5 @@
 # Allow for a silent mode
-if [[ -v EESSI_SILENT ]]; then
+if [[ -v EESSI_SILENT ]] || [ ! -w /dev/stdout ] ; then
   # EESSI_SILENT set
   output=/dev/null
 else

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -1,5 +1,5 @@
 # Allow for a silent mode
-if [[ -v EESSI_SILENT ]]; then
+if [[ -v EESSI_SILENT ]] || [ ! -w /dev/stdout ] ; then
   # EESSI_SILENT set
   output=/dev/null
 else


### PR DESCRIPTION
There are corner cases (like when `su -` into an account) that `/dev/stdout` is not writable, rather than get permission denied errors we can instead silently make things silent