### PR TITLE
{2023.06}[foss-2022a] Added OpenMPI-4.1.4 with GCC 11.3.0

### DIFF
--- a/eessi-2023.06-eb-4.7.2-2022a.yml
+++ b/eessi-2023.06-eb-4.7.2-2022a.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - GCC-11.3.0
+  - OpenMPI-4.1.4-GCC-11.3.0.eb


### PR DESCRIPTION
Working towards a foss-2022a (and eventually TensorFlow 2.11)...