### PR TITLE
three obsolete settings removed from bot cfg

### DIFF
--- a/bot/bot-eessi-aws-citc.cfg
+++ b/bot/bot-eessi-aws-citc.cfg
@@ -228,7 +228,4 @@ missing_modules = Slurm output lacks message "No missing modules!".
 no_tarball_message = Slurm output lacks message about created tarball.
 no_matching_tarball = No tarball matching `{tarball_pattern}` found in job dir.
 multiple_tarballs = Found {num_tarballs} tarballs in job dir - only 1 matching `{tarball_pattern}` expected.
-job_result_comment_fmt = <details><summary>{summary} _(click triangle for detailed information)_</summary>Details:{details}<br/>Artefacts:{artefacts}</details>
-job_result_details_item_fmt = <br/>&nbsp;&nbsp;&nbsp;&nbsp;{item}
-job_result_artefacts_item_fmt = <li><code>{item}</code></li>
 job_result_unknown_fmt = <details><summary>:shrug: UNKNOWN _(click triangle for detailed information)_<summary/><ul><li>Job results file `{filename}` does not exist in job directory or reading it failed.</li><li>No artefacts were found/reported.</li></ul></details>


### PR DESCRIPTION
Overlooked in #268 that these three settings are obsolete.