### PR TITLE
{2023.06}[foss/2021a] GDAL v3.3.0

### DIFF
--- a/.github/workflows/test_eessi.yml
+++ b/.github/workflows/test_eessi.yml
@@ -26,6 +26,7 @@ jobs:
         - eessi-2023.06-eb-4.7.2-2022a.yml
         - eessi-2023.06-eb-4.7.2-2022b.yml
         - eessi-2023.06-eb-4.7.2-system.yml
+        - eessi-2023.06-eb-4.8.0-2021a.yml
         - eessi-2023.06-eb-4.8.0-system.yml
     steps:
         - name: Check out software-layer repository

--- a/eessi-2023.06-eb-4.8.0-2021a.yml
+++ b/eessi-2023.06-eb-4.8.0-2021a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - GDAL-3.3.0-foss-2021a.eb


### PR DESCRIPTION
edit (2023-09-07) missing installations for `GDAL-3.3.0-foss-2021a.eb`:

```
10 out of 65 required modules missing:

* GEOS/3.9.1-GCC-10.3.0 (GEOS-3.9.1-GCC-10.3.0.eb)
* PCRE/8.44-GCCcore-10.3.0 (PCRE-8.44-GCCcore-10.3.0.eb)
* jbigkit/2.1-GCCcore-10.3.0 (jbigkit-2.1-GCCcore-10.3.0.eb)
* netCDF/4.8.0-gompi-2021a (netCDF-4.8.0-gompi-2021a.eb)
* LibTIFF/4.2.0-GCCcore-10.3.0 (LibTIFF-4.2.0-GCCcore-10.3.0.eb)
* PROJ/8.0.1-GCCcore-10.3.0 (PROJ-8.0.1-GCCcore-10.3.0.eb)
* libgeotiff/1.6.0-GCCcore-10.3.0 (libgeotiff-1.6.0-GCCcore-10.3.0.eb)
* libtirpc/1.3.2-GCCcore-10.3.0 (libtirpc-1.3.2-GCCcore-10.3.0.eb)
* HDF/4.2.15-GCCcore-10.3.0 (HDF-4.2.15-GCCcore-10.3.0.eb)
* GDAL/3.3.0-foss-2021a (GDAL-3.3.0-foss-2021a.eb)
```