### PR TITLE
{2023.06}[foss/2021b] OpenFoam v2112

### DIFF
--- a/.github/workflows/test_eessi.yml
+++ b/.github/workflows/test_eessi.yml
@@ -27,6 +27,7 @@ jobs:
         - eessi-2023.06-eb-4.7.2-2022b.yml
         - eessi-2023.06-eb-4.7.2-system.yml
         - eessi-2023.06-eb-4.8.0-system.yml
+        - eessi-2023.06-eb-4.8.0-2021b.yml
     steps:
         - name: Check out software-layer repository
           uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/eessi-2023.06-eb-4.8.0-2021b.yml
+++ b/eessi-2023.06-eb-4.8.0-2021b.yml
@@ -1,7 +1,7 @@
 easyconfigs:
   - MPFR-4.1.0-GCCcore-11.2.0.eb:
-      #fix for different output of tsprintf.c test from GNU C library <2.36
-      #see https://github.com/easybuilders/easybuild-easyconfigs/pull/18746
+      # use patch for MPFR 4.1.0 to fix failing tsprintf test with glibc >= 2.37,
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/18746
       options:
         from-pr: 18746
   - OpenFOAM-v2112-foss-2021b.eb

--- a/eessi-2023.06-eb-4.8.0-2021b.yml
+++ b/eessi-2023.06-eb-4.8.0-2021b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - OpenFOAM-v2112-foss-2021b.eb

--- a/eessi-2023.06-eb-4.8.0-2021b.yml
+++ b/eessi-2023.06-eb-4.8.0-2021b.yml
@@ -1,6 +1,7 @@
 easyconfigs:
-  - OpenFOAM-v2112-foss-2021b.eb:
+  - MPFR-4.1.0-GCCcore-11.2.0.eb:
       #fix for different output of tsprintf.c test from GNU C library <2.36
       #see https://github.com/easybuilders/easybuild-easyconfigs/pull/18746
       options:
         from-pr: 18746
+  - OpenFOAM-v2112-foss-2021b.eb

--- a/eessi-2023.06-eb-4.8.0-2021b.yml
+++ b/eessi-2023.06-eb-4.8.0-2021b.yml
@@ -1,2 +1,6 @@
 easyconfigs:
-  - OpenFOAM-v2112-foss-2021b.eb
+  - OpenFOAM-v2112-foss-2021b.eb:
+      #fix for different output of tsprintf.c test from GNU C library <2.36
+      #see https://github.com/easybuilders/easybuild-easyconfigs/pull/18746
+      options:
+        from-pr: 18746


### PR DESCRIPTION
edit (by @boegel, 2023-09-09):
```
60 out of 105 required modules missing:

* Bison/3.7.6-GCCcore-11.2.0 (Bison-3.7.6-GCCcore-11.2.0.eb)
* METIS/5.1.0-GCCcore-11.2.0 (METIS-5.1.0-GCCcore-11.2.0.eb)
* Eigen/3.4.0-GCCcore-11.2.0 (Eigen-3.4.0-GCCcore-11.2.0.eb)
* pkgconf/1.8.0-GCCcore-11.2.0 (pkgconf-1.8.0-GCCcore-11.2.0.eb)
* libpng/1.6.37-GCCcore-11.2.0 (libpng-1.6.37-GCCcore-11.2.0.eb)
* gzip/1.10-GCCcore-11.2.0 (gzip-1.10-GCCcore-11.2.0.eb)
* MPFR/4.1.0-GCCcore-11.2.0 (MPFR-4.1.0-GCCcore-11.2.0.eb)
* lz4/1.9.3-GCCcore-11.2.0 (lz4-1.9.3-GCCcore-11.2.0.eb)
* NASM/2.15.05-GCCcore-11.2.0 (NASM-2.15.05-GCCcore-11.2.0.eb)
* zstd/1.5.0-GCCcore-11.2.0 (zstd-1.5.0-GCCcore-11.2.0.eb)
* libjpeg-turbo/2.0.6-GCCcore-11.2.0 (libjpeg-turbo-2.0.6-GCCcore-11.2.0.eb)
* pixman/0.40.0-GCCcore-11.2.0 (pixman-0.40.0-GCCcore-11.2.0.eb)
* Brotli/1.0.9-GCCcore-11.2.0 (Brotli-1.0.9-GCCcore-11.2.0.eb)
* libiconv/1.16-GCCcore-11.2.0 (libiconv-1.16-GCCcore-11.2.0.eb)
* freetype/2.11.0-GCCcore-11.2.0 (freetype-2.11.0-GCCcore-11.2.0.eb)
* Doxygen/1.9.1-GCCcore-11.2.0 (Doxygen-1.9.1-GCCcore-11.2.0.eb)
* fontconfig/2.13.94-GCCcore-11.2.0 (fontconfig-2.13.94-GCCcore-11.2.0.eb)
* libgd/2.3.3-GCCcore-11.2.0 (libgd-2.3.3-GCCcore-11.2.0.eb)
* ICU/69.1-GCCcore-11.2.0 (ICU-69.1-GCCcore-11.2.0.eb)
* Boost/1.77.0-GCC-11.2.0 (Boost-1.77.0-GCC-11.2.0.eb)
* libcerf/1.17-GCCcore-11.2.0 (libcerf-1.17-GCCcore-11.2.0.eb)
* Ninja/1.10.2-GCCcore-11.2.0 (Ninja-1.10.2-GCCcore-11.2.0.eb)
* Meson/0.58.2-GCCcore-11.2.0 (Meson-0.58.2-GCCcore-11.2.0.eb)
* Mako/1.1.4-GCCcore-11.2.0 (Mako-1.1.4-GCCcore-11.2.0.eb)
* Python/2.7.18-GCCcore-11.2.0-bare (Python-2.7.18-GCCcore-11.2.0-bare.eb)
* ffnvcodec/11.1.5.2 (ffnvcodec-11.1.5.2.eb)
* PCRE/8.45-GCCcore-11.2.0 (PCRE-8.45-GCCcore-11.2.0.eb)
* GLib/2.69.1-GCCcore-11.2.0 (GLib-2.69.1-GCCcore-11.2.0.eb)
* X11/20210802-GCCcore-11.2.0 (X11-20210802-GCCcore-11.2.0.eb)
* cairo/1.16.0-GCCcore-11.2.0 (cairo-1.16.0-GCCcore-11.2.0.eb)
* GObject-Introspection/1.68.0-GCCcore-11.2.0 (GObject-Introspection-1.68.0-GCCcore-11.2.0.eb)
* netCDF/4.8.1-gompi-2021b (netCDF-4.8.1-gompi-2021b.eb)
* SCOTCH/6.1.2-gompi-2021b (SCOTCH-6.1.2-gompi-2021b.eb)
* libdrm/2.4.107-GCCcore-11.2.0 (libdrm-2.4.107-GCCcore-11.2.0.eb)
* re2c/2.2-GCCcore-11.2.0 (re2c-2.2-GCCcore-11.2.0.eb)
* HarfBuzz/2.8.2-GCCcore-11.2.0 (HarfBuzz-2.8.2-GCCcore-11.2.0.eb)
* x264/20210613-GCCcore-11.2.0 (x264-20210613-GCCcore-11.2.0.eb)
* libglvnd/1.3.3-GCCcore-11.2.0 (libglvnd-1.3.3-GCCcore-11.2.0.eb)
* double-conversion/3.1.5-GCCcore-11.2.0 (double-conversion-3.1.5-GCCcore-11.2.0.eb)
* FriBidi/1.0.10-GCCcore-11.2.0 (FriBidi-1.0.10-GCCcore-11.2.0.eb)
* LAME/3.100-GCCcore-11.2.0 (LAME-3.100-GCCcore-11.2.0.eb)
* Pango/1.48.8-GCCcore-11.2.0 (Pango-1.48.8-GCCcore-11.2.0.eb)
* libunwind/1.5.0-GCCcore-11.2.0 (libunwind-1.5.0-GCCcore-11.2.0.eb)
* PCRE2/10.37-GCCcore-11.2.0 (PCRE2-10.37-GCCcore-11.2.0.eb)
* LLVM/12.0.1-GCCcore-11.2.0 (LLVM-12.0.1-GCCcore-11.2.0.eb)
* graphite2/1.3.14-GCCcore-11.2.0 (graphite2-1.3.14-GCCcore-11.2.0.eb)
* Yasm/1.3.0-GCCcore-11.2.0 (Yasm-1.3.0-GCCcore-11.2.0.eb)
* Mesa/21.1.7-GCCcore-11.2.0 (Mesa-21.1.7-GCCcore-11.2.0.eb)
* libGLU/9.0.2-GCCcore-11.2.0 (libGLU-9.0.2-GCCcore-11.2.0.eb)
* x265/3.5-GCCcore-11.2.0 (x265-3.5-GCCcore-11.2.0.eb)
* FFmpeg/4.3.2-GCCcore-11.2.0 (FFmpeg-4.3.2-GCCcore-11.2.0.eb)
* snappy/1.1.9-GCCcore-11.2.0 (snappy-1.1.9-GCCcore-11.2.0.eb)
* NSPR/4.32-GCCcore-11.2.0 (NSPR-4.32-GCCcore-11.2.0.eb)
* NSS/3.69-GCCcore-11.2.0 (NSS-3.69-GCCcore-11.2.0.eb)
* JasPer/2.0.33-GCCcore-11.2.0 (JasPer-2.0.33-GCCcore-11.2.0.eb)
* Qt5/5.15.2-GCCcore-11.2.0 (Qt5-5.15.2-GCCcore-11.2.0.eb)
* CGAL/4.14.3-gompi-2021b (CGAL-4.14.3-gompi-2021b.eb)
* ParaView/5.9.1-foss-2021b-mpi (ParaView-5.9.1-foss-2021b-mpi.eb)
* gnuplot/5.4.2-GCCcore-11.2.0 (gnuplot-5.4.2-GCCcore-11.2.0.eb)
* OpenFOAM/v2112-foss-2021b (OpenFOAM-v2112-foss-2021b.eb)
```