### PR TITLE
{2023.06} don't filter Lua dependency (and reinstall `gnuplot/5.4.2-GCCcore-11.2.0`)

### DIFF
--- a/configure_easybuild
+++ b/configure_easybuild
@@ -25,8 +25,7 @@ fi
 
 # note: filtering Bison may break some installations, like Qt5 (see https://github.com/EESSI/software-layer/issues/49)
 # filtering pkg-config breaks R-bundle-Bioconductor installation (see also https://github.com/easybuilders/easybuild-easyconfigs/pull/11104)
-# problems occur when filtering pkg-config with gnuplot too (picks up Lua 5.1 from $EPREFIX rather than from Lua 5.3 dependency)
-DEPS_TO_FILTER=Autoconf,Automake,Autotools,binutils,bzip2,DBus,flex,gettext,gperf,help2man,intltool,libreadline,libtool,Lua,M4,makeinfo,ncurses,util-linux,XZ,zlib
+DEPS_TO_FILTER=Autoconf,Automake,Autotools,binutils,bzip2,DBus,flex,gettext,gperf,help2man,intltool,libreadline,libtool,M4,makeinfo,ncurses,util-linux,XZ,zlib
 # For aarch64 we need to also filter out Yasm.
 # See https://github.com/easybuilders/easybuild-easyconfigs/issues/11190
 if [[ "$EESSI_CPU_FAMILY" == "aarch64" ]]; then

--- a/eessi-2023.06-eb-4.8.0-2021b.yml
+++ b/eessi-2023.06-eb-4.8.0-2021b.yml
@@ -4,4 +4,5 @@ easyconfigs:
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/18746
       options:
         from-pr: 18746
+  - gnuplot-5.4.2-GCCcore-11.2.0.eb
   - OpenFOAM-v2112-foss-2021b.eb

--- a/eessi-2023.06-eb-4.8.0-2021b.yml
+++ b/eessi-2023.06-eb-4.8.0-2021b.yml
@@ -4,5 +4,9 @@ easyconfigs:
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/18746
       options:
         from-pr: 18746
-  - gnuplot-5.4.2-GCCcore-11.2.0.eb
+  - gnuplot-5.4.2-GCCcore-11.2.0.eb:
+      # make sure that Lua dependency is correctly picked up,
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19261
+      options:
+        from-pr: 19261
   - OpenFOAM-v2112-foss-2021b.eb

--- a/eessi-2023.06-eb-4.8.2-2022a.yml
+++ b/eessi-2023.06-eb-4.8.2-2022a.yml
@@ -5,27 +5,6 @@ easyconfigs:
   - AOFlagger-3.4.0-foss-2022a:
       options:
         from-pr: 19119
-        # Exclude Lua from `filter-deps` as the compat layer version is too old for the software
-        filter-deps:
-          - Autoconf
-          - Automake
-          - Autotools
-          - binutils
-          - bzip2
-          - DBus
-          - flex
-          - gettext
-          - gperf
-          - help2man
-          - intltool
-          - libreadline
-          - libtool
-          - ncurses
-          - M4
-          - makeinfo
-          - util-linux
-          - XZ
-          - zlib
   - EveryBeam-0.5.2-foss-2022a:
       options:
         from-pr: 19119


### PR DESCRIPTION
Follow-up to #370 in which `Lua` was removed from `filter-deps` for `AOFlagger` in `eessi-2023.06-eb-4.8.2-2022a.yml`.

If the Lua 5.1 from the compat layer is providing to be problematic for some software, we should let EasyBuild provide a compatible Lua as dependency instead. This won't interfere with Lmod, which is hardwired to use the Lua it was installed with.

This will require a re-install of `gnuplot`, which was installed in `pilot.eessi-hpc.org` on top of the Lua provided by the 2023.06 compat layer.