### PR TITLE
test load_easybuild_module.sh with a single EasyBuild version

### DIFF
--- a/.github/workflows/tests_scripts.yml
+++ b/.github/workflows/tests_scripts.yml
@@ -41,8 +41,9 @@ jobs:
         export SINGULARITY_BIND="${PWD}:/software-layer"
 
         # can't test with EasyBuild versions older than v4.5.2 when using EESSI pilot 2023.06,
-        # since Python in compat layer is Python 3.11.x
-        for EB_VERSION in '4.5.2' '4.6.0' '4.7.2'; do
+        # since Python in compat layer is Python 3.11.x;
+        # testing with a single EasyBuild version takes a while in GitHub Actions, so stick to a single sensible version
+        for EB_VERSION in '4.6.0'; do
           # Create script that uses load_easybuild_module.sh which we can run in compat layer environment
           # note: Be careful with single vs double quotes below!
           #       ${EB_VERSION} should be expanded, so use double quotes;


### PR DESCRIPTION
testing the `load_easybuild_module.sh` can take quite a bit of time, so better limit it to a single EasyBuild version (testing with multiple version doesn't really buy us much)