### PR TITLE
restore $PATH and $PYTHONPATH only after last run of pip installed eb

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -165,10 +165,6 @@ else
     eb --install-latest-eb-release &> ${eb_install_out}
     check_exit_code $? "${ok_msg}" "${fail_msg}"
 
-    # restore origin $PATH and $PYTHONPATH values
-    export PATH=${ORIG_PATH}
-    export PYTHONPATH=${ORIG_PYTHONPATH}
-
     eb --search EasyBuild-${REQ_EB_VERSION}.eb | grep EasyBuild-${REQ_EB_VERSION}.eb > /dev/null
     if [[ $? -eq 0 ]]; then
         ok_msg="EasyBuild v${REQ_EB_VERSION} installed, alright!"
@@ -176,6 +172,10 @@ else
         eb EasyBuild-${REQ_EB_VERSION}.eb >> ${eb_install_out} 2>&1
         check_exit_code $? "${ok_msg}" "${fail_msg}"
     fi
+
+    # restore origin $PATH and $PYTHONPATH values
+    export PATH=${ORIG_PATH}
+    export PYTHONPATH=${ORIG_PYTHONPATH}
 
     module avail easybuild/${REQ_EB_VERSION} &> ${ml_av_easybuild_out}
     if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
When starting a fresh software subdir, the `eb` command in https://github.com/EESSI/software-layer/blob/25943f55ddfa3e5e397335a6be7654426d2f108e/EESSI-pilot-install-software.sh#L172 was not found because the PATH was restored too early. See https://github.com/EESSI/software-layer/blob/25943f55ddfa3e5e397335a6be7654426d2f108e/EESSI-pilot-install-software.sh#L169-L170

This PR moves these lines to after the `if` block.

It's been tested with ~ 2 PRs for NESSI starting fresh software subdirs.

The lines originated from #224 