### PR TITLE
{2023.06}[foss/2023a] GROMACS v2023.3

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -5,3 +5,6 @@ easyconfigs:
       options:
         from-pr: 19264
   - foss-2023a.eb
+  - GROMACS-2023.3-foss-2023a.eb:
+      options:
+        from-pr: 19321


### PR DESCRIPTION
~Should first deploy & merge:~
* #403

```
1 out of 58 required modules missing:

* GROMACS/2023.3-foss-2023a (GROMACS-2023.3-foss-2023a.eb)
* ```