### PR TITLE
add WRF/3.9.1.1-foss-2020a-dmpar to EESSI 2021.12 pilot repo

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -329,7 +329,7 @@ check_exit_code $? "${ok_msg}" "${fail_msg}"
 echo ">> Installing WRF 3.9.1.1..."
 ok_msg="WRF installed, it's getting hot in here!"
 fail_msg="Installation of WRF failed, that's unexpected..."
-$EB WRF-3.9.1.1-foss-2020a-dmpar.eb -r
+OMPI_MCA_pml=ucx $EB WRF-3.9.1.1-foss-2020a-dmpar.eb -r --include-easyblocks-from-pr 2648
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 echo ">> Creating/updating Lmod cache..."

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -329,7 +329,7 @@ check_exit_code $? "${ok_msg}" "${fail_msg}"
 echo ">> Installing WRF 3.9.1.1..."
 ok_msg="WRF installed, it's getting hot in here!"
 fail_msg="Installation of WRF failed, that's unexpected..."
-OMPI_MCA_pml=ucx $EB WRF-3.9.1.1-foss-2020a-dmpar.eb -r --include-easyblocks-from-pr 2648
+OMPI_MCA_pml=ucx UCX_TLS=tcp $EB WRF-3.9.1.1-foss-2020a-dmpar.eb -r --include-easyblocks-from-pr 2648
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 echo ">> Creating/updating Lmod cache..."

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -326,6 +326,12 @@ fail_msg="Installation of IPython failed, that's unexpected..."
 $EB IPython-7.15.0-foss-2020a-Python-3.8.2.eb -r
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
+echo ">> Installing WRF 3.9.1.1..."
+ok_msg="WRF installed, it's getting hot in here!"
+fail_msg="Installation of WRF failed, that's unexpected..."
+$EB WRF-3.9.1.1-foss-2020a-dmpar.eb -r
+check_exit_code $? "${ok_msg}" "${fail_msg}"
+
 echo ">> Creating/updating Lmod cache..."
 export LMOD_RC="${EASYBUILD_INSTALLPATH}/.lmod/lmodrc.lua"
 if [ ! -f $LMOD_RC ]; then

--- a/eessi-2021.12.yml
+++ b/eessi-2021.12.yml
@@ -47,3 +47,7 @@ software:
     toolchains:
       SYSTEM:
         versions: '3.7.3'
+  WRF:
+     toolchains:
+       foss-2020a:
+         versions: ['3.9.1.1']

--- a/eessi-2021.12.yml
+++ b/eessi-2021.12.yml
@@ -50,4 +50,6 @@ software:
   WRF:
      toolchains:
        foss-2020a:
-         versions: ['3.9.1.1']
+         versions: 
+           '3.9.1.1': 
+             versionsuffix: -dmpar


### PR DESCRIPTION
adding WRF to the default EESSI stack; let's see if the process works here ;)
if no big blockers, target date of Jan 14th would be awesome!
initial target archs: zen2 and skylake_avx512

edit: checklist:
* [x] `aarch64/generic` (done, ingested)
* [x] `aarch64/graviton2` (done, ingested)
* [x] `ppc64le/generic` (done, ingested)
* [x] `ppc64le/power9le` (done, ingested)
* [x] `x86_64/generic` (done, ingested)
* [x] `x86_64/amd/zen2` (done, ingested)
* [x] `x86_64/amd/zen3` (done, ingested)
* [x] `x86_64/intel/haswell` (done, ingested)
* [x] `x86_64/intel/skylake_avx512` (done, ingested)