### PR TITLE
clean up local tmp if it has been saved to a tarball

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -207,7 +207,7 @@ if [[ -d ${STORAGE} ]]; then
     # double-check that at least one tarball of the temporary storage was created
     if check_tmp_tarball ${TARBALL_TMP_BUILD_STEP_DIR} || check_tmp_tarball ${TARBALL_TMP_TARBALL_STEP_DIR}; then
         echo "Removing temporary storage under '${STORAGE}'"
-        # rm -rf ${STORAGE}
+        rm -rf ${STORAGE}
     else
         echo "Did not find any tarball containing the temporary storage for neither the"
         echo "build nor the tar step. Hence, not removing the storage at '${STORAGE}'."

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -211,6 +211,7 @@ if [[ -d ${STORAGE} ]]; then
     else
         echo "Did not find any tarball containing the temporary storage for neither the"
         echo "build nor the tar step. Hence, not removing the storage at '${STORAGE}'."
+    fi
 else
     echo "Local disk storage at '${STORAGE}' not accessible, so wasn't cleaned up."
 fi

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -196,4 +196,23 @@ echo "                     -- ./create_tarball.sh ${TMP_IN_CONTAINER} ${EESSI_PI
 ./eessi_container.sh "${COMMON_ARGS[@]}" "${TARBALL_STEP_ARGS[@]}" \
                      -- ./create_tarball.sh ${TMP_IN_CONTAINER} ${EESSI_PILOT_VERSION} ${EESSI_SOFTWARE_SUBDIR_OVERRIDE} /eessi_bot_job/${TGZ} 2>&1 | tee -a ${tar_outerr}
 
+function check_tmp_tarball {
+    dir=$1
+    ls ${dir} | grep -E 'tgz$|\.gz$'
+    return $?
+}
+
+# clean storage used on local disk
+if [[ -d ${STORAGE} ]]; then
+    # double-check that at least one tarball of the temporary storage was created
+    if check_tmp_tarball ${TARBALL_TMP_BUILD_STEP_DIR} || check_tmp_tarball ${TARBALL_TMP_TARBALL_STEP_DIR}; then
+        echo "Removing temporary storage under '${STORAGE}'"
+        # rm -rf ${STORAGE}
+    else
+        echo "Did not find any tarball containing the temporary storage for neither the"
+        echo "build nor the tar step. Hence, not removing the storage at '${STORAGE}'."
+else
+    echo "Local disk storage at '${STORAGE}' not accessible, so wasn't cleaned up."
+fi
+
 exit 0


### PR DESCRIPTION
The `bot/build.sh` runs `eessi_container.sh` twice and each run results in a tarball containing the temporary folder. If a job runs on a machine where this temporary folder is not cleaned up automatically, disk usage can pile up leading to failing build jobs.

This PR checks if a temporary folder is accessible (`${STORAGE}`). If so it removes it if there is any tarball created for it.

Improves situation that resulted in creating https://github.com/EESSI/eessi-bot-software-layer/issues/186 