### PR TITLE
Use EESSI version dir as top dir in "init" tarballs

### DIFF
--- a/create_init_tarball.sh
+++ b/create_init_tarball.sh
@@ -32,14 +32,15 @@ then
 fi
 
 tartmp=$(mktemp -t -d init.XXXXX)
+mkdir "${tartmp}/${version}"
 tarname="eessi-${version}-init-$(date +%s).tar.gz"
-curl -Ls ${SOFTWARE_LAYER_TARBALL_URL} | tar xzf - -C ${tartmp} --strip-components=1 --wildcards */init/
-source ${tartmp}/init/minimal_eessi_env
+curl -Ls ${SOFTWARE_LAYER_TARBALL_URL} | tar xzf - -C "${tartmp}/${version}" --strip-components=1 --wildcards */init/
+source "${tartmp}/${version}/init/minimal_eessi_env"
 if [ "${EESSI_PILOT_VERSION}" != "${version}" ]
 then
   error "Specified version ${version} does not match version ${EESSI_PILOT_VERSION} in the init files!"
 fi
-tar czf ${tarname} -C ${tartmp} init
-rm -rf ${tartmp}
+tar czf "${tarname}" -C "${tartmp}" "${version}"
+rm -rf "${tartmp}"
 
 echo_green "Done! Created tarball ${tarname}."


### PR DESCRIPTION
This will make sure that the base dir in the tarball is the version, e.g. `2021.12`, similar to the `compat` and `software` tarballs.

Example:
```
$ ./create_init_tarball.sh 2021.12
Done! Created tarball eessi-2021.12-init-1639845877.tar.gz.

$ tar tzf eessi-2021.12-init-1639845877.tar.gz 
2021.12/
2021.12/init/
2021.12/init/test.py
2021.12/init/bash
2021.12/init/minimal_eessi_env
2021.12/init/eessi_software_subdir_for_host.py
2021.12/init/eessi_environment_variables
2021.12/init/README.md
2021.12/init/Magic_Castle/
2021.12/init/Magic_Castle/bash
2021.12/init/Magic_Castle/eessi_pilot_python3
```