### PR TITLE
{2023.06}[foss/2023a] SciPy-bundle v2023.07

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -6,3 +6,9 @@ easyconfigs:
       options:
         include-easyblocks-from-pr: 3038
   - foss-2023a.eb
+  - pybind11-2.11.1-GCCcore-12.3.0.eb:
+      # avoid indirect dependency on old CMake version built with GCCcore/10.2.0 via Catch2 build dependency;
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19270
+      options:
+        from-pr: 19270
+  - SciPy-bundle-2023.07-gfbf-2023a.eb

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -336,7 +336,7 @@ def pre_test_hook_ignore_failing_tests_FFTWMPI(self, *args, **kwargs):
 
 def pre_test_hook_ignore_failing_tests_SciPybundle(self, *args, **kwargs):
     """
-    Pre-test hook for SciPy-bundle: skip failing tests for selected SciPy-bundle vrsions
+    Pre-test hook for SciPy-bundle: skip failing tests for selected SciPy-bundle versions
     In version 2021.10, 2 failing tests in scipy 1.6.3:
         FAILED optimize/tests/test_linprog.py::TestLinprogIPSparse::test_bug_6139 - A...
         FAILED optimize/tests/test_linprog.py::TestLinprogIPSparsePresolve::test_bug_6139

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -314,11 +314,19 @@ def pre_test_hook_ignore_failing_tests_FFTWMPI(self, *args, **kwargs):
 
 def pre_test_hook_ignore_failing_tests_SciPybundle(self, *args, **kwargs):
     """
-    Pre-test hook for SciPy-bundle: skip failing tests for SciPy-bundle 2021.10 (currently the only version that is failing).
+    Pre-test hook for SciPy-bundle: skip failing tests for selected SciPy-bundle vrsions
+    In version 2021.10, 2 failing tests in scipy 1.6.3:
+        FAILED optimize/tests/test_linprog.py::TestLinprogIPSparse::test_bug_6139 - A...
+        FAILED optimize/tests/test_linprog.py::TestLinprogIPSparsePresolve::test_bug_6139
+        = 2 failed, 30554 passed, 2064 skipped, 10992 deselected, 76 xfailed, 7 xpassed, 40 warnings in 380.27s (0:06:20) =
+    In versions 2023.07, 2 failing tests in scipy 1.11.1:
+        FAILED scipy/spatial/tests/test_distance.py::TestPdist::test_pdist_correlation_iris
+        FAILED scipy/spatial/tests/test_distance.py::TestPdist::test_pdist_correlation_iris_float32
+        = 2 failed, 54409 passed, 3016 skipped, 223 xfailed, 13 xpassed, 10917 warnings in 892.04s (0:14:52) =
     In previous versions we were not as strict yet on the numpy/SciPy tests
     """
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
-    if self.name == 'SciPy-bundle' and self.version == '2021.10' and cpu_target == CPU_TARGET_NEOVERSE_V1:
+    if self.name == 'SciPy-bundle' and self.version in ['2021.10', '2023.07'] and cpu_target == CPU_TARGET_NEOVERSE_V1:
         self.cfg['testopts'] = "|| echo ignoring failing tests" 
 
 

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -189,7 +189,7 @@ def parse_hook_pybind11_replace_catch2(ec, eprefix):
     Replace Catch2 build dependency in pybind11 easyconfigs with one that doesn't use system toolchain.
     cfr. https://github.com/easybuilders/easybuild-easyconfigs/pull/19270
     """
-    # tihs is mainly necessary to avoid that --missing keeps reporting Catch2/2.13.9 is missing,
+    # this is mainly necessary to avoid that --missing keeps reporting Catch2/2.13.9 is missing,
     # and to avoid that we need to use "--from-pr 19270" for every easyconfigs that (indirectly) depends on pybind11
     if ec.name == 'pybind11' and ec.version in ['2.10.3', '2.11.1']:
         build_deps = ec['builddependencies']


### PR DESCRIPTION
```
22 out of 44 required modules missing:

* expat/2.5.0-GCCcore-12.3.0 (expat-2.5.0-GCCcore-12.3.0.eb)
* hatchling/1.18.0-GCCcore-12.3.0 (hatchling-1.18.0-GCCcore-12.3.0.eb)
* scikit-build/0.17.6-GCCcore-12.3.0 (scikit-build-0.17.6-GCCcore-12.3.0.eb)
* Eigen/3.4.0-GCCcore-12.3.0 (Eigen-3.4.0-GCCcore-12.3.0.eb)
* Meson/1.1.1-GCCcore-12.3.0 (Meson-1.1.1-GCCcore-12.3.0.eb)
* git/2.41.0-GCCcore-12.3.0-nodocs (git-2.41.0-GCCcore-12.3.0-nodocs.eb)
* flit/3.9.0-GCCcore-12.3.0 (flit-3.9.0-GCCcore-12.3.0.eb)
* virtualenv/20.23.1-GCCcore-12.3.0 (virtualenv-20.23.1-GCCcore-12.3.0.eb)
* GCCcore/10.2.0 (GCCcore-10.2.0.eb)
* setuptools-rust/1.6.0-GCCcore-12.3.0 (setuptools-rust-1.6.0-GCCcore-12.3.0.eb)
* cffi/1.15.1-GCCcore-12.3.0 (cffi-1.15.1-GCCcore-12.3.0.eb)
* cURL/7.72.0-GCCcore-10.2.0 (cURL-7.72.0-GCCcore-10.2.0.eb)
* cryptography/41.0.1-GCCcore-12.3.0 (cryptography-41.0.1-GCCcore-12.3.0.eb)
* poetry/1.5.1-GCCcore-12.3.0 (poetry-1.5.1-GCCcore-12.3.0.eb)
* Python-bundle-PyPI/2023.06-GCCcore-12.3.0 (Python-bundle-PyPI-2023.06-GCCcore-12.3.0.eb)
* gfbf/2023a (gfbf-2023a.eb)
* hypothesis/6.82.0-GCCcore-12.3.0 (hypothesis-6.82.0-GCCcore-12.3.0.eb)
* libarchive/3.4.3-GCCcore-10.2.0 (libarchive-3.4.3-GCCcore-10.2.0.eb)
* CMake/3.18.4-GCCcore-10.2.0 (CMake-3.18.4-GCCcore-10.2.0.eb)
* Catch2/2.13.9 (Catch2-2.13.9.eb)
* pybind11/2.11.1-GCCcore-12.3.0 (pybind11-2.11.1-GCCcore-12.3.0.eb)
* SciPy-bundle/2023.07-gfbf-2023a (SciPy-bundle-2023.07-gfbf-2023a.eb)
```