### PR TITLE
avoid that versions/2021.06/init is included in init tarball

### DIFF
--- a/create_directory_tarballs.sh
+++ b/create_directory_tarballs.sh
@@ -26,7 +26,7 @@ fi
 tartmp=$(mktemp -t -d init.XXXXX)
 mkdir "${tartmp}/${version}"
 tarname="eessi-${version}-init-$(date +%s).tar.gz"
-curl -Ls ${SOFTWARE_LAYER_TARBALL_URL} | tar xzf - -C "${tartmp}/${version}" --strip-components=1 --wildcards */init/
+curl -Ls ${SOFTWARE_LAYER_TARBALL_URL} | tar xzf - -C "${tartmp}/${version}" --strip-components=1 --no-wildcards-match-slash --wildcards '*/init/'
 source "${tartmp}/${version}/init/minimal_eessi_env"
 if [ "${EESSI_PILOT_VERSION}" != "${version}" ]
 then
@@ -42,7 +42,7 @@ echo_green "Done! Created tarball ${tarname}."
 tartmp=$(mktemp -t -d scripts.XXXXX)
 mkdir "${tartmp}/${version}"
 tarname="eessi-${version}-scripts-$(date +%s).tar.gz"
-curl -Ls ${SOFTWARE_LAYER_TARBALL_URL} | tar xzf - -C "${tartmp}/${version}" --strip-components=1 --wildcards '*/scripts/'
+curl -Ls ${SOFTWARE_LAYER_TARBALL_URL} | tar xzf - -C "${tartmp}/${version}" --strip-components=1 --no-wildcards-match-slash --wildcards '*/scripts/'
 tar czf "${tarname}" -C "${tartmp}" "${version}"
 rm -rf "${tartmp}"
 


### PR DESCRIPTION
This avoids that the `versions/2021.06/init` directory that was added in #246 gets included in the init tarball, which is not the intention:

```
$ tar tfvz eessi-2021.12-init-1684395250.tar.gz
drwxrwxr-x boegel/boegel 0 2023-05-18 09:34 2021.12/
drwxrwxr-x boegel/boegel 0 2023-05-18 09:27 2021.12/init/
-rw-rw-r-- boegel/boegel 3411 2023-05-18 09:27 2021.12/init/eessi_environment_variables
-rw-rw-r-- boegel/boegel  372 2023-05-18 09:27 2021.12/init/eessi_defaults
-rw-rw-r-- boegel/boegel 1257 2023-05-18 09:27 2021.12/init/bash
-rw-rw-r-- boegel/boegel 1587 2023-05-18 09:27 2021.12/init/README.md
-rwxrwxr-x boegel/boegel 4410 2023-05-18 09:27 2021.12/init/eessi_software_subdir_for_host.py
-rw-rw-r-- boegel/boegel 3086 2023-05-18 09:27 2021.12/init/test.py
-rwxrwxr-x boegel/boegel 5206 2023-05-18 09:27 2021.12/init/eessi_archdetect.sh
-rw-rw-r-- boegel/boegel  874 2023-05-18 09:27 2021.12/init/minimal_eessi_env
drwxrwxr-x boegel/boegel    0 2023-05-18 09:27 2021.12/init/arch_specs/
-rwxrwxr-x boegel/boegel  333 2023-05-18 09:27 2021.12/init/arch_specs/eessi_arch_arm.spec
-rwxrwxr-x boegel/boegel  157 2023-05-18 09:27 2021.12/init/arch_specs/eessi_arch_ppc.spec
-rwxrwxr-x boegel/boegel  450 2023-05-18 09:27 2021.12/init/arch_specs/eessi_arch_x86.spec
drwxrwxr-x boegel/boegel    0 2023-05-18 09:27 2021.12/init/Magic_Castle/
-rw-rw-r-- boegel/boegel 1307 2023-05-18 09:27 2021.12/init/Magic_Castle/bash
-rwxrwxr-x boegel/boegel  801 2023-05-18 09:27 2021.12/init/Magic_Castle/eessi_pilot_python3
drwxrwxr-x boegel/boegel    0 2023-05-18 09:34 2021.12/versions/
drwxrwxr-x boegel/boegel    0 2023-05-18 09:34 2021.12/versions/2021.06/
drwxrwxr-x boegel/boegel    0 2023-05-18 09:27 2021.12/versions/2021.06/init/
-rw-rw-r-- boegel/boegel  140 2023-05-18 09:27 2021.12/versions/2021.06/init/bash
-rwxrwxr-x boegel/boegel  807 2023-05-18 09:27 2021.12/versions/2021.06/init/print_deprecation_warning.sh
drwxrwxr-x boegel/boegel    0 2023-05-18 09:27 2021.12/versions/2021.06/init/Magic_Castle/
-rw-rw-r-- boegel/boegel  153 2023-05-18 09:27 2021.12/versions/2021.06/init/Magic_Castle/bash
```

only the top-level `init` dir should be included:

```
$ tar tfvz eessi-2021.12-init-1684396813.tar.gz
drwxrwxr-x boegel/boegel 0 2023-05-18 10:00 2021.12/
drwxrwxr-x boegel/boegel 0 2023-05-18 09:27 2021.12/init/
-rw-rw-r-- boegel/boegel 3411 2023-05-18 09:27 2021.12/init/eessi_environment_variables
-rw-rw-r-- boegel/boegel  372 2023-05-18 09:27 2021.12/init/eessi_defaults
-rw-rw-r-- boegel/boegel 1257 2023-05-18 09:27 2021.12/init/bash
-rw-rw-r-- boegel/boegel 1587 2023-05-18 09:27 2021.12/init/README.md
-rwxrwxr-x boegel/boegel 4410 2023-05-18 09:27 2021.12/init/eessi_software_subdir_for_host.py
-rw-rw-r-- boegel/boegel 3086 2023-05-18 09:27 2021.12/init/test.py
-rwxrwxr-x boegel/boegel 5206 2023-05-18 09:27 2021.12/init/eessi_archdetect.sh
-rw-rw-r-- boegel/boegel  874 2023-05-18 09:27 2021.12/init/minimal_eessi_env
drwxrwxr-x boegel/boegel    0 2023-05-18 09:27 2021.12/init/arch_specs/
-rwxrwxr-x boegel/boegel  333 2023-05-18 09:27 2021.12/init/arch_specs/eessi_arch_arm.spec
-rwxrwxr-x boegel/boegel  157 2023-05-18 09:27 2021.12/init/arch_specs/eessi_arch_ppc.spec
-rwxrwxr-x boegel/boegel  450 2023-05-18 09:27 2021.12/init/arch_specs/eessi_arch_x86.spec
drwxrwxr-x boegel/boegel    0 2023-05-18 09:27 2021.12/init/Magic_Castle/
-rw-rw-r-- boegel/boegel 1307 2023-05-18 09:27 2021.12/init/Magic_Castle/bash
-rwxrwxr-x boegel/boegel  801 2023-05-18 09:27 2021.12/init/Magic_Castle/eessi_pilot_python3
```