### PR TITLE
fix exit code check for ReFrame and RStudio-Server in software install script

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -304,15 +304,15 @@ if [ ! "${EESSI_CPU_FAMILY}" = "ppc64le" ]; then
 fi
 
 echo ">> Installing ReFrame 3.4.1 ..."
-$EB ReFrame-3.4.1.eb --robot
 ok_msg="ReFrame installed, enjoy!"
 fail_msg="Installation of ReFrame failed, that's a bit strange..."
+$EB ReFrame-3.4.1.eb --robot
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 echo ">> Installing RStudio-Server 1.3.1093..."
-$EB RStudio-Server-1.3.1093-foss-2020a-Java-11-R-4.0.0.eb --robot
 ok_msg="RStudio-Server installed, enjoy!"
 fail_msg="Installation of RStudio-Server failed, might be OS deps..."
+$EB RStudio-Server-1.3.1093-foss-2020a-Java-11-R-4.0.0.eb --robot
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 echo ">> Installing OSU-Micro-Benchmarks 5.6.3..."


### PR DESCRIPTION
The exit code check must happen right after the `eb` call, otherwise we're checking the exit code of the variable assignment... 🤦

We overlooked a broken ReFrame installation because of this issue (see #81).

We should also add a final check at the end to make sure that all target software is indeed installed, probably via an easystack file (I'll look into that in a separate PR).