### PR TITLE
let det_host_triple print warning if vendor was not found in vendor map (+ add test for det_host_triple)

### DIFF
--- a/init/eessi_software_subdir_for_host.py
+++ b/init/eessi_software_subdir_for_host.py
@@ -35,6 +35,8 @@ def det_host_triple():
     """
     host_cpu = archspec.cpu.host()
     host_vendor = VENDOR_MAP.get(host_cpu.vendor)
+    if host_vendor is None:
+        warning("No match for host CPU vendor '%s' in vendor map!" % host_cpu.vendor)
     host_cpu_family = host_cpu.family.name
     host_cpu_name = host_cpu.name
 

--- a/init/test.py
+++ b/init/test.py
@@ -3,7 +3,7 @@ import pytest
 import re
 
 import eessi_software_subdir_for_host
-from eessi_software_subdir_for_host import find_best_target
+from eessi_software_subdir_for_host import det_host_triple, find_best_target
 
 
 def prep_tmpdir(tmpdir, subdirs):
@@ -31,6 +31,15 @@ def test_no_targets(tmpdir, capsys):
     captured = capsys.readouterr()
     assert captured.out == ''
     assert re.match('^ERROR: No compatible targets found for .*', captured.err)
+
+
+def test_det_host_triple(tmpdir):
+    """Test det_host_triple function."""
+    host_cpu_family, host_vendor, host_cpu_name = det_host_triple()
+
+    assert isinstance(host_cpu_family, str)
+    assert isinstance(host_vendor, str)
+    assert isinstance(host_cpu_name, str)
 
 
 def test_broadwell_host(tmpdir, capsys, monkeypatch):


### PR DESCRIPTION
Trying to figure out why `test_no_targets` is failing with:

```
init/eessi_software_subdir_for_host.py:60: in find_best_target
    paths = glob.glob(os.path.join(eessi_software_layer_path, host_cpu_family, host_vendor, '*'))
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/posixpath.py:90: in join
    genericpath._check_arg_types('join', a, *p)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

funcname = 'join'
args = ('/tmp/pytest-of-runner/pytest-0/test_no_targets0/software/linux', 'x86_64', None, '*')
hasstr = True, hasbytes = False, s = None

    def _check_arg_types(funcname, *args):
        hasstr = hasbytes = False
        for s in args:
            if isinstance(s, str):
                hasstr = True
            elif isinstance(s, bytes):
                hasbytes = True
            else:
>               raise TypeError(f'{funcname}() argument must be str, bytes, or '
                                f'os.PathLike object, not {s.__class__.__name__!r}') from None
E               TypeError: join() argument must be str, bytes, or os.PathLike object, not 'NoneType'

/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/genericpath.py:152: TypeError
```