### PR TITLE
add Nextflow/22.10.1 to EESSI pilot 2021.12

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -359,7 +359,7 @@ check_exit_code $? "${ok_msg}" "${fail_msg}"
 echo ">> Installing Nextflow 22.10.1..."
 ok_msg="Nextflow installed, the work must flow..."
 fail_msg="Installation of Nextflow failed, that's unexpected..."
-$EB -r --from-pr 16531
+$EB -r --from-pr 16531 Nextflow-22.10.1.eb
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
 ### add packages here

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -356,6 +356,12 @@ fail_msg="Installation of WRF failed, that's unexpected..."
 OMPI_MCA_pml=ucx UCX_TLS=tcp $EB WRF-3.9.1.1-foss-2020a-dmpar.eb -r --include-easyblocks-from-pr 2648
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
+echo ">> Installing Nextflow 22.10.1..."
+ok_msg="Nextflow installed, the work must flow..."
+fail_msg="Installation of Nextflow failed, that's unexpected..."
+$EB -r --from-pr 16531
+check_exit_code $? "${ok_msg}" "${fail_msg}"
+
 ### add packages here
 
 echo ">> Creating/updating Lmod cache..."

--- a/eessi-2021.12.yml
+++ b/eessi-2021.12.yml
@@ -53,3 +53,7 @@ software:
          versions: 
            '3.9.1.1': 
              versionsuffix: -dmpar
+  Nextflow:
+    toolchains:
+      SYSTEM:
+        versions: '22.10.1'


### PR DESCRIPTION
My first attempt at the whole procedure, hope all is right

checklist to install everywhere:
* [x] `aarch64/generic` (ingested)
* [x] `aarch64/graviton2` (ingested)
* [x] `aarch64/graviton3` (ingested)
* [x] `ppc64le/generic` (ingested)
* [x] `ppc64le/power9le` (ingested)
* [x] `x86_64/generic` (ingested)
* [x] `x86_64/amd/zen2` (ingested)
* [x] `x86_64/amd/zen3` (ingested)
* [x] `x86_64/intel/haswell` (ingested)
* [x] `x86_64/intel/skylake_avx512` (ingested)