### PR TITLE
{2023.06}[foss/2022a] BAMM v2.5.0

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -5,3 +5,4 @@ easyconfigs:
       options:
         from-pr: 18870
   - foss-2022a
+  - BAMM-2.5.0-foss-2022a.eb


### PR DESCRIPTION
1 out of 38 required modules missing:

* BAMM/2.5.0-foss-2022a (BAMM-2.5.0-foss-2022a.eb)