### PR TITLE
{2023.06}[GCCcore/11.3.0] BWA-0.7.17-GCCcore-11.3.0

### DIFF
--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -10,3 +10,4 @@ easyconfigs:
   - ESPResSo-4.2.1-foss-2022a:
       options:
         from-pr: 18963
+  - BWA-0.7.17-GCCcore-11.3.0.eb

--- a/eessi-2023.06-eb-4.8.1-2022a.yml
+++ b/eessi-2023.06-eb-4.8.1-2022a.yml
@@ -11,3 +11,5 @@ easyconfigs:
       options:
         from-pr: 18963
   - BWA-0.7.17-GCCcore-11.3.0.eb
+      options:
+        from-pr: 19273


### PR DESCRIPTION
adding BWA 0.7.17 with GCCcore-11.3.0 to EESSI pilot 2023.06 2022a toolchain