### PR TITLE
{2023.06}[foss/2023a] TensorFlow v2.13.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -12,3 +12,8 @@ easyconfigs:
       options:
         from-pr: 19270
   - SciPy-bundle-2023.07-gfbf-2023a.eb
+  - TensorFlow-2.13.0-foss-2023a.eb:
+      # patch setup.py for grpcio extension in TensorFlow 2.13.0 easyconfigs to take into account alternate sysroot;
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19268
+      options:
+        from-pr: 19268

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -314,11 +314,19 @@ def pre_test_hook_ignore_failing_tests_FFTWMPI(self, *args, **kwargs):
 
 def pre_test_hook_ignore_failing_tests_SciPybundle(self, *args, **kwargs):
     """
-    Pre-test hook for SciPy-bundle: skip failing tests for SciPy-bundle 2021.10 (currently the only version that is failing).
+    Pre-test hook for SciPy-bundle: skip failing tests for selected SciPy-bundle vrsions
+    In version 2021.10, 2 failing tests in scipy 1.6.3:
+        FAILED optimize/tests/test_linprog.py::TestLinprogIPSparse::test_bug_6139 - A...
+        FAILED optimize/tests/test_linprog.py::TestLinprogIPSparsePresolve::test_bug_6139
+        = 2 failed, 30554 passed, 2064 skipped, 10992 deselected, 76 xfailed, 7 xpassed, 40 warnings in 380.27s (0:06:20) =
+    In versions 2023.07, 2 failing tests in scipy 1.11.1:
+        FAILED scipy/spatial/tests/test_distance.py::TestPdist::test_pdist_correlation_iris
+        FAILED scipy/spatial/tests/test_distance.py::TestPdist::test_pdist_correlation_iris_float32
+        = 2 failed, 54409 passed, 3016 skipped, 223 xfailed, 13 xpassed, 10917 warnings in 892.04s (0:14:52) =
     In previous versions we were not as strict yet on the numpy/SciPy tests
     """
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
-    if self.name == 'SciPy-bundle' and self.version == '2021.10' and cpu_target == CPU_TARGET_NEOVERSE_V1:
+    if self.name == 'SciPy-bundle' and self.version in ['2021.10', '2023.07'] and cpu_target == CPU_TARGET_NEOVERSE_V1:
         self.cfg['testopts'] = "|| echo ignoring failing tests" 
 
 

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -69,6 +69,21 @@ def parse_hook(ec, *args, **kwargs):
         PARSE_HOOKS[ec.name](ec, eprefix)
 
 
+def post_ready_hook(self, *args, **kwargs):
+    """
+    Post-ready hook: limit parallellism for selected builds, because they require a lot of memory per used core.
+    """
+    # 'parallel' easyconfig parameter is set via EasyBlock.set_parallel in ready step based on available cores.
+    # here we reduce parallellism to only use half of that for selected software,
+    # to avoid failing builds/tests due to out-of-memory problems
+    if self.name in ['TensorFlow']:
+        parallel = self.cfg['parallel']
+        if parallel > 1:
+            self.cfg['parallel'] = parallel // 2
+            msg = "limiting parallelism to %s (was %s) for %s to avoid out-of-memory failures during building/testing"
+            print_msg(msg % (self.cfg['parallel'], parallel, self.name), log=self.log)
+
+
 def pre_prepare_hook(self, *args, **kwargs):
     """Main pre-prepare hook: trigger custom functions."""
 


### PR DESCRIPTION
Should first deploy & merge:
* #403

Note: partially overlaps with:
* #401
which also requires `mpi4py` as dependency

```
 26 out of 81 required modules missing:

* Zip/3.0-GCCcore-12.3.0 (Zip-3.0-GCCcore-12.3.0.eb)
* Java/11.0.20 (Java-11.0.20.eb)
* Java/11 (Java-11.eb)
* dill/0.3.7-GCCcore-12.3.0 (dill-0.3.7-GCCcore-12.3.0.eb)
* Bazel/6.3.1-GCCcore-12.3.0 (Bazel-6.3.1-GCCcore-12.3.0.eb)
* double-conversion/3.3.0-GCCcore-12.3.0 (double-conversion-3.3.0-GCCcore-12.3.0.eb)
* flatbuffers-python/23.5.26-GCCcore-12.3.0 (flatbuffers-python-23.5.26-GCCcore-12.3.0.eb)
* flatbuffers/23.5.26-GCCcore-12.3.0 (flatbuffers-23.5.26-GCCcore-12.3.0.eb)
* giflib/5.2.1-GCCcore-12.3.0 (giflib-5.2.1-GCCcore-12.3.0.eb)
* Szip/2.1.1-GCCcore-12.3.0 (Szip-2.1.1-GCCcore-12.3.0.eb)
* pkgconfig/1.5.5-GCCcore-12.3.0-python (pkgconfig-1.5.5-GCCcore-12.3.0-python.eb)
* ICU/73.2-GCCcore-12.3.0 (ICU-73.2-GCCcore-12.3.0.eb)
* JsonCpp/1.9.5-GCCcore-12.3.0 (JsonCpp-1.9.5-GCCcore-12.3.0.eb)
* NASM/2.16.01-GCCcore-12.3.0 (NASM-2.16.01-GCCcore-12.3.0.eb)
* libjpeg-turbo/2.1.5.1-GCCcore-12.3.0 (libjpeg-turbo-2.1.5.1-GCCcore-12.3.0.eb)
* nsync/1.26.0-GCCcore-12.3.0 (nsync-1.26.0-GCCcore-12.3.0.eb)
* mpi4py/3.1.4-gompi-2023a (mpi4py-3.1.4-gompi-2023a.eb)
* HDF5/1.14.0-gompi-2023a (HDF5-1.14.0-gompi-2023a.eb)
* h5py/3.9.0-foss-2023a (h5py-3.9.0-foss-2023a.eb)
* libpng/1.6.39-GCCcore-12.3.0 (libpng-1.6.39-GCCcore-12.3.0.eb)
* snappy/1.1.10-GCCcore-12.3.0 (snappy-1.1.10-GCCcore-12.3.0.eb)
* Abseil/20230125.3-GCCcore-12.3.0 (Abseil-20230125.3-GCCcore-12.3.0.eb)
* protobuf/24.0-GCCcore-12.3.0 (protobuf-24.0-GCCcore-12.3.0.eb)
* protobuf-python/4.24.0-GCCcore-12.3.0 (protobuf-python-4.24.0-GCCcore-12.3.0.eb)
* RE2/2023-08-01-GCCcore-12.3.0 (RE2-2023-08-01-GCCcore-12.3.0.eb)
* TensorFlow/2.13.0-foss-2023a (TensorFlow-2.13.0-foss-2023a.eb)
```