### PR TITLE
Make sure installations are read only by enabling --read-only-installdir EasyBuild configure option

### DIFF
--- a/configure_easybuild
+++ b/configure_easybuild
@@ -13,6 +13,7 @@ export EASYBUILD_ZIP_LOGS=bzip2
 
 export EASYBUILD_RPATH=1
 export EASYBUILD_FILTER_ENV_VARS=LD_LIBRARY_PATH
+export EASYBUILD_READ_ONLY_INSTALLDIR=1
 
 # assume that eb_hooks.py is located in same directory as this script (configure_easybuild)
 TOPDIR=$(dirname $(realpath $BASH_SOURCE))


### PR DESCRIPTION
This should help us avoid the issue we saw with `.pyc` files