### PR TITLE
{2023.06} foss/2022a

### DIFF
--- a/.github/workflows/test_eessi.yml
+++ b/.github/workflows/test_eessi.yml
@@ -31,6 +31,7 @@ jobs:
         - eessi-2023.06-eb-4.8.0-2021b.yml
         - eessi-2023.06-eb-4.8.1-system.yml
         - eessi-2023.06-eb-4.8.1-2021b.yml
+        - eessi-2023.06-eb-4.8.1-2022a.yml
     steps:
         - name: Check out software-layer repository
           uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -274,6 +274,14 @@ def pre_test_hook_ignore_failing_tests_SciPybundle(self, *args, **kwargs):
         self.cfg['testopts'] = "|| echo ignoring failing tests" 
 
 
+def pre_test_hook_ignore_failing_tests_FFTWMPI(self, *args, **kwargs):
+    """
+    Pre-test hook for FFTW.MPI: skip failing tests for FFTWMPI 3.3.10
+    """
+    cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
+    if self.name == 'FFTW.MPI' and self.version == '3.3.10' and cpu_target == 'aarch64/neoverse_v1':
+        self.cfg['testopts'] = "|| echo ignoring failing tests"
+
 PARSE_HOOKS = {
     'CGAL': parse_hook_cgal_toolchainopts_precise,
     'fontconfig': parse_hook_fontconfig_add_fonts,
@@ -295,4 +303,5 @@ PRE_CONFIGURE_HOOKS = {
 
 PRE_TEST_HOOKS = {
     'SciPy-bundle': pre_test_hook_ignore_failing_tests_SciPybundle,
+    'FFTW.MPI': pre_test_hook_ignore_failing_tests_FFTWMPI,
 }

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -276,7 +276,8 @@ def pre_test_hook_ignore_failing_tests_SciPybundle(self, *args, **kwargs):
 
 def pre_test_hook_ignore_failing_tests_FFTWMPI(self, *args, **kwargs):
     """
-    Pre-test hook for FFTW.MPI: skip failing tests for FFTWMPI 3.3.10
+    Pre-test hook for FFTW.MPI: skip failing tests for FFTW.MPI 3.3.10 on neoverse_v1
+    cfr. https://github.com/EESSI/software-layer/issues/325
     """
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
     if self.name == 'FFTW.MPI' and self.version == '3.3.10' and cpu_target == 'aarch64/neoverse_v1':

--- a/eessi-2023.06-eb-4.7.2-2022a.yml
+++ b/eessi-2023.06-eb-4.7.2-2022a.yml
@@ -1,4 +1,10 @@
 easyconfigs:
   - GCC-11.3.0
   - OpenMPI-4.1.4-GCC-11.3.0.eb
+  - CMake-3.23.1-GCCcore-11.3.0.eb:
+      options:
+        include-easyblocks-from-pr: 2248
+  - CMake-3.24.3-GCCcore-11.3.0.eb:
+      options:
+        include-easyblocks-from-pr: 2248
   - foss-2022a

--- a/eessi-2023.06-eb-4.7.2-2022a.yml
+++ b/eessi-2023.06-eb-4.7.2-2022a.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - GCC-11.3.0
+  - foss-2022a

--- a/eessi-2023.06-eb-4.7.2-2022a.yml
+++ b/eessi-2023.06-eb-4.7.2-2022a.yml
@@ -1,10 +1,3 @@
 easyconfigs:
   - GCC-11.3.0
   - OpenMPI-4.1.4-GCC-11.3.0.eb
-  - CMake-3.23.1-GCCcore-11.3.0.eb:
-      options:
-        include-easyblocks-from-pr: 2248
-  - CMake-3.24.3-GCCcore-11.3.0.eb:
-      options:
-        include-easyblocks-from-pr: 2248
-  - foss-2022a

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -1,0 +1,7 @@
+easyconfigs:
+  - OpenBLAS-0.3.20-GCC-11.3.0:
+      # use easyconfig that includes patch to fix detection of Neoverse V1 CPUs,
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/18870
+      options:
+        from-pr: 18870
+  - foss-2022a


### PR DESCRIPTION
17 out of 37 required modules missing:

* FFTW/3.3.10-GCC-11.3.0 (FFTW-3.3.10-GCC-11.3.0.eb)
* UnZip/6.0-GCCcore-11.3.0 (UnZip-6.0-GCCcore-11.3.0.eb)
* cURL/7.83.0-GCCcore-11.3.0 (cURL-7.83.0-GCCcore-11.3.0.eb)
* libarchive/3.6.1-GCCcore-11.3.0 (libarchive-3.6.1-GCCcore-11.3.0.eb)
* CMake/3.23.1-GCCcore-11.3.0 (CMake-3.23.1-GCCcore-11.3.0.eb)
* libffi/3.4.2-GCCcore-11.3.0 (libffi-3.4.2-GCCcore-11.3.0.eb)
* make/4.3-GCCcore-11.3.0 (make-4.3-GCCcore-11.3.0.eb)
* Tcl/8.6.12-GCCcore-11.3.0 (Tcl-8.6.12-GCCcore-11.3.0.eb)
* SQLite/3.38.3-GCCcore-11.3.0 (SQLite-3.38.3-GCCcore-11.3.0.eb)
* Python/3.10.4-GCCcore-11.3.0-bare (Python-3.10.4-GCCcore-11.3.0-bare.eb)
* BLIS/0.9.0-GCC-11.3.0 (BLIS-0.9.0-GCC-11.3.0.eb)
* OpenBLAS/0.3.20-GCC-11.3.0 (OpenBLAS-0.3.20-GCC-11.3.0.eb)
* FlexiBLAS/3.2.0-GCC-11.3.0 (FlexiBLAS-3.2.0-GCC-11.3.0.eb)
* gompi/2022a (gompi-2022a.eb)
* FFTW.MPI/3.3.10-gompi-2022a (FFTW.MPI-3.3.10-gompi-2022a.eb)
* ScaLAPACK/2.2.0-gompi-2022a-fb (ScaLAPACK-2.2.0-gompi-2022a-fb.eb)
* foss/2022a (foss-2022a.eb)