### PR TITLE
{2023.06}[foss/2021a] ESPResSo v4.2.1

### DIFF
--- a/eessi-2023.06-eb-4.8.0-2021a.yml
+++ b/eessi-2023.06-eb-4.8.0-2021a.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - GDAL-3.3.0-foss-2021a.eb
+  - ESPResSo-4.2.1-foss-2021a.eb


### PR DESCRIPTION
Add ESPResSo for 2021a without CUDA support