### PR TITLE
{2023.06}[2023a] X11 20230603

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2023a.yml
+++ b/eessi-2023.06-eb-4.8.1-2023a.yml
@@ -8,3 +8,4 @@ easyconfigs:
       options:
         from-pr: 18887
   - foss-2023a
+  - X11-20230603-GCCcore-12.3.0


### PR DESCRIPTION
11 out of 25 required modules missing:

* Bison/3.8.2-GCCcore-12.3.0 (Bison-3.8.2-GCCcore-12.3.0.eb)
* libiconv/1.17-GCCcore-12.3.0 (libiconv-1.17-GCCcore-12.3.0.eb)
* expat/2.5.0-GCCcore-12.3.0 (expat-2.5.0-GCCcore-12.3.0.eb)
* libpng/1.6.39-GCCcore-12.3.0 (libpng-1.6.39-GCCcore-12.3.0.eb)
* Ninja/1.11.1-GCCcore-12.3.0 (Ninja-1.11.1-GCCcore-12.3.0.eb)
* Brotli/1.0.9-GCCcore-12.3.0 (Brotli-1.0.9-GCCcore-12.3.0.eb)
* Meson/1.1.1-GCCcore-12.3.0 (Meson-1.1.1-GCCcore-12.3.0.eb)
* Doxygen/1.9.7-GCCcore-12.3.0 (Doxygen-1.9.7-GCCcore-12.3.0.eb)
* freetype/2.13.0-GCCcore-12.3.0 (freetype-2.13.0-GCCcore-12.3.0.eb)
* fontconfig/2.14.2-GCCcore-12.3.0 (fontconfig-2.14.2-GCCcore-12.3.0.eb)
* X11/20230603-GCCcore-12.3.0 (X11-20230603-GCCcore-12.3.0.eb)