### PR TITLE
restore original $PATH and $PYTHONPATH values after installing first EasyBuild module

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -152,6 +152,10 @@ else
     pip_install_out=${TMPDIR}/pip_install.out
     pip3 install --prefix $EB_TMPDIR easybuild &> ${pip_install_out}
 
+    # keep track of original $PATH and $PYTHONPATH values, so we can restore them
+    ORIG_PATH=$PATH
+    ORIG_PYTHONPATH=$PYTHONPATH
+
     echo ">> Final installation in ${EASYBUILD_INSTALLPATH}..."
     export PATH=${EB_TMPDIR}/bin:$PATH
     export PYTHONPATH=$(ls -d ${EB_TMPDIR}/lib/python*/site-packages):$PYTHONPATH
@@ -160,6 +164,10 @@ else
     fail_msg="Installing latest EasyBuild release failed, that's not good... (output: ${eb_install_out})"
     eb --install-latest-eb-release &> ${eb_install_out}
     check_exit_code $? "${ok_msg}" "${fail_msg}"
+
+    # restore origin $PATH and $PYTHONPATH values
+    export PATH=${ORIG_PATH}
+    export PYTHONPATH=${ORIG_PYTHONPATH}
 
     eb --search EasyBuild-${REQ_EB_VERSION}.eb | grep EasyBuild-${REQ_EB_VERSION}.eb > /dev/null
     if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
When running the install script to build the software from scratch (for a new type of CPU for example), the first non-EasyBuild installation fails hard because it's accidentally picking up stuff from the EasyBuild v4.7.0 installation that was installed with `pip install`:

```
== 2023-01-24 12:47:20,473 build_log.py:169 ERROR EasyBuild crashed with an error (at easybuild/base/exceptions.py:124 in __init__):
Failed to process easyconfig /cvmfs/pilot.eessi-hpc.org/versions/2021.12/software/linux/aarch64/altra/software/EasyBuild/4.5.0/easybuild/easyconfigs/j/Java/Java-11.eb: import_available_modules:
Failed to import easybuild.toolchains.gmpit: cannot import name 'LooseVersion' from 'easybuild.tools' (/cvmfs/pilot.eessi-hpc.org/versions/2021.12/software/linux/aarch64/altra/software/EasyBuild/4.5.0/lib/python3.9/site-packages/easybuild/tools/__init__.py) (at easybuild/framework/easyconfig/easyconfig.py:2071 in process_easyconfig)
```

The `import_available_modules` calls is picking up on `easybuild/toolchains/*.py` in the EasyBuild v4.7.0 installation that was installed in a temporary directory, because that location is still listed in `$PYTHONPATH`, but those files use:

```
from easybuild.tools import LooseVersion
```

which is not compatible with EasyBuild v4.5.0 (cfr. https://github.com/easybuilders/easybuild-framework/pull/3794)