### PR TITLE
{2023.06}[foss/2022b] TensorFlow 2.13.0

### DIFF
--- a/.github/workflows/test_eessi.yml
+++ b/.github/workflows/test_eessi.yml
@@ -33,6 +33,7 @@ jobs:
         - eessi-2023.06-eb-4.8.1-2021a.yml
         - eessi-2023.06-eb-4.8.1-2021b.yml
         - eessi-2023.06-eb-4.8.1-2022a.yml
+        - eessi-2023.06-eb-4.8.1-2022b.yml
     steps:
         - name: Check out software-layer repository
           uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/eessi-2023.06-eb-4.8.1-2022b.yml
+++ b/eessi-2023.06-eb-4.8.1-2022b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - TensorFlow-2.13.0-foss-2022b


### PR DESCRIPTION
```
36 out of 75 required modules missing:

* Zip/3.0-GCCcore-12.2.0 (Zip-3.0-GCCcore-12.2.0.eb)
* Eigen/3.4.0-GCCcore-12.2.0 (Eigen-3.4.0-GCCcore-12.2.0.eb)
* double-conversion/3.2.1-GCCcore-12.2.0 (double-conversion-3.2.1-GCCcore-12.2.0.eb)
* GMP/6.2.1-GCCcore-12.2.0 (GMP-6.2.1-GCCcore-12.2.0.eb)
* git/2.38.1-GCCcore-12.2.0-nodocs (git-2.38.1-GCCcore-12.2.0-nodocs.eb)
* Rust/1.65.0-GCCcore-12.2.0 (Rust-1.65.0-GCCcore-12.2.0.eb)
* Python/3.10.8-GCCcore-12.2.0 (Python-3.10.8-GCCcore-12.2.0.eb)
* pybind11/2.10.3-GCCcore-12.2.0 (pybind11-2.10.3-GCCcore-12.2.0.eb)
* dill/0.3.7-GCCcore-12.2.0 (dill-0.3.7-GCCcore-12.2.0.eb)
* pkgconfig/1.5.5-GCCcore-12.2.0-python (pkgconfig-1.5.5-GCCcore-12.2.0-python.eb)
* hypothesis/6.68.2-GCCcore-12.2.0 (hypothesis-6.68.2-GCCcore-12.2.0.eb)
* Bazel/6.3.1-GCCcore-12.2.0 (Bazel-6.3.1-GCCcore-12.2.0.eb)
* flatbuffers-python/23.1.4-GCCcore-12.2.0 (flatbuffers-python-23.1.4-GCCcore-12.2.0.eb)
* Ninja/1.11.1-GCCcore-12.2.0 (Ninja-1.11.1-GCCcore-12.2.0.eb)
* flatbuffers/23.1.4-GCCcore-12.2.0 (flatbuffers-23.1.4-GCCcore-12.2.0.eb)
* Meson/0.64.0-GCCcore-12.2.0 (Meson-0.64.0-GCCcore-12.2.0.eb)
* giflib/5.2.1-GCCcore-12.2.0 (giflib-5.2.1-GCCcore-12.2.0.eb)
* Szip/2.1.1-GCCcore-12.2.0 (Szip-2.1.1-GCCcore-12.2.0.eb)
* ICU/72.1-GCCcore-12.2.0 (ICU-72.1-GCCcore-12.2.0.eb)
* JsonCpp/1.9.5-GCCcore-12.2.0 (JsonCpp-1.9.5-GCCcore-12.2.0.eb)
* gfbf/2022b (gfbf-2022b.eb)
* SciPy-bundle/2023.02-gfbf-2022b (SciPy-bundle-2023.02-gfbf-2022b.eb)
* NASM/2.15.05-GCCcore-12.2.0 (NASM-2.15.05-GCCcore-12.2.0.eb)
* libjpeg-turbo/2.1.4-GCCcore-12.2.0 (libjpeg-turbo-2.1.4-GCCcore-12.2.0.eb)
* nsync/1.26.0-GCCcore-12.2.0 (nsync-1.26.0-GCCcore-12.2.0.eb)
* mpi4py/3.1.4-gompi-2022b (mpi4py-3.1.4-gompi-2022b.eb)
* HDF5/1.14.0-gompi-2022b (HDF5-1.14.0-gompi-2022b.eb)
* h5py/3.8.0-foss-2022b (h5py-3.8.0-foss-2022b.eb)
* patchelf/0.17.2-GCCcore-12.2.0 (patchelf-0.17.2-GCCcore-12.2.0.eb)
* libpng/1.6.38-GCCcore-12.2.0 (libpng-1.6.38-GCCcore-12.2.0.eb)
* snappy/1.1.9-GCCcore-12.2.0 (snappy-1.1.9-GCCcore-12.2.0.eb)
* Abseil/20230125.2-GCCcore-12.2.0 (Abseil-20230125.2-GCCcore-12.2.0.eb)
* protobuf/23.0-GCCcore-12.2.0 (protobuf-23.0-GCCcore-12.2.0.eb)
* protobuf-python/4.23.0-GCCcore-12.2.0 (protobuf-python-4.23.0-GCCcore-12.2.0.eb)
* RE2/2023-03-01-GCCcore-12.2.0 (RE2-2023-03-01-GCCcore-12.2.0.eb)
* TensorFlow/2.13.0-foss-2022b (TensorFlow-2.13.0-foss-2022b.eb)
```