### PR TITLE
also filter OpenSSL dependency in EasyBuild configuration

### DIFF
--- a/configure_easybuild
+++ b/configure_easybuild
@@ -26,7 +26,7 @@ fi
 # note: filtering Bison may break some installations, like Qt5 (see https://github.com/EESSI/software-layer/issues/49)
 # filtering pkg-config breaks R-bundle-Bioconductor installation (see also https://github.com/easybuilders/easybuild-easyconfigs/pull/11104)
 # problems occur when filtering pkg-config with gnuplot too (picks up Lua 5.1 from $EPREFIX rather than from Lua 5.3 dependency)
-DEPS_TO_FILTER=Autoconf,Automake,Autotools,binutils,bzip2,cURL,DBus,flex,gettext,gperf,help2man,intltool,libreadline,libtool,Lua,M4,makeinfo,ncurses,util-linux,XZ,zlib
+DEPS_TO_FILTER=Autoconf,Automake,Autotools,binutils,bzip2,cURL,DBus,flex,gettext,gperf,help2man,intltool,libreadline,libtool,Lua,M4,makeinfo,ncurses,OpenSSL,util-linux,XZ,zlib
 # For aarch64 we need to also filter out Yasm.
 # See https://github.com/easybuilders/easybuild-easyconfigs/issues/11190
 if [[ "$EESSI_CPU_FAMILY" == "aarch64" ]]; then


### PR DESCRIPTION
In EESSI pilot 2023.04, OpenSSL 3.x is installed in the compat layer:

```
Apptainer> /cvmfs/pilot.eessi-hpc.org/versions/2023.04/compat/linux/x86_64/startprefix
Entering Gentoo Prefix /cvmfs/pilot.eessi-hpc.org/versions/2023.04/compat/linux/x86_64
$ openssl version
OpenSSL 3.0.8 7 Feb 2023 (Library: OpenSSL 3.0.8 7 Feb 2023)
```

In several easyconfigs included with EasyBuild, the wrapper module `OpenSSL/1.1` is listed as a dependency, which leads to EasyBuild building OpenSSL 1.1.1 from *source* because the "system" OpenSSL can't be wrapped to fulfill `OpenSSL/1.1`.

To avoid this, we should simply filter out the `OpenSSL` dependency, and let EasyBuild rely on the OpenSSL provided by the compat layer.