### PR TITLE
add script to create tarball to ingest on build node

### DIFF
--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -ne 2 ]; then
+    echo "ERROR: Usage: $0 <pilot version (example: 2021.03)> <CPU arch subdir (example: x86_64/amd/zen2)" >&2
+    exit 1
+fi
+pilot_version=$1
+cpu_arch_subdir=$2
+
+tmpdir=`mktemp -d`
+echo ">> tmpdir: $tmpdir"
+
+os="linux"
+cvmfs_repo="/cvmfs/pilot.eessi-hpc.org"
+
+software_dir="${cvmfs_repo}/${pilot_version}/software/${os}/${cpu_arch_subdir}"
+if [ ! -d ${software_dir} ]; then
+    echo "Software directory ${software_dir} does not exist?!" >&2
+    exit 2
+fi
+
+overlay_upper_dir="/tmp/$USER/EESSI/overlay-upper"
+
+software_dir_overlay="${overlay_upper_dir}/${pilot_version}/software/${os}/${cpu_arch_subdir}"
+if [ ! -d ${software_dir_overlay} ]; then
+    echo "Software directory overlay ${software_dir_overlay} does not exist?!" >&2
+    exit 3
+fi
+
+cd ${overlay_upper_dir}/${pilot_version}
+echo ">> Collecting list of files/directories to include in tarball via ${PWD}..."
+
+files_list=${tmpdir}/files.list.txt
+
+# always include Lmod cache directory
+echo "software/${os}/${cpu_arch_subdir}/.lmod/cache" > ${files_list}
+# module files
+find software/${os}/${cpu_arch_subdir}/modules -type f >> ${files_list}
+# module symlinks
+find software/${os}/${cpu_arch_subdir}/modules -type l >> ${files_list}
+# installation directories, exclude EasyBuild (*.pyc files)
+ls -d software/${os}/${cpu_arch_subdir}/software/*/* | grep -v '/software/EasyBuild/' >> ${files_list}
+
+topdir=${cvmfs_repo}/${pilot_version}
+timestamp=`date +%s`
+target_tgz="$HOME/eessi-${pilot_version}-software-${os}-`echo ${cpu_arch_subdir} | tr '/' '-'`-${timestamp}.tar.gz"
+
+echo ">> Creating tarball ${target_tgz} from ${topdir}..."
+tar cfvz ${target_tgz} -C ${topdir} --files-from=${files_list}
+
+echo ${target_tgz} created!
+
+echo ">> Cleaning up tmpdir ${tmpdir}..."
+rm -r ${tmpdir}


### PR DESCRIPTION
First stab at a script that facilitates creating the tarball to be ingested on a build node after building/installing additional software.

Far from perfect, because:

* It assumes that the `fuse-overlayfs` upper directory is located at `/tmp/$USER/EESSI/overlay-upper`
* Only deals with adding of new files/directories (except for Lmod cache)
* Hard filters out the `EasyBuild` software installation, because `*.pyc` files are created when EasyBuild is running, resulting in things like:
```
$ find /tmp/ec2-user/EESSI/overlay-upper/2021.03/software/linux/aarch64/generic/software/EasyBuild/ -type f
/tmp/ec2-user/EESSI/overlay-upper/2021.03/software/linux/aarch64/generic/software/EasyBuild/4.3.4/lib/python3.8/site-packages/easybuild/easyblocks/e/__pycache__/elpa.cpython-38.opt-1.pyc
/tmp/ec2-user/EESSI/overlay-upper/2021.03/software/linux/aarch64/generic/software/EasyBuild/4.3.4/lib/python3.8/site-packages/easybuild/easyblocks/e/__pycache__/.wh.elpa.cpython-38.opt-1.pyc.281473148148112
/tmp/ec2-user/EESSI/overlay-upper/2021.03/software/linux/aarch64/generic/software/EasyBuild/4.3.4/lib/python3.8/site-packages/easybuild/easyblocks/q/__pycache__/quantumespresso.cpython-38.opt-1.pyc
/tmp/ec2-user/EESSI/overlay-upper/2021.03/software/linux/aarch64/generic/software/EasyBuild/4.3.4/lib/python3.8/site-packages/easybuild/easyblocks/q/__pycache__/.wh.quantumespresso.cpython-38.opt-1.pyc.281473142905232
```