### PR TITLE
only create & bind build_logs_dir and shared_fs_path if they are specified

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -57,11 +57,13 @@ echo "bot/build.sh: LOCAL_TMP='${LOCAL_TMP}'"
 BUILD_LOGS_DIR=$(cfg_get_value "site_config" "build_logs_dir")
 echo "bot/build.sh: BUILD_LOGS_DIR='${BUILD_LOGS_DIR}'"
 # if $BUILD_LOGS_DIR is set, add it to $SINGULARITY_BIND so the path is available in the build container
-mkdir -p ${BUILD_LOGS_DIR}
-if [[ -z ${SINGULARITY_BIND} ]]; then
-    export SINGULARITY_BIND="${BUILD_LOGS_DIR}"
-else
-    export SINGULARITY_BIND="${SINGULARITY_BIND},${BUILD_LOGS_DIR}"
+if [[ ! -z ${BUILD_LOGS_DIR} ]]; then
+    mkdir -p ${BUILD_LOGS_DIR}
+    if [[ -z ${SINGULARITY_BIND} ]]; then
+        export SINGULARITY_BIND="${BUILD_LOGS_DIR}"
+    else
+        export SINGULARITY_BIND="${SINGULARITY_BIND},${BUILD_LOGS_DIR}"
+    fi
 fi
 
 # check if path to directory on shared filesystem is specified,
@@ -69,11 +71,13 @@ fi
 SHARED_FS_PATH=$(cfg_get_value "site_config" "shared_fs_path")
 echo "bot/build.sh: SHARED_FS_PATH='${SHARED_FS_PATH}'"
 # if $SHARED_FS_PATH is set, add it to $SINGULARITY_BIND so the path is available in the build container
-mkdir -p ${SHARED_FS_PATH}
-if [[ -z ${SINGULARITY_BIND} ]]; then
-    export SINGULARITY_BIND="${SHARED_FS_PATH}"
-else
-    export SINGULARITY_BIND="${SINGULARITY_BIND},${SHARED_FS_PATH}"
+if [[ ! -z ${SHARED_FS_PATH} ]]; then
+    mkdir -p ${SHARED_FS_PATH}
+    if [[ -z ${SINGULARITY_BIND} ]]; then
+        export SINGULARITY_BIND="${SHARED_FS_PATH}"
+    else
+        export SINGULARITY_BIND="${SINGULARITY_BIND},${SHARED_FS_PATH}"
+    fi
 fi
 
 SINGULARITY_CACHEDIR=$(cfg_get_value "site_config" "container_cachedir")


### PR DESCRIPTION
This fixes early failures in the build job when `shared_fs_path` or `build_logs_dir` are not specified in the bot configuration.

Only trace of this in job output is the `bot/build.sh` script finishing very early (because `set -e` is used in `bot/build.sh`)

```
bot/build.sh: SHARED_FS_PATH=''
mkdir: missing operand
Try 'mkdir --help' for more information.
bot/build.sh finished
```