### PR TITLE
use `easybuild/sources` subdirectory in shared filesystem path as EasyBuild source path, if specified via `shared_fs_path` in provided configuration

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -8,10 +8,12 @@
 
 display_help() {
   echo "usage: $0 [OPTIONS]"
+  echo "  --build-logs-dir       -  location to copy EasyBuild logs to for failed builds"
   echo "  -g | --generic         -  instructs script to build for generic architecture target"
   echo "  -h | --help            -  display this usage information"
   echo "  -x | --http-proxy URL  -  provides URL for the environment variable http_proxy"
   echo "  -y | --https-proxy URL -  provides URL for the environment variable https_proxy"
+  echo "  --shared-fs-path       -  path to directory on shared filesystem that can be used"
 }
 
 function copy_build_log() {
@@ -68,6 +70,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --build-logs-dir)
       export build_logs_dir="${2}"
+      shift 2
+      ;;
+    --shared-fs-path)
+      export shared_fs_path="${2}"
       shift 2
       ;;
     -*|--*)
@@ -159,6 +165,14 @@ fi
 
 echo ">> Configuring EasyBuild..."
 source $TOPDIR/configure_easybuild
+
+if [ ! -z "${shared_fs_path}" ]; then
+    shared_eb_sourcepath=${shared_fs_path}/easybuild/sources
+    echo ">> Using ${shared_eb_sourcepath} as shared EasyBuild source path"
+    export EASYBUILD_SOURCEPATH=${shared_eb_sourcepath}:${EASYBUILD_SOURCEPATH}
+fi
+
+${EB} --show-config
 
 echo ">> Setting up \$MODULEPATH..."
 # make sure no modules are loaded

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -64,6 +64,18 @@ else
     export SINGULARITY_BIND="${SINGULARITY_BIND},${BUILD_LOGS_DIR}"
 fi
 
+# check if path to directory on shared filesystem is specified,
+# and use it as location for source tarballs used by EasyBuild if so
+SHARED_FS_PATH=$(cfg_get_value "site_config" "shared_fs_path")
+echo "bot/build.sh: SHARED_FS_PATH='${SHARED_FS_PATH}'"
+# if $SHARED_FS_PATH is set, add it to $SINGULARITY_BIND so the path is available in the build container
+mkdir -p ${SHARED_FS_PATH}
+if [[ -z ${SINGULARITY_BIND} ]]; then
+    export SINGULARITY_BIND="${SHARED_FS_PATH}"
+else
+    export SINGULARITY_BIND="${SINGULARITY_BIND},${SHARED_FS_PATH}"
+fi
+
 SINGULARITY_CACHEDIR=$(cfg_get_value "site_config" "container_cachedir")
 echo "bot/build.sh: SINGULARITY_CACHEDIR='${SINGULARITY_CACHEDIR}'"
 if [[ ! -z ${SINGULARITY_CACHEDIR} ]]; then
@@ -167,6 +179,7 @@ if [[ ${EESSI_SOFTWARE_SUBDIR_OVERRIDE} =~ .*/generic$ ]]; then
     INSTALL_SCRIPT_ARGS+=("--generic")
 fi
 [[ ! -z ${BUILD_LOGS_DIR} ]] && INSTALL_SCRIPT_ARGS+=("--build-logs-dir" "${BUILD_LOGS_DIR}")
+[[ ! -z ${SHARED_FS_PATH} ]] && INSTALL_SCRIPT_ARGS+=("--shared-fs-path" "${SHARED_FS_PATH}")
 
 # create tmp file for output of build step
 build_outerr=$(mktemp build.outerr.XXXX)


### PR DESCRIPTION
Works as designed, tested with https://github.com/boegel/software-layer/pull/27 and sources ended up in `~/bot-shared/easybuild/sources`, as specified in the bot config with:

```ini
shared_fs_path = /mnt/shared/home/boegel/bot-shared
```