### PR TITLE
always exclude '.wh.*' files when creating tarball in overlay

### DIFF
--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -43,13 +43,13 @@ if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/.lmod ]; then
 fi
 if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules ]; then
     # module files
-    find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules -type f >> ${files_list}
+    find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules -type f | grep -v '/\.wh\.' >> ${files_list}
     # module symlinks
-    find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules -type l >> ${files_list}
+    find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules -type l | grep -v '/\.wh\.' >> ${files_list}
 fi
 if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software ]; then
     # installation directories
-    ls -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software/*/* >> ${files_list}
+    ls -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software/*/* | grep -v '/\.wh\.' >> ${files_list}
 fi
 
 topdir=${cvmfs_repo}/versions/


### PR DESCRIPTION
Fix for errors that pop up when creating the tarball because "whiteout" files are accidentally picked up, like:

```
tar: 2021.12/software/linux/x86_64/amd/zen2/modules/all/CaDiCaL/.wh..wh..opq: Cannot stat: No such file or directory
```

(starting seeing this in some cases when using updated build container, cfr. #219)