### PR TITLE
remove check for support for extended attributes from script for using build container

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -18,22 +18,6 @@ fi
 # make sure specified temporary directory exists
 mkdir -p $EESSI_TMPDIR
 
-# make sure that specified location has support for extended attributes,
-# since that's required by CernVM-FS
-command -v attr &> /dev/null
-if [ $? -eq 0 ]; then
-    testfile=$(mktemp -p $EESSI_TMPDIR)
-    attr -s test -V test $testfile > /dev/null
-    if [ $? -ne 0 ]; then
-        echo "ERROR: $EESSI_TMPDIR does not support extended attributes!" >&2
-        #exit 2
-    else
-        rm $testfile
-    fi
-else
-    echo "WARNING: 'attr' command not available, so can't check support for extended attributes..." >&2
-fi
-
 echo "Using $EESSI_TMPDIR as parent for temporary directories..."
 
 # create temporary directories


### PR DESCRIPTION
The `attr` check isn't needed anymore thanks to https://github.com/EESSI/filesystem-layer/pull/125, and `attr` is often not available anyway...