### PR TITLE
Fix issue with build_container.sh when passing a command with arguments

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -10,7 +10,7 @@ SHELL_OR_RUN=$1
 EESSI_TMPDIR=$2
 shift 2
 
-if [ "$SHELL_OR_RUN" == "run" ] && [ -z "$@" ]; then
+if [ "$SHELL_OR_RUN" == "run" ] && [ $# -eq 0 ]; then
     echo "ERROR: No command specified to run?!" >&2
     exit 1
 fi


### PR DESCRIPTION
I saw this error when passing a command with arguments to the `build_container.sh` script:
```
$ ./build_container.sh run /tmp/eessi ./run_in_compat_layer_env.sh ls
./build_container.sh: line 13: [: ./run_in_compat_layer_env.sh: binary operator expected
```

This change fixes that.