### PR TITLE
don't filter cURL as dependency in EasyBuild

### DIFF
--- a/configure_easybuild
+++ b/configure_easybuild
@@ -26,7 +26,7 @@ fi
 # note: filtering Bison may break some installations, like Qt5 (see https://github.com/EESSI/software-layer/issues/49)
 # filtering pkg-config breaks R-bundle-Bioconductor installation (see also https://github.com/easybuilders/easybuild-easyconfigs/pull/11104)
 # problems occur when filtering pkg-config with gnuplot too (picks up Lua 5.1 from $EPREFIX rather than from Lua 5.3 dependency)
-DEPS_TO_FILTER=Autoconf,Automake,Autotools,binutils,bzip2,cURL,DBus,flex,gettext,gperf,help2man,intltool,libreadline,libtool,Lua,M4,makeinfo,ncurses,util-linux,XZ,zlib
+DEPS_TO_FILTER=Autoconf,Automake,Autotools,binutils,bzip2,DBus,flex,gettext,gperf,help2man,intltool,libreadline,libtool,Lua,M4,makeinfo,ncurses,util-linux,XZ,zlib
 # For aarch64 we need to also filter out Yasm.
 # See https://github.com/easybuilders/easybuild-easyconfigs/issues/11190
 if [[ "$EESSI_CPU_FAMILY" == "aarch64" ]]; then

--- a/eessi-2023.06-eb-4.7.2-2021a.yml
+++ b/eessi-2023.06-eb-4.7.2-2021a.yml
@@ -6,6 +6,7 @@ easyconfigs:
   - foss-2021a
   - libpng-1.6.37-GCCcore-10.3.0.eb:
   - libjpeg-turbo-2.0.6-GCCcore-10.3.0.eb
+  - git-2.32.0-GCCcore-10.3.0-nodocs.eb
   - QuantumESPRESSO-6.7-foss-2021a.eb
   - GROMACS-2021.3-foss-2021a.eb
   - Qt5-5.15.2-GCCcore-10.3.0.eb:

--- a/eessi-2023.06-eb-4.7.2-2021b.yml
+++ b/eessi-2023.06-eb-4.7.2-2021b.yml
@@ -11,6 +11,7 @@ easyconfigs:
   - gompi-2021b
   - FlexiBLAS-3.0.4-GCC-11.2.0.eb
   - foss-2021b.eb
+  - git-2.33.1-GCCcore-11.2.0-nodocs.eb
   - QuantumESPRESSO-6.8-foss-2021b.eb
   - SciPy-bundle-2021.10-foss-2021b
   - GROMACS-2021.5-foss-2021b.eb


### PR DESCRIPTION
Two builds are failing because cURL is being filtered.
- https://github.com/EESSI/software-layer/pull/299
- https://github.com/EESSI/software-layer/pull/321