### PR TITLE
{2023.06}[foss/2021b] LAMMPS 23Jun2022

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -268,18 +268,16 @@ def pre_configure_hook_wrf_aarch64(self, *args, **kwargs):
         raise EasyBuildError("WRF-specific hook triggered for non-WRF easyconfig?!")
 
 
-def pre_configure_hook_PLUMED_aarch64(self, *args, **kwargs):
+def pre_configure_hook_LAMMPS_aarch64(self, *args, **kwargs):
     """
     pre-configure hook for PLUMED:
     - remove unsupported --enable-asmjit option on aarch64
     """
 
-    if self.name == 'PLUMED':
-        if  get_cpu_architecture() == AARCH64:
-            configopts = self.cfg['configopts']
-            regex = re.compile(r'--enable-asmjit')
-            if re.search(regex, configopts):
-                self.cfg['configopts'] = regex.sub('', configopts)
+    if self.name == 'LAMMPS':
+        if self.version == '23Jun2022':
+            if  get_cpu_architecture() == AARCH64:
+                self.cfg['kokkos_arch'] = 'A64FX'
     else:
         raise EasyBuildError("PLUMED-specific hook triggered for non-PLUMED easyconfig?!")
 
@@ -362,7 +360,7 @@ PRE_CONFIGURE_HOOKS = {
     'MetaBAT': pre_configure_hook_metabat_filtered_zlib_dep,
     'OpenBLAS': pre_configure_hook_openblas_optarch_generic,
     'WRF': pre_configure_hook_wrf_aarch64,
-    'PLUMED': pre_configure_hook_PLUMED_aarch64,
+    'PLUMED': pre_configure_hook_LAMMPS_aarch64,
 }
 
 PRE_TEST_HOOKS = {

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -268,6 +268,22 @@ def pre_configure_hook_wrf_aarch64(self, *args, **kwargs):
         raise EasyBuildError("WRF-specific hook triggered for non-WRF easyconfig?!")
 
 
+def pre_configure_hook_PLUMED_aarch64(self, *args, **kwargs):
+    """
+    pre-configure hook for PLUMED:
+    - remove unsupported --enable-asmjit option on aarch64
+    """
+
+    if self.name == 'PLUMED':
+        if  get_cpu_architecture() == AARCH64:
+            configopts = self.cfg['configopts']
+            regex = re.compile(r'--enable-asmjit')
+            if re.search(regex, configopts):
+                self.cfg['configopts'] = regex.sub('', configopts)
+    else:
+        raise EasyBuildError("PLUMED-specific hook triggered for non-PLUMED easyconfig?!")
+
+
 def pre_test_hook(self,*args, **kwargs):
     """Main pre-test hook: trigger custom functions based on software name."""
     if self.name in PRE_TEST_HOOKS:
@@ -346,6 +362,7 @@ PRE_CONFIGURE_HOOKS = {
     'MetaBAT': pre_configure_hook_metabat_filtered_zlib_dep,
     'OpenBLAS': pre_configure_hook_openblas_optarch_generic,
     'WRF': pre_configure_hook_wrf_aarch64,
+    'PLUMED': pre_configure_hook_PLUMED_aarch64,
 }
 
 PRE_TEST_HOOKS = {

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -279,7 +279,7 @@ def pre_configure_hook_LAMMPS_aarch64(self, *args, **kwargs):
             if  get_cpu_architecture() == AARCH64:
                 self.cfg['kokkos_arch'] = 'A64FX'
     else:
-        raise EasyBuildError("PLUMED-specific hook triggered for non-PLUMED easyconfig?!")
+        raise EasyBuildError("LAMMPS-specific hook triggered for non-LAMMPS easyconfig?!")
 
 
 def pre_test_hook(self,*args, **kwargs):

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -360,7 +360,7 @@ PRE_CONFIGURE_HOOKS = {
     'MetaBAT': pre_configure_hook_metabat_filtered_zlib_dep,
     'OpenBLAS': pre_configure_hook_openblas_optarch_generic,
     'WRF': pre_configure_hook_wrf_aarch64,
-    'PLUMED': pre_configure_hook_LAMMPS_aarch64,
+    'LAMMPS': pre_configure_hook_LAMMPS_aarch64,
 }
 
 PRE_TEST_HOOKS = {

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -19,6 +19,7 @@ except ImportError:
 
 
 CPU_TARGET_NEOVERSE_V1 = 'aarch64/neoverse_v1'
+CPU_TARGET_AARCH64_GENERIC = 'aarch64/generic' 
 
 EESSI_RPATH_OVERRIDE_ATTR = 'orig_rpath_override_dirs'
 
@@ -277,7 +278,10 @@ def pre_configure_hook_LAMMPS_aarch64(self, *args, **kwargs):
     if self.name == 'LAMMPS':
         if self.version == '23Jun2022':
             if  get_cpu_architecture() == AARCH64:
-                self.cfg['kokkos_arch'] = 'A64FX'
+                if cpu_target == CPU_TARGET_AARCH64_GENERIC:
+                    self.cfg['kokkos_arch'] = 'ARM81'
+                else:
+                    self.cfg['kokkos_arch'] = 'ARM80'
     else:
         raise EasyBuildError("LAMMPS-specific hook triggered for non-LAMMPS easyconfig?!")
 

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -270,8 +270,8 @@ def pre_configure_hook_wrf_aarch64(self, *args, **kwargs):
 
 def pre_configure_hook_LAMMPS_aarch64(self, *args, **kwargs):
     """
-    pre-configure hook for PLUMED:
-    - remove unsupported --enable-asmjit option on aarch64
+    pre-configure hook for LAMMPS:
+    - set kokkos_arch on Aarch64
     """
 
     if self.name == 'LAMMPS':

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -275,6 +275,7 @@ def pre_configure_hook_LAMMPS_aarch64(self, *args, **kwargs):
     - set kokkos_arch on Aarch64
     """
 
+    cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
     if self.name == 'LAMMPS':
         if self.version == '23Jun2022':
             if  get_cpu_architecture() == AARCH64:

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -279,9 +279,9 @@ def pre_configure_hook_LAMMPS_aarch64(self, *args, **kwargs):
         if self.version == '23Jun2022':
             if  get_cpu_architecture() == AARCH64:
                 if cpu_target == CPU_TARGET_AARCH64_GENERIC:
-                    self.cfg['kokkos_arch'] = 'ARM81'
-                else:
                     self.cfg['kokkos_arch'] = 'ARM80'
+                else:
+                    self.cfg['kokkos_arch'] = 'ARM81'
     else:
         raise EasyBuildError("LAMMPS-specific hook triggered for non-LAMMPS easyconfig?!")
 

--- a/eessi-2023.06-eb-4.8.1-2021b.yml
+++ b/eessi-2023.06-eb-4.8.1-2021b.yml
@@ -5,3 +5,4 @@ easyconfigs:
       options:
         from-pr: 18834
   - R-4.2.0-foss-2021b.eb
+  - LAMMPS-23Jun2022-foss-2021b-kokkos.eb

--- a/eessi-2023.06-eb-4.8.1-2021b.yml
+++ b/eessi-2023.06-eb-4.8.1-2021b.yml
@@ -9,11 +9,7 @@ easyconfigs:
       # the --enable-asmjit is not supported on Aarch64
       options:
         from-pr: 19110
-  - ScaFaCoS-1.0.4-foss-2021b.eb:
-      # Newer version of ScaFaCoS for LAMMPS
-      options:
-        from-pr: 19163
   - LAMMPS-23Jun2022-foss-2021b-kokkos.eb:
-      # TBB is an optional dependency when building on Intel arch
+      # TBB and ScaFaCos are optional dependencies when building on Intel arch
       options:
         from-pr: 19164

--- a/eessi-2023.06-eb-4.8.1-2021b.yml
+++ b/eessi-2023.06-eb-4.8.1-2021b.yml
@@ -9,7 +9,11 @@ easyconfigs:
       # the --enable-asmjit is not supported on Aarch64
       options:
         from-pr: 19110
+  - ScaFaCoS-1.0.4-foss-2021b.eb:
+      # Newer version of ScaFaCoS for LAMMPS
+      options:
+        from-pr: 19163
   - LAMMPS-23Jun2022-foss-2021b-kokkos.eb:
       # TBB is an optional dependency when building on Intel arch
       options:
-        from-pr: 19000
+        from-pr: 19164

--- a/eessi-2023.06-eb-4.8.1-2021b.yml
+++ b/eessi-2023.06-eb-4.8.1-2021b.yml
@@ -12,4 +12,4 @@ easyconfigs:
   - LAMMPS-23Jun2022-foss-2021b-kokkos.eb:
       # TBB and ScaFaCos are optional dependencies when building on Intel arch
       options:
-        from-pr: 19164
+        from-pr: 19246

--- a/eessi-2023.06-eb-4.8.1-2021b.yml
+++ b/eessi-2023.06-eb-4.8.1-2021b.yml
@@ -5,6 +5,10 @@ easyconfigs:
       options:
         from-pr: 18834
   - R-4.2.0-foss-2021b.eb
+  - PLUMED-2.7.3-foss-2021b.eb:
+      # the --enable-asmjit is not supported on Aarch64
+      options:
+        from-pr: 19110
   - LAMMPS-23Jun2022-foss-2021b-kokkos.eb:
       # TBB is an optional dependency when building on Intel arch
       options:

--- a/eessi-2023.06-eb-4.8.1-2021b.yml
+++ b/eessi-2023.06-eb-4.8.1-2021b.yml
@@ -5,4 +5,7 @@ easyconfigs:
       options:
         from-pr: 18834
   - R-4.2.0-foss-2021b.eb
-  - LAMMPS-23Jun2022-foss-2021b-kokkos.eb
+  - LAMMPS-23Jun2022-foss-2021b-kokkos.eb:
+      # TBB is an optional dependency when building on Intel arch
+      options:
+        from-pr: 19000


### PR DESCRIPTION
9 out of 90 required modules missing:

* tbb/2020.3-GCCcore-11.2.0 (tbb-2020.3-GCCcore-11.2.0.eb)
* archspec/0.1.3-GCCcore-11.2.0 (archspec-0.1.3-GCCcore-11.2.0.eb)
* Voro++/0.4.6-GCCcore-11.2.0 (Voro++-0.4.6-GCCcore-11.2.0.eb)
* kim-api/2.3.0-GCCcore-11.2.0 (kim-api-2.3.0-GCCcore-11.2.0.eb)
* xxd/8.2.4220-GCCcore-11.2.0 (xxd-8.2.4220-GCCcore-11.2.0.eb)
* ScaFaCoS/1.0.1-foss-2021b (ScaFaCoS-1.0.1-foss-2021b.eb)
* PLUMED/2.7.3-foss-2021b (PLUMED-2.7.3-foss-2021b.eb)
* VTK/9.1.0-foss-2021b (VTK-9.1.0-foss-2021b.eb)
* LAMMPS/23Jun2022-foss-2021b-kokkos (LAMMPS-23Jun2022-foss-2021b-kokkos.eb)