### PR TITLE
fix bot config: add required `job_result_unknown_fmt` + use 16 cores for jobs

### DIFF
--- a/bot/bot-eessi-aws-citc.cfg
+++ b/bot/bot-eessi-aws-citc.cfg
@@ -230,3 +230,4 @@ multiple_tarballs = Found {num_tarballs} tarballs in job dir - only 1 matching `
 job_result_comment_fmt = <details><summary>{summary} _(click triangle for detailed information)_</summary>Details:{details}<br/>Artefacts:{artefacts}</details>
 job_result_details_item_fmt = <br/>&nbsp;&nbsp;&nbsp;&nbsp;{item}
 job_result_artefacts_item_fmt = <li><code>{item}</code></li>
+job_result_unknown_fmt = <details><summary>:shrug: UNKNOWN _(click triangle for detailed information)_<summary/><ul><li>Job results file `{filename}` does not exist in job directory or reading it failed.</li><li>No artefacts were found/reported.</li></ul></details>

--- a/bot/bot-eessi-aws-citc.cfg
+++ b/bot/bot-eessi-aws-citc.cfg
@@ -83,7 +83,8 @@ local_tmp = /tmp/$USER/EESSI
 # NOTE 2 '--get-user-env' may be needed on systems where the job's environment needs
 #        to be initialised as if it is for a login shell.
 # note: hardcoded 24h time limit until https://github.com/EESSI/eessi-bot-software-layer/issues/146 is fixed
-slurm_params = --hold --time=24:0:0
+# note: 16 cores which corresponds to *.4xlarge node types, see also arch_target_map
+slurm_params = --hold --time=24:0:0 --nodes=1 --ntasks-per-node=16
 
 # full path to the job submission command
 submit_command = /usr/bin/sbatch


### PR DESCRIPTION
Without this, the job manager crashes - required because of changes in https://github.com/EESSI/eessi-bot-software-layer/pull/174