### PR TITLE
set `shared_fs_path` for bot on AWS CitC Slurm cluster

### DIFF
--- a/bot/bot-eessi-aws-citc.cfg
+++ b/bot/bot-eessi-aws-citc.cfg
@@ -44,6 +44,10 @@ command_response_fmt =
 # name of the job script used for building an EESSI stack
 build_job_script = /mnt/shared/home/bot/eessi-bot-software-layer/scripts/bot-build.slurm
 
+# path to directory on shared filesystem that can be used for sharing data across build jobs
+# (for example source tarballs used by EasyBuild)
+shared_fs_path = /mnt/shared/home/bot/shared
+
 # Path (directory) to which build logs for (only) failing builds should be copied by bot/build.sh script
 build_logs_dir = /mnt/shared/bot-build-logs
 


### PR DESCRIPTION
using `shared` subdirectory in home directory of bot on AWS CitC cluster so build script can use `easybuild/sources` in there as EasyBuild sourcepath which is shared across all build jobs