### PR TITLE
{2023.03} foss/2023a

### DIFF
--- a/.github/workflows/test_eessi.yml
+++ b/.github/workflows/test_eessi.yml
@@ -29,6 +29,7 @@ jobs:
         - eessi-2023.06-eb-4.8.0-2021a.yml
         - eessi-2023.06-eb-4.8.0-system.yml
         - eessi-2023.06-eb-4.8.0-2021b.yml
+        - eessi-2023.06-eb-4.8.1-2023a.yml
     steps:
         - name: Check out software-layer repository
           uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -172,7 +172,7 @@ else
     echo_green ">> MODULEPATH set up: ${MODULEPATH}"
 fi
 
-for eb_version in '4.7.2' '4.8.0'; do
+for eb_version in '4.7.2' '4.8.0' '4.8.1'; do
 
     # load EasyBuild module (will be installed if it's not available yet)
     source ${TOPDIR}/load_easybuild_module.sh ${eb_version}

--- a/eessi-2023.06-eb-4.8.1-2023a.yml
+++ b/eessi-2023.06-eb-4.8.1-2023a.yml
@@ -1,8 +1,10 @@
 easyconfigs:
   - GCC-12.3.0
   - OpenBLAS-0.3.23-GCC-12.3.0:
-      # add patch to avoid hang when running OpenBLAS test suite,
+      # add patch to disable flaky DDRGES3 LAPACK test,
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/18887;
+      # also pulls in patch to avoid hang when running OpenBLAS test suite,
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/18790
       options:
-        from-pr: 18790
+        from-pr: 18887
   - foss-2023a

--- a/eessi-2023.06-eb-4.8.1-2023a.yml
+++ b/eessi-2023.06-eb-4.8.1-2023a.yml
@@ -1,0 +1,3 @@
+easyconfigs:
+  - GCC-12.3.0
+  - foss-2023a

--- a/eessi-2023.06-eb-4.8.1-2023a.yml
+++ b/eessi-2023.06-eb-4.8.1-2023a.yml
@@ -1,3 +1,8 @@
 easyconfigs:
   - GCC-12.3.0
+  - OpenBLAS-0.3.23-GCC-12.3.0:
+      # add patch to avoid hang when running OpenBLAS test suite,
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/18790
+      options:
+        from-pr: 18790
   - foss-2023a


### PR DESCRIPTION
```
32 out of 34 required modules missing:

* GCCcore/12.3.0 (GCCcore-12.3.0.eb)
* GCC/12.3.0 (GCC-12.3.0.eb)
* pkgconf/1.9.5-GCCcore-12.3.0 (pkgconf-1.9.5-GCCcore-12.3.0.eb)
* FFTW/3.3.10-GCC-12.3.0 (FFTW-3.3.10-GCC-12.3.0.eb)
* Perl/5.36.1-GCCcore-12.3.0 (Perl-5.36.1-GCCcore-12.3.0.eb)
* numactl/2.0.16-GCCcore-12.3.0 (numactl-2.0.16-GCCcore-12.3.0.eb)
* UnZip/6.0-GCCcore-12.3.0 (UnZip-6.0-GCCcore-12.3.0.eb)
* UCX/1.14.1-GCCcore-12.3.0 (UCX-1.14.1-GCCcore-12.3.0.eb)
* libxml2/2.11.4-GCCcore-12.3.0 (libxml2-2.11.4-GCCcore-12.3.0.eb)
* cURL/8.0.1-GCCcore-12.3.0 (cURL-8.0.1-GCCcore-12.3.0.eb)
* libevent/2.1.12-GCCcore-12.3.0 (libevent-2.1.12-GCCcore-12.3.0.eb)
* libarchive/3.6.2-GCCcore-12.3.0 (libarchive-3.6.2-GCCcore-12.3.0.eb)
* CMake/3.26.3-GCCcore-12.3.0 (CMake-3.26.3-GCCcore-12.3.0.eb)
* libfabric/1.18.0-GCCcore-12.3.0 (libfabric-1.18.0-GCCcore-12.3.0.eb)
* libffi/3.4.4-GCCcore-12.3.0 (libffi-3.4.4-GCCcore-12.3.0.eb)
* make/4.4.1-GCCcore-12.3.0 (make-4.4.1-GCCcore-12.3.0.eb)
* Tcl/8.6.13-GCCcore-12.3.0 (Tcl-8.6.13-GCCcore-12.3.0.eb)
* SQLite/3.42.0-GCCcore-12.3.0 (SQLite-3.42.0-GCCcore-12.3.0.eb)
* Python/3.11.3-GCCcore-12.3.0 (Python-3.11.3-GCCcore-12.3.0.eb)
* BLIS/0.9.0-GCC-12.3.0 (BLIS-0.9.0-GCC-12.3.0.eb)
* OpenBLAS/0.3.23-GCC-12.3.0 (OpenBLAS-0.3.23-GCC-12.3.0.eb)
* FlexiBLAS/3.3.1-GCC-12.3.0 (FlexiBLAS-3.3.1-GCC-12.3.0.eb)
* xorg-macros/1.20.0-GCCcore-12.3.0 (xorg-macros-1.20.0-GCCcore-12.3.0.eb)
* libpciaccess/0.17-GCCcore-12.3.0 (libpciaccess-0.17-GCCcore-12.3.0.eb)
* hwloc/2.9.1-GCCcore-12.3.0 (hwloc-2.9.1-GCCcore-12.3.0.eb)
* PMIx/4.2.4-GCCcore-12.3.0 (PMIx-4.2.4-GCCcore-12.3.0.eb)
* UCC/1.2.0-GCCcore-12.3.0 (UCC-1.2.0-GCCcore-12.3.0.eb)
* OpenMPI/4.1.5-GCC-12.3.0 (OpenMPI-4.1.5-GCC-12.3.0.eb)
* gompi/2023a (gompi-2023a.eb)
* FFTW.MPI/3.3.10-gompi-2023a (FFTW.MPI-3.3.10-gompi-2023a.eb)
* ScaLAPACK/2.2.0-gompi-2023a-fb (ScaLAPACK-2.2.0-gompi-2023a-fb.eb)
* foss/2023a (foss-2023a.eb)
```