### PR TITLE
also install GROMACS 2020.4 in EESSI pilot 2021.03

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -263,7 +263,7 @@ check_exit_code $? "${ok_msg}" "${fail_msg}"
 echo ">> Installing GROMACS..."
 ok_msg="GROMACS installed, wow!"
 fail_msg="Installation of GROMACS failed, damned..."
-$EB GROMACS-2020.1-foss-2020a-Python-3.8.2.eb --robot
+$EB GROMACS-2020.1-foss-2020a-Python-3.8.2.eb GROMACS-2020.4-foss-2020a-Python-3.8.2.eb --robot
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 # note: compiling OpenFOAM is memory hungry (16GB is not enough with 8 cores)!

--- a/eessi-2021.03.yml
+++ b/eessi-2021.03.yml
@@ -11,6 +11,8 @@ software:
         versions:
           2020.1:
             versionsuffix: -Python-3.8.2
+          2020.4:
+            versionsuffix: -Python-3.8.2
   OpenFOAM:
     toolchains:
       foss-2020a:


### PR DESCRIPTION
GROMACS 2020.4 to add to EESSI pilot 2021.03, which allows for direct comparison with the system installation on JUWELS at JSC (see https://apps.fz-juelich.de/jsc/llview/juwels_modules/MPI/GCC/9.3.0/psmpi/5.4/GROMACS/2020.4.xhtml)

* [x] `aarch64/generic` (in place)
* [x] `aarch64/graviton2` (in place)
* [x] `x86_64/amd/zen2` (in place)
* [x] `x86_64/intel/haswell` ((in place)
* [x] `x86_64/intel/skylake_avx512` ((in place)
* [x] `x86_64/generic` ((in place)