### PR TITLE
update init scripts + README for `software.eessi.io` (+ drop 'pilot' terminology)

### DIFF
--- a/.github/workflows/tests_readme.yml
+++ b/.github/workflows/tests_readme.yml
@@ -19,10 +19,10 @@ jobs:
         - name: Check out software-layer repository
           uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
-        - name: verify if README.md is consistent with EESSI_PILOT_VERSION from init/eessi_defaults
+        - name: verify if README.md is consistent with EESSI_VERSION from init/eessi_defaults
           run: |
             source init/eessi_defaults
-            grep "${EESSI_PILOT_VERSION}" README.md
+            grep "${EESSI_VERSION}" README.md
 
         - name: verify if README.md is consistent with EESSI_CVMFS_REPO from init/eessi_defaults
           run: |

--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -190,7 +190,7 @@ fi
 pr_diff=$(ls [0-9]*.diff | head -1)
 
 # use PR patch file to determine in which easystack files stuff was added
-for easystack_file in $(cat ${pr_diff} | grep '^+++' | cut -f2 -d' ' | sed 's@^[a-z]/@@g' | grep '^eessi.*yml$' | egrep -v 'known-issues|missing'); do
+for easystack_file in $(cat ${pr_diff} | grep '^+++' | cut -f2 -d' ' | sed 's@^[a-z]/@@g' | grep '^easystacks/.*yml$' | egrep -v 'known-issues|missing'); do
 
     echo -e "Processing easystack file ${easystack_file}...\n\n"
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # Software layer
 
-The software layer of the EESSI project uses [EasyBuild](https://easybuild.readthedocs.io), [Lmod](https://lmod.readthedocs.io) and [archspec](https://archspec.readthedocs.io).
+The software layer of the EESSI project uses [EasyBuild](https://docs.easybuild.io), [Lmod](https://lmod.readthedocs.io) and [archspec](https://archspec.readthedocs.io).
 
-See also https://eessi.github.io/docs/software_layer.
+See also https://www.eessi.io/docs/software_layer .
 
 ## Pilot software stack
 
 You can set up your environment by sourcing the init script:
 
 ```
-$ source /cvmfs/pilot.eessi-hpc.org/versions/2023.06/init/bash
-Found EESSI pilot repo @ /cvmfs/pilot.eessi-hpc.org/versions/2023.06!
+$ source /cvmfs/software.eessi.io/versions/2023.06/init/bash
+Found EESSI repo @ /cvmfs/software.eessi.io/versions/2023.06!
 Derived subdirectory for software layer: x86_64/intel/haswell
-Using x86_64/intel/haswell subdirectory for software layer (HARDCODED)
+Using x86_64/intel/haswell subdirectory for software layer
 Initializing Lmod...
-Prepending /cvmfs/pilot.eessi-hpc.org/versions/2023.06/software/x86_64/intel/haswell/modules/all to $MODULEPATH...
-Environment set up to use EESSI pilot software stack, have fun!
-[EESSI pilot 2023.06] $
+Prepending /cvmfs/software.eessi.io/versions/2023.06/software/x86_64/intel/haswell/modules/all to $MODULEPATH...
+Environment set up to use EESSI (2023.06), have fun!
+[EESSI 2023.06] $
 ```
 
 ### Accessing EESSI via a container

--- a/init/Magic_Castle/bash
+++ b/init/Magic_Castle/bash
@@ -6,7 +6,7 @@ EESSI_SILENT=1
 source $(dirname "$BASH_SOURCE")/../eessi_environment_variables
 
 # Don't change the default prompt
-# export PS1="[EESSI pilot $EESSI_PILOT_VERSION] $ "
+# export PS1="[EESSI $EESSI_VERSION] $ "
 
 # Provide a clean MODULEPATH
 export MODULEPATH_ROOT=$EESSI_MODULEPATH
@@ -36,4 +36,4 @@ else
    module reload
 fi
 
-echo "Environment set up to use EESSI pilot software stack (${EESSI_PILOT_VERSION}), have fun!"
+echo "Environment set up to use EESSI (${EESSI_VERSION}), have fun!"

--- a/init/Magic_Castle/eessi_python3
+++ b/init/Magic_Castle/eessi_python3
@@ -12,10 +12,10 @@ export EESSI_SILENT=1
 # for MacOS due to the use of `readlink`)
 source $(dirname "$(readlink -f "$BASH_SOURCE")")/../eessi_environment_variables
 
-eessi_pilot_python=$(ls ${EESSI_SOFTWARE_PATH}/software/Python/3*GCCcore*/bin/python | sed 1q)
-if [ -f "$eessi_pilot_python" ]; then
-  $eessi_pilot_python "$@"
+eessi_python=$(ls ${EESSI_SOFTWARE_PATH}/software/Python/3*GCCcore*/bin/python | sed 1q)
+if [ -f "$eessi_python" ]; then
+  $eessi_python "$@"
 else
-  echo "ERROR: No EESSI pilot python 3 available."
+  echo "ERROR: No EESSI Python 3 available."
   false
 fi

--- a/init/bash
+++ b/init/bash
@@ -13,7 +13,7 @@ source $(dirname "$BASH_SOURCE")/eessi_environment_variables
 # only continue if setting EESSI environment variables worked fine
 if [ $? -eq 0 ]; then
 
-    export PS1="[EESSI pilot $EESSI_PILOT_VERSION] $ "
+    export PS1="[EESSI $EESSI_VERSION] $ "
 
     # add location of commands provided by compat layer to $PATH;
     # see https://github.com/EESSI/software-layer/issues/52
@@ -28,12 +28,12 @@ if [ $? -eq 0 ]; then
     module use $EESSI_MODULEPATH
 
     #echo >> $output
-    #echo "*** Known problems in the ${EESSI_PILOT_VERSION} pilot software stack ***" >> $output
+    #echo "*** Known problems in the ${EESSI_VERSION} software stack ***" >> $output
     #echo >> $output
     #echo "1) ..." >> $output
     #echo >> $output
     #echo >> $output
 
-    echo "Environment set up to use EESSI pilot software stack, have fun!" >> $output
+    echo "Environment set up to use EESSI (${EESSI_VERSION}), have fun!"
 
 fi

--- a/init/eessi_defaults
+++ b/init/eessi_defaults
@@ -8,5 +8,8 @@
 # license: GPLv2
 #
 
-export EESSI_CVMFS_REPO="${EESSI_CVMFS_REPO_OVERRIDE:=/cvmfs/pilot.eessi-hpc.org}"
-export EESSI_PILOT_VERSION="${EESSI_PILOT_VERSION_OVERRIDE:=2023.06}"
+export EESSI_CVMFS_REPO="${EESSI_CVMFS_REPO_OVERRIDE:=/cvmfs/software.eessi.io}"
+export EESSI_VERSION="${EESSI_VERSION_OVERRIDE:=2023.06}"
+# use archdetect by default, unless otherwise specified
+export EESSI_USE_ARCHDETECT="${EESSI_USE_ARCHDETECT:=1}"
+export EESSI_USE_ARCHSPEC="${EESSI_USE_ARCHSPEC:=0}"

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -15,11 +15,11 @@ function error() {
     false
 }
 
-# set up minimal environment: $EESSI_PREFIX, $EESSI_PILOT_VERSION, $EESSI_OS_TYPE, $EESSI_CPU_FAMILY, $EPREFIX
+# set up minimal environment: $EESSI_PREFIX, $EESSI_VERSION, $EESSI_OS_TYPE, $EESSI_CPU_FAMILY, $EPREFIX
 source $EESSI_INIT_DIR_PATH/minimal_eessi_env
 
 if [ -d $EESSI_PREFIX ]; then
-  echo "Found EESSI pilot repo @ $EESSI_PREFIX!" >> $output
+  echo "Found EESSI repo @ $EESSI_PREFIX!" >> $output
 
   export EESSI_EPREFIX=$EPREFIX
   if [ -d $EESSI_EPREFIX ]; then
@@ -29,11 +29,13 @@ if [ -d $EESSI_PREFIX ]; then
       # if archdetect is enabled, use internal code
       export EESSI_SOFTWARE_SUBDIR=$(${EESSI_INIT_DIR_PATH}/eessi_archdetect.sh cpupath)
       echo "archdetect says ${EESSI_SOFTWARE_SUBDIR}" >> $output
-    else
+    elif [ "$EESSI_USE_ARCHSPEC" == "1" ]; then
       # note: eessi_software_subdir_for_host.py will pick up value from $EESSI_SOFTWARE_SUBDIR_OVERRIDE if it's defined!
       export EESSI_EPREFIX_PYTHON=$EESSI_EPREFIX/usr/bin/python3
       export EESSI_SOFTWARE_SUBDIR=$($EESSI_EPREFIX_PYTHON ${EESSI_INIT_DIR_PATH}/eessi_software_subdir_for_host.py $EESSI_PREFIX)
       echo "archspec says ${EESSI_SOFTWARE_SUBDIR}" >> $output
+    else
+      error "Don't know how to detect host CPU, giving up!"
     fi
     if [ ! -z $EESSI_SOFTWARE_SUBDIR ]; then
 
@@ -82,5 +84,5 @@ if [ -d $EESSI_PREFIX ]; then
     error "Compatibility layer directory $EESSI_EPREFIX not found!"
   fi
 else
-  error "EESSI pilot repository at $EESSI_PREFIX not found!"
+  error "EESSI repository at $EESSI_PREFIX not found!"
 fi

--- a/init/minimal_eessi_env
+++ b/init/minimal_eessi_env
@@ -4,11 +4,11 @@
 # $BASH_SOURCE points to correct path, see also http://mywiki.wooledge.org/BashFAQ/028
 EESSI_INIT_DIR_PATH=$(dirname $(realpath $BASH_SOURCE))
 
-# set up defaults: EESSI_CVMFS_REPO, EESSI_PILOT_VERSION
+# set up defaults: EESSI_CVMFS_REPO, EESSI_VERSION
 #   script takes *_OVERRIDEs into account
 source ${EESSI_INIT_DIR_PATH}/eessi_defaults
 
-export EESSI_PREFIX=$EESSI_CVMFS_REPO/versions/$EESSI_PILOT_VERSION
+export EESSI_PREFIX=$EESSI_CVMFS_REPO/versions/$EESSI_VERSION
 
 if [[ $(uname -s) == 'Linux' ]]; then
     export EESSI_OS_TYPE='linux'


### PR DESCRIPTION
Tests in CI will still fail, because they require that `/cvmfs/software.eessi.io/versions/2023.06/init/*` is in place...