### PR TITLE
add Horovod 6.6 to EESSI pilot 2021.03

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -294,6 +294,12 @@ if [ ! "${EESSI_CPU_FAMILY}" = "ppc64le" ]; then
     $EB TensorFlow-2.3.1-foss-2020a-Python-3.8.2.eb --robot --include-easyblocks-from-pr 2218
     check_exit_code $? "${ok_msg}" "${fail_msg}"
 
+    echo ">> Installing Horovod 0.21.3..."
+    ok_msg="Horovod installed! Go do some parallel training!"
+    fail_msg="Horovod installation failed. There comes the headache..."
+    $EB Horovod-0.21.3-foss-2020a-TensorFlow-2.3.1-Python-3.8.2.eb --robot --from-pr 12543
+    check_exit_code $? "${ok_msg}" "${fail_msg}"
+
     echo ">> Installing code-server 3.7.3..."
     ok_msg="code-server 3.7.3 installed, now you can use VS Code!"
     fail_msg="Installation of code-server failed, that's going to be hard to fix..."

--- a/eessi-2021.03.yml
+++ b/eessi-2021.03.yml
@@ -13,6 +13,12 @@ software:
             versionsuffix: -Python-3.8.2
           2020.4:
             versionsuffix: -Python-3.8.2
+  Horovod:
+    toolchains:
+      foss-2020a:
+        versions:
+          0.21.3:
+            versionsuffix: -TensorFlow-2.3.1-Python-3.8.2
   OpenFOAM:
     toolchains:
       foss-2020a:


### PR DESCRIPTION
I'd like to add Horovod to the buildlist, so that we can also experiment with multi-node TensorFlow (with Horovod)

for `2021.03`:

* [x] `aarch64/generic` (in place)
* [x] `aarch64/graviton2` (in place)
* [x] `x86_64/amd/zen2` (in place)
* [x] `x86_64/intel/haswell` (in place)
* [x] `x86_64/intel/skylake_avx512` (in place)
* [x] `x86_64/generic` (in place)