### PR TITLE
add script to start build node environment

### DIFF
--- a/start_build_node_env.sh
+++ b/start_build_node_env.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-# create temporary directories
-export EESSI_TMPDIR=/tmp/$USER/EESSI
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <path for temporary directories>" >&2
+    exit 1
+fi
+export EESSI_TMPDIR=$1
 echo "Using $EESSI_TMPDIR as parent for temporary directories..."
+
+# create temporary directories
 mkdir -p $EESSI_TMPDIR/{home,overlay-upper,overlay-work}
 mkdir -p $EESSI_TMPDIR/{var-lib-cvmfs,var-run-cvmfs}
 # configure Singularity

--- a/start_build_node_env.sh
+++ b/start_build_node_env.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# create temporary directories
+export EESSI_TMPDIR=/tmp/$USER/EESSI
+echo "Using $EESSI_TMPDIR as parent for temporary directories..."
+mkdir -p $EESSI_TMPDIR/{home,overlay-upper,overlay-work}
+mkdir -p $EESSI_TMPDIR/{var-lib-cvmfs,var-run-cvmfs}
+# configure Singularity
+export SINGULARITY_CACHEDIR=$EESSI_TMPDIR/singularity_cache
+export SINGULARITY_BIND="$EESSI_TMPDIR/var-run-cvmfs:/var/run/cvmfs,$EESSI_TMPDIR/var-lib-cvmfs:/var/lib/cvmfs"
+export SINGULARITY_HOME="$EESSI_TMPDIR/home:/home/$USER"
+
+# set environment variables for fuse mounts in Singularity container
+export EESSI_PILOT_READONLY="container:cvmfs2 pilot.eessi-hpc.org /cvmfs_ro/pilot.eessi-hpc.org"
+export EESSI_PILOT_WRITABLE_OVERLAY="container:fuse-overlayfs -o lowerdir=/cvmfs_ro/pilot.eessi-hpc.org -o upperdir=$EESSI_TMPDIR/overlay-upper -o workdir=$EESSI_TMPDIR/overlay-work /cvmfs/pilot.eessi-hpc.org"
+
+# start shell in Singularity container, with EESSI repository mounted with writable overlay
+echo "Starting Singularity container..."
+singularity shell --fusemount "$EESSI_PILOT_READONLY" --fusemount "$EESSI_PILOT_WRITABLE_OVERLAY" docker://ghcr.io/eessi/build-node:debian10


### PR DESCRIPTION
This will make the procedure documented at https://eessi.github.io/docs/software_layer/build_nodes a bit easier to follow, we can mostly change it to:

```
git clone https://github.com/EESSI/software-layer.git
cd software-layer
./start_build_node_env.sh
```

You need to clone the `software-layer` repository anyway to get the software install script...

TODO: allow to easily use a different directory than `/tmp`, since that has significant limitations on some systems.
Maybe we need to change the `start_build_node_env.sh` script to make it require a single argument, a path that can be used to create temporary directories? Usage would then become:

```
$ ./start_build_node_env.sh /tmp
```