### PR TITLE
fix init script for archspec 0.1.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8]
+        python: [3.6, 3.7, 3.8, 3.9, '3.10']
       fail-fast: false
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests_init.yml
+++ b/.github/workflows/tests_init.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8]
+        python: [3.6, 3.7, 3.8, 3.9, '3.10']
       fail-fast: false
     steps:
     - uses: actions/checkout@v2

--- a/eessi_software_subdir.py
+++ b/eessi_software_subdir.py
@@ -4,7 +4,7 @@
 #
 import os
 import argparse
-import archspec.cpu
+from archspec.cpu.detect import compatible_microarchitectures, raw_info_dictionary
 
 software_subdir = os.getenv('EESSI_SOFTWARE_SUBDIR_OVERRIDE')
 if software_subdir is None:
@@ -14,7 +14,26 @@ if software_subdir is None:
                         default=False, help='Use generic for CPU name.')
     args = parser.parse_args()
 
-    host_cpu = archspec.cpu.host()
+    # we can't directly use archspec.cpu.host(), because we may get back a virtual microarchitecture like x86_64_v3...
+    def sorting_fn(item):
+        """Helper function to sort compatible microarchitectures."""
+        return len(item.ancestors), len(item.features)
+
+    raw_cpu_info = raw_info_dictionary()
+    compat_targets = compatible_microarchitectures(raw_cpu_info)
+
+    # filter out generic targets
+    non_generic_compat_targets = [t for t in compat_targets if t.vendor != "generic"]
+
+    # Filter the candidates to be descendant of the best generic candidate
+    best_generic = max([t for t in compat_targets if t.vendor == "generic"], key=sorting_fn)
+    best_compat_targets = [t for t in non_generic_compat_targets if t > best_generic]
+
+    if best_compat_targets:
+        host_cpu = max(best_compat_targets, key=sorting_fn)
+    else:
+        host_cpu = max(non_generic_compat_targets, key=sorting_fn)
+
     vendors = {
         'GenuineIntel': 'intel',
         'AuthenticAMD': 'amd',


### PR DESCRIPTION
fixes #142 (although I really think that the `archspec` API could be improved to avoid all this copy-pasting...)

We have largely the same logic in `eessi_software_subdir.py` (used by build script) and `init/eessi_software_subdir_for_host.py` (used by `init/bash` script), we should fix that too at some point...

The build script should leverage the script from `init/` (but that's a follow-up PR imho...)