### PR TITLE
add QuantumESPRESSO 6.6 to EESSI pilot 2021.03

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -277,6 +277,7 @@ check_exit_code $? "${ok_msg}" "${fail_msg}"
 echo ">> Installing QuantumESPRESSO..."
 ok_msg="QuantumESPRESSO installed, let's go quantum!"
 fail_msg="Installing QuantumESPRESSO failed, did somebody observe it?!"
+$EB --fetch --from-pr 12700 ELPA-2019.11.001-foss-2020a.eb
 # see https://github.com/easybuilders/easybuild-easyconfigs/pull/12911
 $EB --from-pr 12911 QuantumESPRESSO-6.6-foss-2020a.eb --robot
 check_exit_code $? "${ok_msg}" "${fail_msg}"

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -287,7 +287,7 @@ $EB --from-pr 12912 libxc-4.3.4-GCC-9.3.0.eb --robot
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 ok_msg="QuantumESPRESSO installed, let's go quantum!"
-fail_msg="Installing QuantumESPRESSO failed, did somebody observe it?!"
+fail_msg="Installation of QuantumESPRESSO failed, did somebody observe it?!"
 # see https://github.com/easybuilders/easybuild-easyconfigs/pull/12911
 $EB --from-pr 12911 QuantumESPRESSO-6.6-foss-2020a.eb --robot
 check_exit_code $? "${ok_msg}" "${fail_msg}"

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -274,6 +274,12 @@ fail_msg="Installation of OpenFOAM failed, we were so close..."
 $EB OpenFOAM-8-foss-2020a.eb OpenFOAM-v2006-foss-2020a.eb --robot
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
+echo ">> Installing QuantumESPRESSO..."
+ok_msg="QuantumESPRESSO installed, let's go quantum!"
+fail_msg="Installing QuantumESPRESSO failed, did somebody observe it?!"
+# see https://github.com/easybuilders/easybuild-easyconfigs/pull/12911
+$EB --from-pr 12911 QuantumESPRESSO-6.6-foss-2020a.eb --robot
+check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 echo ">> Installing R 4.0.0 (better be patient)..."
 ok_msg="R installed, wow!"

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -282,7 +282,7 @@ $EB --fetch --from-pr 12700 ELPA-2019.11.001-foss-2020a.eb
 
 # see https://github.com/easybuilders/easybuild-easyconfigs/pull/12912
 ok_msg="libxc installed, one down..."
-fail_msg="Installing libxc failed, ugh..."
+fail_msg="Installation of libxc failed, ugh..."
 $EB --from-pr 12912 libxc-4.3.4-GCC-9.3.0.eb --robot
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -275,9 +275,19 @@ $EB OpenFOAM-8-foss-2020a.eb OpenFOAM-v2006-foss-2020a.eb --robot
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 echo ">> Installing QuantumESPRESSO..."
+
+# ELPA source URL changed :facepalm:
+# see https://github.com/easybuilders/easybuild-easyconfigs/pull/12700
+$EB --fetch --from-pr 12700 ELPA-2019.11.001-foss-2020a.eb
+
+# see https://github.com/easybuilders/easybuild-easyconfigs/pull/12912
+ok_msg="libxc installed, one down..."
+fail_msg="Installing libxc failed, ugh..."
+$EB --from-pr 12912 libxc-4.3.4-GCC-9.3.0.eb --robot
+check_exit_code $? "${ok_msg}" "${fail_msg}"
+
 ok_msg="QuantumESPRESSO installed, let's go quantum!"
 fail_msg="Installing QuantumESPRESSO failed, did somebody observe it?!"
-$EB --fetch --from-pr 12700 ELPA-2019.11.001-foss-2020a.eb
 # see https://github.com/easybuilders/easybuild-easyconfigs/pull/12911
 $EB --from-pr 12911 QuantumESPRESSO-6.6-foss-2020a.eb --robot
 check_exit_code $? "${ok_msg}" "${fail_msg}"

--- a/eessi-2021.03.yml
+++ b/eessi-2021.03.yml
@@ -19,6 +19,10 @@ software:
      toolchains:
        gompi-2020a:
          versions: [5.6.3]
+  QuantumESPRESSO:
+     toolchains:
+       foss-2020a:
+         versions: ['6.6']
   TensorFlow:
     toolchains:
       foss-2020a:


### PR DESCRIPTION
* [x] `aarch64/generic` (in place)
* [x] `aarch64/graviton2` (in place)
* [x] `x86_64/amd/zen2` (in place)
* [x] `x86_64/intel/haswell` ((in place)
* [x] `x86_64/intel/skylake_avx512` ((in place)
* [x] `x86_64/generic` ((in place)