### PR TITLE
{2023.06}[foss/2021b] R 4.2.0

### DIFF
--- a/.github/workflows/test_eessi.yml
+++ b/.github/workflows/test_eessi.yml
@@ -30,6 +30,7 @@ jobs:
         - eessi-2023.06-eb-4.8.0-system.yml
         - eessi-2023.06-eb-4.8.0-2021b.yml
         - eessi-2023.06-eb-4.8.1-system.yml
+        - eessi-2023.06-eb-4.8.1-2021b.yml
     steps:
         - name: Check out software-layer repository
           uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/eessi-2023.06-eb-4.8.1-2021b.yml
+++ b/eessi-2023.06-eb-4.8.1-2021b.yml
@@ -2,6 +2,6 @@ easyconfigs:
   - Xvfb-1.20.13-GCCcore-11.2.0.eb:
       # enable exec permissions for xvfb-run after copying;
       # need to also enable user write permissions on xvfb-run to ensure that copying with preserved permissions works
-    options:
-      from-pr: 18834
+      options:
+        from-pr: 18834
   - R-4.2.0-foss-2021b.eb

--- a/eessi-2023.06-eb-4.8.1-2021b.yml
+++ b/eessi-2023.06-eb-4.8.1-2021b.yml
@@ -1,2 +1,7 @@
 easyconfigs:
+  - Xvfb-1.20.13-GCCcore-11.2.0.eb:
+      # enable exec permissions for xvfb-run after copying;
+      # need to also enable user write permissions on xvfb-run to ensure that copying with preserved permissions works
+    options:
+      from-pr: 18834
   - R-4.2.0-foss-2021b.eb

--- a/eessi-2023.06-eb-4.8.1-2021b.yml
+++ b/eessi-2023.06-eb-4.8.1-2021b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - R-4.2.0-foss-2021b.eb


### PR DESCRIPTION
```
25 out of 107 required modules missing:

* nettle/3.7.3-GCCcore-11.2.0 (nettle-3.7.3-GCCcore-11.2.0.eb)
* jbigkit/2.1-GCCcore-11.2.0 (jbigkit-2.1-GCCcore-11.2.0.eb)
* NLopt/2.7.0-GCCcore-11.2.0 (NLopt-2.7.0-GCCcore-11.2.0.eb)
* LibTIFF/4.3.0-GCCcore-11.2.0 (LibTIFF-4.3.0-GCCcore-11.2.0.eb)
* Tk/8.6.11-GCCcore-11.2.0 (Tk-8.6.11-GCCcore-11.2.0.eb)
* Xvfb/1.20.13-GCCcore-11.2.0 (Xvfb-1.20.13-GCCcore-11.2.0.eb)
* libogg/1.3.5-GCCcore-11.2.0 (libogg-1.3.5-GCCcore-11.2.0.eb)
* FLAC/1.3.3-GCCcore-11.2.0 (FLAC-1.3.3-GCCcore-11.2.0.eb)
* libvorbis/1.3.7-GCCcore-11.2.0 (libvorbis-1.3.7-GCCcore-11.2.0.eb)
* libsndfile/1.0.31-GCCcore-11.2.0 (libsndfile-1.0.31-GCCcore-11.2.0.eb)
* UDUNITS/2.2.28-GCCcore-11.2.0 (UDUNITS-2.2.28-GCCcore-11.2.0.eb)
* GSL/2.7-GCC-11.2.0 (GSL-2.7-GCC-11.2.0.eb)
* GLPK/5.0-GCCcore-11.2.0 (GLPK-5.0-GCCcore-11.2.0.eb)
* Ghostscript/9.54.0-GCCcore-11.2.0 (Ghostscript-9.54.0-GCCcore-11.2.0.eb)
* nodejs/14.17.6-GCCcore-11.2.0 (nodejs-14.17.6-GCCcore-11.2.0.eb)
* LittleCMS/2.12-GCCcore-11.2.0 (LittleCMS-2.12-GCCcore-11.2.0.eb)
* libgit2/1.1.1-GCCcore-11.2.0 (libgit2-1.1.1-GCCcore-11.2.0.eb)
* GEOS/3.9.1-GCC-11.2.0 (GEOS-3.9.1-GCC-11.2.0.eb)
* PROJ/8.1.0-GCCcore-11.2.0 (PROJ-8.1.0-GCCcore-11.2.0.eb)
* libgeotiff/1.7.0-GCCcore-11.2.0 (libgeotiff-1.7.0-GCCcore-11.2.0.eb)
* ImageMagick/7.1.0-4-GCCcore-11.2.0 (ImageMagick-7.1.0-4-GCCcore-11.2.0.eb)
* libtirpc/1.3.2-GCCcore-11.2.0 (libtirpc-1.3.2-GCCcore-11.2.0.eb)
* HDF/4.2.15-GCCcore-11.2.0 (HDF-4.2.15-GCCcore-11.2.0.eb)
* GDAL/3.3.2-foss-2021b (GDAL-3.3.2-foss-2021b.eb)
* R/4.2.0-foss-2021b (R-4.2.0-foss-2021b.eb)
```