### PR TITLE
{2023.06}[foss/2022a] ImageMagick 7.1.0-37

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -7,3 +7,4 @@ easyconfigs:
   - foss-2022a
   - SciPy-bundle-2022.05-foss-2022a
   - BAMM-2.5.0-foss-2022a.eb
+  - ImageMagick-7.1.0-37-GCCcore-11.3.0.eb


### PR DESCRIPTION
PR with dual purpose:

1. Investigate failing builds of ImageMagick with foss/2022a
2. Test new build cluster `eessi-bot-mc-aws`

The PR will add the following packages:

```
34 out of 57 required modules missing:

* Bison/3.8.2-GCCcore-11.3.0 (Bison-3.8.2-GCCcore-11.3.0.eb)
* libpng/1.6.37-GCCcore-11.3.0 (libpng-1.6.37-GCCcore-11.3.0.eb)
* NASM/2.15.05-GCCcore-11.3.0 (NASM-2.15.05-GCCcore-11.3.0.eb)
* jbigkit/2.1-GCCcore-11.3.0 (jbigkit-2.1-GCCcore-11.3.0.eb)
* libiconv/1.17-GCCcore-11.3.0 (libiconv-1.17-GCCcore-11.3.0.eb)
* Doxygen/1.9.4-GCCcore-11.3.0 (Doxygen-1.9.4-GCCcore-11.3.0.eb)
* Brotli/1.0.9-GCCcore-11.3.0 (Brotli-1.0.9-GCCcore-11.3.0.eb)
* JasPer/2.0.33-GCCcore-11.3.0 (JasPer-2.0.33-GCCcore-11.3.0.eb)
* libjpeg-turbo/2.1.3-GCCcore-11.3.0 (libjpeg-turbo-2.1.3-GCCcore-11.3.0.eb)
* freetype/2.12.1-GCCcore-11.3.0 (freetype-2.12.1-GCCcore-11.3.0.eb)
* LittleCMS/2.13.1-GCCcore-11.3.0 (LittleCMS-2.13.1-GCCcore-11.3.0.eb)
* libdeflate/1.10-GCCcore-11.3.0 (libdeflate-1.10-GCCcore-11.3.0.eb)
* pixman/0.40.0-GCCcore-11.3.0 (pixman-0.40.0-GCCcore-11.3.0.eb)
* gzip/1.12-GCCcore-11.3.0 (gzip-1.12-GCCcore-11.3.0.eb)
* PCRE/8.45-GCCcore-11.3.0 (PCRE-8.45-GCCcore-11.3.0.eb)
* lz4/1.9.3-GCCcore-11.3.0 (lz4-1.9.3-GCCcore-11.3.0.eb)
* zstd/1.5.2-GCCcore-11.3.0 (zstd-1.5.2-GCCcore-11.3.0.eb)
* LibTIFF/4.3.0-GCCcore-11.3.0 (LibTIFF-4.3.0-GCCcore-11.3.0.eb)
* fontconfig/2.14.0-GCCcore-11.3.0 (fontconfig-2.14.0-GCCcore-11.3.0.eb)
* FriBidi/1.0.12-GCCcore-11.3.0 (FriBidi-1.0.12-GCCcore-11.3.0.eb)
* ICU/71.1-GCCcore-11.3.0 (ICU-71.1-GCCcore-11.3.0.eb)
* Ninja/1.10.2-GCCcore-11.3.0 (Ninja-1.10.2-GCCcore-11.3.0.eb)
* Meson/0.62.1-GCCcore-11.3.0 (Meson-0.62.1-GCCcore-11.3.0.eb)
* GLib/2.72.1-GCCcore-11.3.0 (GLib-2.72.1-GCCcore-11.3.0.eb)
* X11/20220504-GCCcore-11.3.0 (X11-20220504-GCCcore-11.3.0.eb)
* cairo/1.17.4-GCCcore-11.3.0 (cairo-1.17.4-GCCcore-11.3.0.eb)
* GObject-Introspection/1.72.0-GCCcore-11.3.0 (GObject-Introspection-1.72.0-GCCcore-11.3.0.eb)
* HarfBuzz/4.2.1-GCCcore-11.3.0 (HarfBuzz-4.2.1-GCCcore-11.3.0.eb)
* ATK/2.38.0-GCCcore-11.3.0 (ATK-2.38.0-GCCcore-11.3.0.eb)
* Gdk-Pixbuf/2.42.8-GCCcore-11.3.0 (Gdk-Pixbuf-2.42.8-GCCcore-11.3.0.eb)
* Pango/1.50.7-GCCcore-11.3.0 (Pango-1.50.7-GCCcore-11.3.0.eb)
* GTK2/2.24.33-GCCcore-11.3.0 (GTK2-2.24.33-GCCcore-11.3.0.eb)
* Ghostscript/9.56.1-GCCcore-11.3.0 (Ghostscript-9.56.1-GCCcore-11.3.0.eb)
* ImageMagick/7.1.0-37-GCCcore-11.3.0 (ImageMagick-7.1.0-37-GCCcore-11.3.0.eb)
```