### PR TITLE
Set permissions on copied build log for failed builds

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -30,6 +30,7 @@ function copy_build_log() {
         fi
         mkdir -p $(dirname ${build_log_path})
         cp -a ${build_log} ${build_log_path}
+        chmod 0644 ${build_log_path}
 
         # add context to end of copied log file
         echo >> ${build_log_path}


### PR DESCRIPTION
@laraPPr just found out that the build logs were not accessible, and this was due to the file having incorrect permissions:
```
-rw-------. 1 bot users 16103454 12 jul 09:21 /mnt/shared/bot-build-logs/jobs/5806/easybuild-y0xokk13.log
```

I've added a `chmod 0644` which makes the file readable for everyone. We could also do a `0640`, since all `citc` users should be in the `users` group, so both should have the same effect.