### PR TITLE
include files in compatability layer may also be required

### DIFF
--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -32,6 +32,9 @@ if [ -d $EESSI_PREFIX ]; then
   # add location of commands provided by compat layer to $PATH;
   # see https://github.com/EESSI/software-layer/issues/52
   export PATH=$EPREFIX/usr/bin:$EPREFIX/bin:$PATH
+  
+  # also add include files provided by compat layer to $CPATH
+  export CPATH=$EPREFIX/usr/include
 
   export EESSI_EPREFIX=$EPREFIX
   if [ -d $EESSI_EPREFIX ]; then


### PR DESCRIPTION
For example:
```
[ocaisa@node1 0.7-GCCcore-9.3.0]$ cling
In file included from input_line_1:1:
In file included from /cvmfs/pilot.eessi-hpc.org/2021.03/software/linux/x86_64/amd/zen2/software/GCCcore/9.3.0/lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../include/c++/9.3.0/new:39:
In file included from /cvmfs/pilot.eessi-hpc.org/2021.03/software/linux/x86_64/amd/zen2/software/GCCcore/9.3.0/lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../include/c++/9.3.0/x86_64-pc-linux-gnu/bits/c++config.h:524:
/cvmfs/pilot.eessi-hpc.org/2021.03/software/linux/x86_64/amd/zen2/software/GCCcore/9.3.0/lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../include/c++/9.3.0/x86_64-pc-linux-gnu/bits/os_defines.h:39:10: fatal error: 'features.h' file not found
#include <features.h>
         ^~~~~~~~~~~~
Replaced symbol atexit cannot be found in JIT!
Replaced symbol at_quick_exit cannot be found in JIT!

****************** CLING ******************
* Type C++ code and press enter to run it *
*             Type .q to exit             *
*******************************************
[cling]$ .q
```