### PR TITLE
{2023.06}[foss/2021a] Arrow V6.0.0

### DIFF
--- a/eessi-2023.06-eb-4.7.2-2021a.yml
+++ b/eessi-2023.06-eb-4.7.2-2021a.yml
@@ -13,6 +13,13 @@ easyconfigs:
        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/18087
        options:                                  
          from-pr: 18087
+  - RapidJSON-1.1.0-GCCcore-10.3.0.eb:
+       # strip out hardcoded -march=native,
+       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/18725
+       options:
+         from-pr: 18725
   - Arrow-6.0.0-foss-2021a.eb:
+       # fix installation of pyarrow Python bindings
+       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/18348
        options:
          from-pr: 18348

--- a/eessi-2023.06-eb-4.7.2-2021a.yml
+++ b/eessi-2023.06-eb-4.7.2-2021a.yml
@@ -13,3 +13,4 @@ easyconfigs:
        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/18087
        options:                                  
          from-pr: 18087
+  - Arrow-6.0.0-foss-2021a.eb

--- a/eessi-2023.06-eb-4.7.2-2021a.yml
+++ b/eessi-2023.06-eb-4.7.2-2021a.yml
@@ -13,4 +13,6 @@ easyconfigs:
        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/18087
        options:                                  
          from-pr: 18087
-  - Arrow-6.0.0-foss-2021a.eb
+  - Arrow-6.0.0-foss-2021a.eb:
+       options:
+         from-pr: 18348


### PR DESCRIPTION
edit (by @boegel - 2023-09-06): missing installations for `Arrow-6.0.0-foss-2021a.eb` in EESSI pilot 2023.06:

```
6 out of 53 required modules missing:

* RapidJSON/1.1.0-GCCcore-10.3.0 (RapidJSON-1.1.0-GCCcore-10.3.0.eb)
* RE2/2022-02-01-GCCcore-10.3.0 (RE2-2022-02-01-GCCcore-10.3.0.eb)
* utf8proc/2.6.1-GCCcore-10.3.0 (utf8proc-2.6.1-GCCcore-10.3.0.eb)
* ICU/69.1-GCCcore-10.3.0 (ICU-69.1-GCCcore-10.3.0.eb)
* Boost/1.76.0-GCC-10.3.0 (Boost-1.76.0-GCC-10.3.0.eb)
* Arrow/6.0.0-foss-2021a (Arrow-6.0.0-foss-2021a.eb)
```