### PR TITLE
use shorter 'pilot' job name in workflow to check for missing installations

### DIFF
--- a/.github/workflows/test_eessi.yml
+++ b/.github/workflows/test_eessi.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
-  eessi_pilot_repo:
+  pilot:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
This will help to make the overview of jobs in the workflow more readable, since there's no way to make the column wider:

![Screenshot 2023-08-09 at 17 29 55](https://github.com/EESSI/software-layer/assets/620876/97a3e6dc-f9d8-46d9-b286-036bd54e352e)
