### PR TITLE
adding QuantumESPRESSO/6.7 with GCC/10.3.0 to EESSI pilot 2023.06

### DIFF
--- a/eessi-2023.06-eb-4.7.2-2021a.yml
+++ b/eessi-2023.06-eb-4.7.2-2021a.yml
@@ -6,3 +6,4 @@ easyconfigs:
   - foss-2021a
   - libpng-1.6.37-GCCcore-10.3.0.eb:
   - libjpeg-turbo-2.0.6-GCCcore-10.3.0.eb
+  - QuantumESPRESSO-6.7-foss-2021a.eb


### PR DESCRIPTION
Trying to add QuantumESPRESSO/6.7 with GCC/10.3.0 to EESSI pilot 2023.06