### PR TITLE
add OSU-Micro-Benchmarks/5.7.1-gompi-2021a to EESSI pilot 2021.12

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -362,6 +362,12 @@ fail_msg="Installation of Nextflow failed, that's unexpected..."
 $EB -r --from-pr 16531 Nextflow-22.10.1.eb
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
+echo ">> Installing OSU-Micro-Benchmarks/5.7.1-gompi-2021a..."
+ok_msg="OSU-Micro-Benchmarks installed, yihaa!"
+fail_msg="Installation of OSU-Micro-Benchmarks failed, that's unexpected..."
+$EB OSU-Micro-Benchmarks-5.7.1-gompi-2021a.eb -r
+check_exit_code $? "${ok_msg}" "${fail_msg}"
+
 ### add packages here
 
 echo ">> Creating/updating Lmod cache..."

--- a/eessi-2021.12.yml
+++ b/eessi-2021.12.yml
@@ -27,6 +27,8 @@ software:
      toolchains:
        gompi-2020a:
          versions: ['5.6.3']
+       gompi-2021a:
+         versions: ['5.7.1']
   QuantumESPRESSO:
      toolchains:
        foss-2020a:


### PR DESCRIPTION
checklist:

* [x] `aarch64/generic` (done, [ingested](https://github.com/EESSI/staging/pull/104))
* [x] `aarch64/graviton2` (done, [ingested](https://github.com/EESSI/staging/pull/105))
* [x] `aarch64/graviton3` (done, [ingested](https://github.com/EESSI/staging/pull/106))
* [x] `ppc64le/generic` (done, [ingested](https://github.com/EESSI/staging/pull/110))
* [x] `ppc64le/power9le` (done, [ingested](https://github.com/EESSI/staging/pull/111))
* [x] `x86_64/generic` (done, [ingested](https://github.com/EESSI/staging/pull/113))
* [x] `x86_64/amd/zen2` (done, [ingested](https://github.com/EESSI/staging/pull/98))
* [x] `x86_64/amd/zen3` (done, [inge sted](https://github.com/EESSI/staging/pull/112))
* [x] `x86_64/intel/haswell` (done, [ingested](https://github.com/EESSI/staging/pull/114))
* [x] `x86_64/intel/skylake_avx512` (done,[ingested](https://github.com/EESSI/staging/pull/115))