### PR TITLE
determine easystack files to process via PR patch file

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -186,11 +186,8 @@ else
     echo_green ">> MODULEPATH set up: ${MODULEPATH}"
 fi
 
-# assume there's only one diff file that corresponds to the PR patch file
-pr_diff=$(ls [0-9]*.diff | head -1)
-
-# use PR patch file to determine in which easystack files stuff was added
-for easystack_file in $(cat ${pr_diff} | grep '^+++' | cut -f2 -d' ' | sed 's@^[a-z]/@@g' | grep '^eessi.*yml$'); do
+# use 'git diff' to determine which easystack files were changed
+for easystack_file in $(git diff --name-only | grep '^eessi.*yml$'); do
 
     echo -e "Processing easystack file ${easystack_file}...\n\n"
 

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -41,7 +41,7 @@ function copy_build_log() {
         echo "- working directory: ${PWD}" >> ${build_log_path}
         echo "- Slurm job ID: ${SLURM_OUT}" >> ${build_log_path}
         echo "- EasyBuild version: ${eb_version}" >> ${build_log_path}
-        echo "- easystack file: ${es}" >> ${build_log_path}
+        echo "- easystack file: ${easystack_file}" >> ${build_log_path}
 
         echo "EasyBuild log file ${build_log} copied to ${build_log_path} (with context appended)"
     fi
@@ -186,36 +186,42 @@ else
     echo_green ">> MODULEPATH set up: ${MODULEPATH}"
 fi
 
-for eb_version in '4.7.2' '4.8.0' '4.8.1'; do
+# assume there's only one diff file that corresponds to the PR patch file
+pr_diff=$(ls [0-9]*.diff | head -1)
+
+# use PR patch file to determine in which easystack files stuff was added
+for easystack_file in $(cat ${pr_diff} | grep '^+++' | cut -f2 -d' ' | sed 's@^[a-z]/@@g' | grep '^eessi.*yml$'); do
+
+    echo -e "Processing easystack file ${easystack_file}...\n\n"
+
+    # determine version of EasyBuild module to load based on EasyBuild version included in name of easystack file
+    eb_version=$(echo ${easystack_file} | sed 's/.*eb-\([0-9.]*\).*/\1/g')
 
     # load EasyBuild module (will be installed if it's not available yet)
     source ${TOPDIR}/load_easybuild_module.sh ${eb_version}
 
     echo_green "All set, let's start installing some software with EasyBuild v${eb_version} in ${EASYBUILD_INSTALLPATH}..."
 
-    for es in $(ls eessi-${EESSI_PILOT_VERSION}-eb-${eb_version}-*.yml); do
+    if [ -f ${easystack_file} ]; then
+        echo_green "Feeding easystack file ${easystack_file} to EasyBuild..."
 
-        if [ -f ${es} ]; then
-            echo_green "Feeding easystack file ${es} to EasyBuild..."
+        ${EB} --easystack ${TOPDIR}/${easystack_file} --robot
+        ec=$?
 
-            ${EB} --easystack ${TOPDIR}/${es} --robot
-            ec=$?
-
-            # copy EasyBuild log file if EasyBuild exited with an error
-            if [ ${ec} -ne 0 ]; then
-                eb_last_log=$(unset EB_VERBOSE; eb --last-log)
-                # copy to current working directory
-                cp -a ${eb_last_log} .
-                echo "Last EasyBuild log file copied from ${eb_last_log} to ${PWD}"
-                # copy to build logs dir (with context added)
-                copy_build_log "${eb_last_log}" "${build_logs_dir}"
-            fi
-
-            $TOPDIR/check_missing_installations.sh ${TOPDIR}/${es}
-        else
-            fatal_error "Easystack file ${es} not found!"
+        # copy EasyBuild log file if EasyBuild exited with an error
+        if [ ${ec} -ne 0 ]; then
+            eb_last_log=$(unset EB_VERBOSE; eb --last-log)
+            # copy to current working directory
+            cp -a ${eb_last_log} .
+            echo "Last EasyBuild log file copied from ${eb_last_log} to ${PWD}"
+            # copy to build logs dir (with context added)
+            copy_build_log "${eb_last_log}" "${build_logs_dir}"
         fi
-    done
+
+        $TOPDIR/check_missing_installations.sh ${TOPDIR}/${easystack_file}
+    else
+        fatal_error "Easystack file ${easystack_file} not found!"
+    fi
 
 done
 


### PR DESCRIPTION
We're starting to hit GitHub rate limits more often because we're using `--from-pr` and `--include-easyblocks-from-pr` in various easystack files now.

Currently, the `EESSI-pilot-install-software.sh` script that is run by `bot/build.sh` script simply iterates over all existing easystack files, regardless of whether or not they have been changed, and thus triggers a whole bunch of useless EasyBuild sessions that hammer the GitHub API.

These changes use the `<PR>.diff` files that is left behind in the working directory that is prepared by the bot to only process the easystack files that are actually changed in a PR, which significantly limits the EasyBuild sessions being started.

I think it would be better if the bot collects the info on which files have been changed/added/removed by a PR, but for now this "dirty" approach would already help a lot, and can be replaced with a cleaner approach later if the bot feeds in a list of changed/removed/added files via the `cfg/job.cfg` file it prepares for each build job.

tested via https://github.com/boegel/software-layer/pull/28, works as intended