### PR TITLE
only tar up software directories for which modules were generated

### DIFF
--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -38,6 +38,7 @@ cd ${overlay_upper_dir}/versions/
 echo ">> Collecting list of files/directories to include in tarball via ${PWD}..."
 
 files_list=${tmpdir}/files.list.txt
+module_files_list=${tmpdir}/module_files.list.txt
 
 if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/.lmod ]; then
     # include Lmod cache and configuration file (lmodrc.lua),
@@ -49,11 +50,25 @@ if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules ]; then
     find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules -type f | grep -v '/\.wh\.' >> ${files_list}
     # module symlinks
     find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules -type l | grep -v '/\.wh\.' >> ${files_list}
+    # module files and symlinks
+    find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules -type f -o -type l \
+        | grep -v '/\.wh\.' | sed -e 's/.lua$//' | awk -F'/' '{printf "%s/%s\n", $(NF-1), $NF}' | sort | uniq \
+        >> ${module_files_list}
 fi
 if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software ]; then
     # installation directories
-    ls -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software/*/* | grep -v '/\.wh\.' >> ${files_list}
+    # ls -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software/*/* | grep -v '/\.wh\.' >> ${files_list}
+    for package_version in $(cat ${module_files_list}); do
+        echo "handling ${package_version}"
+        ls -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software/${package_version} \
+            | grep -v '/\.wh\.' >> ${files_list}
+    done
 fi
+
+echo "wrote file list to ${files_list}"
+cat ${files_list}
+echo "wrote module file list to ${module_files_list}"
+cat ${module_files_list}
 
 topdir=${cvmfs_repo}/versions/
 

--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -51,13 +51,12 @@ if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules ]; then
     # module symlinks
     find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules -type l | grep -v '/\.wh\.' >> ${files_list}
     # module files and symlinks
-    find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules -type f -o -type l \
+    find ${pilot_version}/software/${os}/${cpu_arch_subdir}/modules/all -type f -o -type l \
         | grep -v '/\.wh\.' | sed -e 's/.lua$//' | awk -F'/' '{printf "%s/%s\n", $(NF-1), $NF}' | sort | uniq \
         >> ${module_files_list}
 fi
 if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software ]; then
-    # installation directories
-    # ls -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software/*/* | grep -v '/\.wh\.' >> ${files_list}
+    # installation directories but only those for which module files were created
     for package_version in $(cat ${module_files_list}); do
         echo "handling ${package_version}"
         ls -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software/${package_version} \
@@ -65,6 +64,7 @@ if [ -d ${pilot_version}/software/${os}/${cpu_arch_subdir}/software ]; then
     done
 fi
 
+# add a bit debug output
 echo "wrote file list to ${files_list}"
 cat ${files_list}
 echo "wrote module file list to ${module_files_list}"


### PR DESCRIPTION
This lets `create_tarball.sh` only include software directories for which module files have been created.

It implements the first option in https://github.com/EESSI/software-layer/issues/225#issuecomment-1473437691

It has been tested interactively (resuming from a previous build job) and also in a bot job (https://github.com/NorESSI/software-layer/pull/57).