### PR TITLE
Adjustments to scripts necessary for bot PR24

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,17 @@ See also https://eessi.github.io/docs/software_layer.
 
 ## Pilot software stack
 
-A script that sets up your environment to start using the 2020.08 version of the EESSI pilot software stack
-is available at `EESSI-pilot-2020.08_init.sh`.
-
-This script should be copied to `/cvmfs/pilot.eessi-hpc.org/2020.08/init/bash` if it is not available there already,
-and sourced to set up your environment:
+You can set up your environment by sourcing the init script:
 
 ```
-$ source /cvmfs/pilot.eessi-hpc.org/2020.08/init/bash
-Found EESSI pilot repo @ /cvmfs/pilot.eessi-hpc.org/2020.08!
+$ source /cvmfs/pilot.eessi-hpc.org/versions/2021.12/init/bash
+Found EESSI pilot repo @ /cvmfs/pilot.eessi-hpc.org/versions/2021.12!
 Derived subdirectory for software layer: x86_64/intel/haswell
 Using x86_64/intel/haswell subdirectory for software layer (HARDCODED)
 Initializing Lmod...
-Prepending /cvmfs/pilot.eessi-hpc.org/2020.08/software/x86_64/intel/haswell/modules/all to $MODULEPATH...
+Prepending /cvmfs/pilot.eessi-hpc.org/versions/2021.12/software/x86_64/intel/haswell/modules/all to $MODULEPATH...
 Environment set up to use EESSI pilot software stack, have fun!
-[EESSI pilot 2020.08] $
+[EESSI pilot 2021.12] $
 ```
 
 # License

--- a/build_container.sh
+++ b/build_container.sh
@@ -26,7 +26,7 @@ if [ $? -eq 0 ]; then
     attr -s test -V test $testfile > /dev/null
     if [ $? -ne 0 ]; then
         echo "ERROR: $EESSI_TMPDIR does not support extended attributes!" >&2
-       exit 2
+        #exit 2
     else
         rm $testfile
     fi

--- a/install_software_layer.sh
+++ b/install_software_layer.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 export EESSI_PILOT_VERSION='2021.12'
-./run_in_compat_layer_env.sh ./EESSI-pilot-install-software.sh
+./run_in_compat_layer_env.sh ./EESSI-pilot-install-software.sh "$@"


### PR DESCRIPTION
This PR contains a few changes to make the software layer compatible with [EESSI/eessi-bot-software-layer/PR24](https://github.com/EESSI/eessi-bot-software-layer/pull/24).

This can be used as a base branch for adding new software packages to the EESSI pilot via the bot.

- The parameters for EESSI-pilot-install-software.sh and the handling of GENERIC option have been changed. Also a note where more sections for additional packages has been added.
- The README.md has been updated (newer pilot version).
- The 'exit 2' when `/tmp` directory does not support extended attributes or the command 'attr' was not found has been commented out.
- In 'install_software_layer.sh' the parameter "$@" was added to running the script "EESSI-pilot-install-software.sh".