### PR TITLE
use separate script to determine EESSI pilot version and CVMFS repo

### DIFF
--- a/.github/workflows/tests_readme.yml
+++ b/.github/workflows/tests_readme.yml
@@ -1,0 +1,31 @@
+# documentation: https://help.github.com/en/articles/workflow-syntax-for-github-actions
+name: Tests for consistency of README.md
+on:
+  push:
+    paths:
+      - README.md
+      - init/eessi_defaults
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - README.md
+      - init/eessi_defaults
+permissions:
+  contents: read # to fetch code (actions/checkout)
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: verify if README.md is consistent with EESSI_PILOT_VERSION from init/eessi_defaults
+      run: |
+        source init/eessi_defaults
+        grep "${EESSI_PILOT_VERSION}" README.md
+
+    - name: verify if README.md is consistent with EESSI_CVMFS_REPO from init/eessi_defaults
+      run: |
+        source init/eessi_defaults
+        grep "${EESSI_CVMFS_REPO}" README.md

--- a/.github/workflows/tests_readme.yml
+++ b/.github/workflows/tests_readme.yml
@@ -18,14 +18,15 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+        - name: Check out software-layer repository
+          uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
-    - name: verify if README.md is consistent with EESSI_PILOT_VERSION from init/eessi_defaults
-      run: |
-        source init/eessi_defaults
-        grep "${EESSI_PILOT_VERSION}" README.md
+        - name: verify if README.md is consistent with EESSI_PILOT_VERSION from init/eessi_defaults
+          run: |
+            source init/eessi_defaults
+            grep "${EESSI_PILOT_VERSION}" README.md
 
-    - name: verify if README.md is consistent with EESSI_CVMFS_REPO from init/eessi_defaults
-      run: |
-        source init/eessi_defaults
-        grep "${EESSI_CVMFS_REPO}" README.md
+        - name: verify if README.md is consistent with EESSI_CVMFS_REPO from init/eessi_defaults
+          run: |
+            source init/eessi_defaults
+            grep "${EESSI_CVMFS_REPO}" README.md

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Script to install EESSI pilot software stack (version 2021.12)
+# Script to install EESSI pilot software stack (version set through init/eessi_defaults)
 
 # see example parsing of command line arguments at
 #   https://wiki.bash-hackers.org/scripting/posparams#using_a_while_loop

--- a/build_container.sh
+++ b/build_container.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+base_dir=$(dirname $(realpath $0))
+
 BUILD_CONTAINER="docker://ghcr.io/eessi/build-node:debian10"
 
 if [ $# -lt 2 ]; then
@@ -39,9 +41,13 @@ if [ -z $SINGULARITY_HOME ]; then
     export SINGULARITY_HOME="$EESSI_TMPDIR/home:/home/$USER"
 fi
 
+source ${base_dir}/init/eessi_defaults
+# strip "/cvmfs/" from default setting
+repo_name=${EESSI_CVMFS_REPO/\/cvmfs\//}
+
 # set environment variables for fuse mounts in Singularity container
-export EESSI_PILOT_READONLY="container:cvmfs2 pilot.eessi-hpc.org /cvmfs_ro/pilot.eessi-hpc.org"
-export EESSI_PILOT_WRITABLE_OVERLAY="container:fuse-overlayfs -o lowerdir=/cvmfs_ro/pilot.eessi-hpc.org -o upperdir=$EESSI_TMPDIR/overlay-upper -o workdir=$EESSI_TMPDIR/overlay-work /cvmfs/pilot.eessi-hpc.org"
+export EESSI_PILOT_READONLY="container:cvmfs2 ${repo_name} /cvmfs_ro/${repo_name}"
+export EESSI_PILOT_WRITABLE_OVERLAY="container:fuse-overlayfs -o lowerdir=/cvmfs_ro/${repo_name} -o upperdir=$EESSI_TMPDIR/overlay-upper -o workdir=$EESSI_TMPDIR/overlay-work ${EESSI_CVMFS_REPO}"
 
 if [ "$SHELL_OR_RUN" == "shell" ]; then
     # start shell in Singularity container, with EESSI repository mounted with writable overlay

--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+base_dir=$(dirname $(realpath $0))
+
 if [ $# -ne 4 ]; then
     echo "ERROR: Usage: $0 <EESSI tmp dir (example: /tmp/$USER/EESSI)> <pilot version (example: 2021.03)> <CPU arch subdir (example: x86_64/amd/zen2)> <path to tarball>" >&2
     exit 1
@@ -15,7 +17,8 @@ tmpdir=`mktemp -d`
 echo ">> tmpdir: $tmpdir"
 
 os="linux"
-cvmfs_repo="/cvmfs/pilot.eessi-hpc.org"
+source ${base_dir}/init/eessi_defaults
+cvmfs_repo=${EESSI_CVMFS_REPO}
 
 software_dir="${cvmfs_repo}/versions/${pilot_version}/software/${os}/${cpu_arch_subdir}"
 if [ ! -d ${software_dir} ]; then

--- a/init/eessi_defaults
+++ b/init/eessi_defaults
@@ -1,0 +1,13 @@
+# define default values for some EESSI_* environment variables
+#
+# This file is part of the EESSI software layer,
+# see https://github.com/EESSI/software-layer
+#
+# author: Thomas Roeblitz (@trz42)
+#
+# license: GPLv2
+#
+
+export EESSI_CVMFS_REPO="${EESSI_CVMFS_REPO_OVERRIDE:=/cvmfs/pilot.eessi-hpc.org}"
+export EESSI_PILOT_VERSION="${EESSI_PILOT_VERSION_OVERRIDE:=2021.12}"
+

--- a/init/minimal_eessi_env
+++ b/init/minimal_eessi_env
@@ -1,7 +1,13 @@
 # define minimal EESSI environment, without relying on external scripts
+#
+# this script is *sourced*, not executed, so can't rely on $0 to determine path to self
+# $BASH_SOURCE points to correct path, see also http://mywiki.wooledge.org/BashFAQ/028
+EESSI_INIT_DIR_PATH=$(dirname $(realpath $BASH_SOURCE))
 
-export EESSI_CVMFS_REPO="/cvmfs/pilot.eessi-hpc.org"
-export EESSI_PILOT_VERSION="${EESSI_PILOT_VERSION_OVERRIDE:=2021.12}"
+# set up defaults: EESSI_CVMFS_REPO, EESSI_PILOT_VERSION
+#   script takes *_OVERRIDEs into account
+source ${EESSI_INIT_DIR_PATH}/eessi_defaults
+
 export EESSI_PREFIX=$EESSI_CVMFS_REPO/versions/$EESSI_PILOT_VERSION
 
 if [[ $(uname -s) == 'Linux' ]]; then

--- a/install_software_layer.sh
+++ b/install_software_layer.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-export EESSI_PILOT_VERSION='2021.12'
+base_dir=$(dirname $(realpath $0))
+source ${base_dir}/init/eessi_defaults
 ./run_in_compat_layer_env.sh ./EESSI-pilot-install-software.sh "$@"

--- a/run_in_compat_layer_env.sh
+++ b/run_in_compat_layer_env.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
+
+base_dir=$(dirname $(realpath $0))
+source ${base_dir}/init/eessi_defaults
+
+BUILD_CONTAINER="docker://ghcr.io/eessi/build-node:debian10"
 if [ -z $EESSI_PILOT_VERSION ]; then
     echo "ERROR: \$EESSI_PILOT_VERSION must be set!" >&2
     exit 1
 fi
-EESSI_COMPAT_LAYER_DIR="/cvmfs/pilot.eessi-hpc.org/versions/${EESSI_PILOT_VERSION}/compat/linux/$(uname -m)"
+EESSI_COMPAT_LAYER_DIR="${EESSI_CVMFS_REPO}/versions/${EESSI_PILOT_VERSION}/compat/linux/$(uname -m)"
 if [ ! -d ${EESSI_COMPAT_LAYER_DIR} ]; then
     echo "ERROR: ${EESSI_COMPAT_LAYER_DIR} does not exist!" >&2
     exit 1

--- a/run_in_compat_layer_env.sh
+++ b/run_in_compat_layer_env.sh
@@ -3,7 +3,6 @@
 base_dir=$(dirname $(realpath $0))
 source ${base_dir}/init/eessi_defaults
 
-BUILD_CONTAINER="docker://ghcr.io/eessi/build-node:debian10"
 if [ -z $EESSI_PILOT_VERSION ]; then
     echo "ERROR: \$EESSI_PILOT_VERSION must be set!" >&2
     exit 1


### PR DESCRIPTION
This PR fixes #207

- adds a new configuration file `init/eessi_defaults` which sets `EESSI_PILOT_VERSION` to a default or `$EESSI_PILOT_VERSION_OVERRIDE` and `EESSI_CVMFS_REPO` to a default or `$EESSI_CVMFS_REPO_OVERRIDE`
- existing init files and scripts that used hardcoded values are adjusted to `source` the new configuration file
- a comment in `EESSI-pilot-install-software.sh` is updated to note that not a hardcoded pilot version but the one set in `init/eessi_defaults` is used
- a simple test is added which checks if the default values in `init/eessi_defaults` correspond to values used in `README.md`