### PR TITLE
{2023.06} foss/2023a

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -1,0 +1,7 @@
+easyconfigs:
+  - Rust-1.70.0-GCCcore-12.3.0.eb:
+      # fix build of Rust 1.70.0 by disabling download of pre-built LLVM;
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19264
+      options:
+        from-pr: 19264
+  - foss-2023a.eb


### PR DESCRIPTION
requires that `EasyBuild/4.8.2` is installed & deployed first:
* #393