### PR TITLE
use string values for versions in easystack file for 2021.06

### DIFF
--- a/eessi-2021.06.yml
+++ b/eessi-2021.06.yml
@@ -3,30 +3,30 @@ software:
     toolchains:
       foss-2020a:
         versions:
-          3.11:
+          '3.11':
             versionsuffix: -R-4.0.0
   GROMACS:
     toolchains:
       foss-2020a:
         versions:
-          2020.1:
+          '2020.1':
             versionsuffix: -Python-3.8.2
-          2020.4:
+          '2020.4':
             versionsuffix: -Python-3.8.2
   Horovod:
     toolchains:
       foss-2020a:
         versions:
-          0.21.3:
+          '0.21.3':
             versionsuffix: -TensorFlow-2.3.1-Python-3.8.2
   OpenFOAM:
     toolchains:
       foss-2020a:
-        versions: [8, v2006]
+        versions: ['8', 'v2006']
   OSU-Micro-Benchmarks:
      toolchains:
        gompi-2020a:
-         versions: [5.6.3]
+         versions: ['5.6.3']
   QuantumESPRESSO:
      toolchains:
        foss-2020a:
@@ -35,19 +35,19 @@ software:
     toolchains:
       foss-2020a:
         versions:
-          2.3.1:
+          '2.3.1':
             versionsuffix: -Python-3.8.2
   RStudio-Server:
     toolchains:
       foss-2020a:
         versions:
-          1.3.1093:
+          '1.3.1093':
             versionsuffix: -Java-11-R-4.0.0
   ReFrame:
     toolchains:
       SYSTEM:
-        versions: 3.6.2
+        versions: '3.6.2'
   code-server:
     toolchains:
       SYSTEM:
-        versions: 3.7.3
+        versions: '3.7.3'


### PR DESCRIPTION
EasyBuild v4.4.x includes a sanity check on versions in easystack files (see https://github.com/easybuilders/easybuild-framework/pull/3693), which we're hitting unless we use explicit string values like `'3.11'` rather than `3.11`.

```
ERROR: Value 3.11 (of type <class 'float'>) obtained for R-bundle-Bioconductor (with foss toolchain) is not valid!
Make sure to wrap the value in single quotes (like '3.11') to avoid that it is interpreted by the YAML parser as a non-string value.
```