### PR TITLE
check status of software layer in EESSI pilot repo (2020.12) [WIP]

### DIFF
--- a/.github/workflows/pilot_repo.yml
+++ b/.github/workflows/pilot_repo.yml
@@ -1,0 +1,45 @@
+# documentation: https://help.github.com/en/articles/workflow-syntax-for-github-actions
+name: Tests for EESSI pilot repo
+on: [push, pull_request]
+jobs:
+  pilot_repo:
+    runs-on: ubuntu-18.04
+    env:
+        EESSI_VERSION: 2020.12
+    steps:
+        - name: Check out software-layer repository
+          uses: actions/checkout@v2
+
+        - name: Mount EESSI CernVM-FS pilot repository
+          uses: cvmfs-contrib/github-action-cvmfs@main
+          with:
+              cvmfs_config_package: https://github.com/EESSI/filesystem-layer/releases/download/v0.2.3/cvmfs-config-eessi_0.2.3_all.deb
+              cvmfs_http_proxy: DIRECT
+              cvmfs_repositories: pilot.eessi-hpc.org
+
+        - name: Check access to EESSI pilot repository
+          run: |
+              ls /cvmfs/pilot.eessi-hpc.org
+              source /cvmfs/pilot.eessi-hpc.org/${EESSI_VERSION}/init/bash
+              module avail
+
+        - name: Check software install in EESSI pilot repository
+          env:
+              EB_PYTHON: python3
+          run: |
+              source /cvmfs/pilot.eessi-hpc.org/${EESSI_VERSION}/init/bash
+              module load EasyBuild
+              which -a pip3
+              python3 -m easy_install --user pip
+              python3 -m pip install setuptools wheel
+              python3 -m pip install PyYAML
+              ls -lrtd $HOME/.local/lib/python*/site-packages
+              ls -lrt $HOME/.local/lib/python*/site-packages
+              python3 -V
+              python3 -c 'import yaml'
+              which -a eb
+              eb --version
+              eb --show-system-info
+              export EASYBUILD_FILTER_DEPS='Autoconf,Automake,Autotools,binutils,bzip2,cURL,flex,gettext,gperf,help2man,intltool,libreadline,libtool,M4,ncurses,XZ,zlib'
+              eb --easystack eessi-${EESSI_VERSION}.yml --experimental --missing 2>&1 | tee eb_missing.out
+              grep "^No missing modules!" eb_missing.out

--- a/.github/workflows/pilot_repo.yml
+++ b/.github/workflows/pilot_repo.yml
@@ -6,6 +6,20 @@ jobs:
     runs-on: ubuntu-18.04
     env:
         EESSI_VERSION: 2020.12
+    strategy:
+      fail-fast: false
+      matrix:
+        EESSI_SOFTWARE_SUBDIR_OVERRIDE:
+        - aarch64/generic
+        - aarch64/a64fx
+        - aarch64/generic
+        - aarch64/graviton2
+        - aarch64/thunderx2
+        - ppc64le/power9le
+        - x86_64/generic
+        - x86_64/amd/zen2
+        - x86_64/intel/haswell
+        - x86_64/intel/skylake_avx512
     steps:
         - name: Check out software-layer repository
           uses: actions/checkout@v2
@@ -17,15 +31,10 @@ jobs:
               cvmfs_http_proxy: DIRECT
               cvmfs_repositories: pilot.eessi-hpc.org
 
-        - name: Check access to EESSI pilot repository
-          run: |
-              ls /cvmfs/pilot.eessi-hpc.org
-              source /cvmfs/pilot.eessi-hpc.org/${EESSI_VERSION}/init/bash
-              module avail
-
-        - name: Check software install in EESSI pilot repository
+        - name: Check software installations in EESSI pilot repository
           env:
               EB_PYTHON: python3
+              EESSI_SOFTWARE_SUBDIR_OVERRIDE: ${{matrix.EESSI_SOFTWARE_SUBDIR_OVERRIDE}}
           run: |
               source /cvmfs/pilot.eessi-hpc.org/${EESSI_VERSION}/init/bash
               module load EasyBuild

--- a/eessi-2020.12.yml
+++ b/eessi-2020.12.yml
@@ -1,0 +1,27 @@
+software:
+  R-bundle-Bioconductor:
+    toolchains:
+      foss-2020a:
+        versions:
+          3.11:
+            versionsuffix: -R-4.0.0
+  GROMACS:
+    toolchains:
+      foss-2020a:
+        versions:
+          2020.1:
+            versionsuffix: -Python-3.8.2
+  OpenFOAM:
+    toolchains:
+      foss-2020a:
+        versions: [8, v2006]
+  OSU-Micro-Benchmarks:
+     toolchains:
+       gompi-2020a:
+         versions: [5.6.3]
+  TensorFlow:
+    toolchains:
+      foss-2020a:
+        versions:
+          2.3.1:
+            versionsuffix: -Python-3.8.2


### PR DESCRIPTION
The checks work correctly for the `x86_64/*` software subdirectories, but not for `aarch64/*` and `ppc64le/*`, because EasyBuild is *always* run on `x86_64`, and we override the software subdirectory that is picked via `$EESSI_SOFTWARE_SUBDIR_OVERRIDE` (which then determines which path is added to `$MODULEPATH`).

As a result, the `x86_64` dependency for the Java wrapper is always selected, which is of course missing for the `aarch64/*` and `ppc64le/*` software subdirectories.

In addition, `Yasm` is not installed  for `aarch64` (but it is for `ppc64le`?!), we need to selectively add it to `$EASYBUILD_FILTER_DEPS`. Ideally, the list of software names to include in `$EASYBUILD_FILTER_DEPS` also comes from somewhere else, perhaps a proper EasyBuild configuration file which is shared between the installation script and these checks?

Two real problems were also found:

* `TensorFlow` is not installed (yet) for `pp64le`
* The Lmod configuration file (and probably also cache) is missing in `software/aarch64/thunderx2`