### PR TITLE
{2023.06}[2023a] X11 20230603

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -17,3 +17,4 @@ easyconfigs:
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19268
       options:
         from-pr: 19268
+  - X11-20230603-GCCcore-12.3.0.eb


### PR DESCRIPTION
Needed for #406 and #404 
```
 7 out of 25 required modules missing:

* Bison/3.8.2-GCCcore-12.3.0 (Bison-3.8.2-GCCcore-12.3.0.eb)
* libiconv/1.17-GCCcore-12.3.0 (libiconv-1.17-GCCcore-12.3.0.eb)
* Brotli/1.0.9-GCCcore-12.3.0 (Brotli-1.0.9-GCCcore-12.3.0.eb)
* Doxygen/1.9.7-GCCcore-12.3.0 (Doxygen-1.9.7-GCCcore-12.3.0.eb)
* freetype/2.13.0-GCCcore-12.3.0 (freetype-2.13.0-GCCcore-12.3.0.eb)
* fontconfig/2.14.2-GCCcore-12.3.0 (fontconfig-2.14.2-GCCcore-12.3.0.eb)
* X11/20230603-GCCcore-12.3.0 (X11-20230603-GCCcore-12.3.0.eb)
```
