### PR TITLE
{2023.06}[foss/2022a] TensorFlow 2.11.0

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -5,3 +5,4 @@ easyconfigs:
       options:
         from-pr: 18870
   - foss-2022a
+  - TensorFlow-2.11.0-foss-2022a


### PR DESCRIPTION
```
31 out of 70 required modules missing:

* Zip/3.0-GCCcore-11.3.0 (Zip-3.0-GCCcore-11.3.0.eb)
* Eigen/3.4.0-GCCcore-11.3.0 (Eigen-3.4.0-GCCcore-11.3.0.eb)
* protobuf/3.19.4-GCCcore-11.3.0 (protobuf-3.19.4-GCCcore-11.3.0.eb)
* double-conversion/3.2.0-GCCcore-11.3.0 (double-conversion-3.2.0-GCCcore-11.3.0.eb)
* GMP/6.2.1-GCCcore-11.3.0 (GMP-6.2.1-GCCcore-11.3.0.eb)
* Rust/1.60.0-GCCcore-11.3.0 (Rust-1.60.0-GCCcore-11.3.0.eb)
* git/2.36.0-GCCcore-11.3.0-nodocs (git-2.36.0-GCCcore-11.3.0-nodocs.eb)
* Python/3.10.4-GCCcore-11.3.0 (Python-3.10.4-GCCcore-11.3.0.eb)
* pybind11/2.9.2-GCCcore-11.3.0 (pybind11-2.9.2-GCCcore-11.3.0.eb)
* dill/0.3.6-GCCcore-11.3.0 (dill-0.3.6-GCCcore-11.3.0.eb)
* pkgconfig/1.5.5-GCCcore-11.3.0-python (pkgconfig-1.5.5-GCCcore-11.3.0-python.eb)
* hypothesis/6.46.7-GCCcore-11.3.0 (hypothesis-6.46.7-GCCcore-11.3.0.eb)
* Bazel/5.1.1-GCCcore-11.3.0 (Bazel-5.1.1-GCCcore-11.3.0.eb)
* giflib/5.2.1-GCCcore-11.3.0 (giflib-5.2.1-GCCcore-11.3.0.eb)
* Ninja/1.10.2-GCCcore-11.3.0 (Ninja-1.10.2-GCCcore-11.3.0.eb)
* Szip/2.1.1-GCCcore-11.3.0 (Szip-2.1.1-GCCcore-11.3.0.eb)
* flatbuffers/2.0.7-GCCcore-11.3.0 (flatbuffers-2.0.7-GCCcore-11.3.0.eb)
* ICU/71.1-GCCcore-11.3.0 (ICU-71.1-GCCcore-11.3.0.eb)
* JsonCpp/1.9.5-GCCcore-11.3.0 (JsonCpp-1.9.5-GCCcore-11.3.0.eb)
* LMDB/0.9.29-GCCcore-11.3.0 (LMDB-0.9.29-GCCcore-11.3.0.eb)
* NASM/2.15.05-GCCcore-11.3.0 (NASM-2.15.05-GCCcore-11.3.0.eb)
* libjpeg-turbo/2.1.3-GCCcore-11.3.0 (libjpeg-turbo-2.1.3-GCCcore-11.3.0.eb)
* nsync/1.25.0-GCCcore-11.3.0 (nsync-1.25.0-GCCcore-11.3.0.eb)
* protobuf-python/3.19.4-GCCcore-11.3.0 (protobuf-python-3.19.4-GCCcore-11.3.0.eb)
* HDF5/1.12.2-gompi-2022a (HDF5-1.12.2-gompi-2022a.eb)
* SciPy-bundle/2022.05-foss-2022a (SciPy-bundle-2022.05-foss-2022a.eb)
* h5py/3.7.0-foss-2022a (h5py-3.7.0-foss-2022a.eb)
* libpng/1.6.37-GCCcore-11.3.0 (libpng-1.6.37-GCCcore-11.3.0.eb)
* snappy/1.1.9-GCCcore-11.3.0 (snappy-1.1.9-GCCcore-11.3.0.eb)
* networkx/2.8.4-foss-2022a (networkx-2.8.4-foss-2022a.eb)
* TensorFlow/2.11.0-foss-2022a (TensorFlow-2.11.0-foss-2022a.eb)
```