### PR TITLE
{2023.06}[foss/2023a] Qt5 v5.15.10

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -18,6 +18,6 @@ easyconfigs:
       options:
         from-pr: 19268
   - X11-20230603-GCCcore-12.3.0.eb
-  - Qt5-5.15.10-GCCcore-12.3.0.eb
+  - Qt5-5.15.10-GCCcore-12.3.0.eb:
       options:
         from-pr: 19339

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -18,6 +18,7 @@ easyconfigs:
       options:
         from-pr: 19268
   - X11-20230603-GCCcore-12.3.0.eb
-  - Qt5-5.15.10-GCCcore-12.3.0.eb:
+  - HarfBuzz-5.3.1-GCCcore-12.3.0.eb:
       options:
         from-pr: 19339
+  - Qt5-5.15.10-GCCcore-12.3.0.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -19,3 +19,5 @@ easyconfigs:
         from-pr: 19268
   - X11-20230603-GCCcore-12.3.0.eb
   - Qt5-5.15.10-GCCcore-12.3.0.eb
+      options:
+        from-pr: 19339

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -17,3 +17,4 @@ easyconfigs:
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19268
       options:
         from-pr: 19268
+  - Qt5-5.15.10-GCCcore-12.3.0.eb


### PR DESCRIPTION
Will start when #405 gets merged.
This PR and #405 are needed for #404.
```
23 out of 55 required modules missing:

* PCRE2/10.42-GCCcore-12.3.0 (PCRE2-10.42-GCCcore-12.3.0.eb)
* re2c/3.1-GCCcore-12.3.0 (re2c-3.1-GCCcore-12.3.0.eb)
* GLib/2.77.1-GCCcore-12.3.0 (GLib-2.77.1-GCCcore-12.3.0.eb)
* graphite2/1.3.14-GCCcore-12.3.0 (graphite2-1.3.14-GCCcore-12.3.0.eb)
* pixman/0.42.2-GCCcore-12.3.0 (pixman-0.42.2-GCCcore-12.3.0.eb)
* cairo/1.17.8-GCCcore-12.3.0 (cairo-1.17.8-GCCcore-12.3.0.eb)
* GObject-Introspection/1.76.1-GCCcore-12.3.0 (GObject-Introspection-1.76.1-GCCcore-12.3.0.eb)
* HarfBuzz/5.3.1-GCCcore-12.3.0 (HarfBuzz-5.3.1-GCCcore-12.3.0.eb)
* Mako/1.2.4-GCCcore-12.3.0 (Mako-1.2.4-GCCcore-12.3.0.eb)
* NSPR/4.35-GCCcore-12.3.0 (NSPR-4.35-GCCcore-12.3.0.eb)
* NSS/3.89.1-GCCcore-12.3.0 (NSS-3.89.1-GCCcore-12.3.0.eb)
* JasPer/4.0.0-GCCcore-12.3.0 (JasPer-4.0.0-GCCcore-12.3.0.eb)
* libdrm/2.4.115-GCCcore-12.3.0 (libdrm-2.4.115-GCCcore-12.3.0.eb)
* gzip/1.12-GCCcore-12.3.0 (gzip-1.12-GCCcore-12.3.0.eb)
* nodejs/18.17.1-GCCcore-12.3.0 (nodejs-18.17.1-GCCcore-12.3.0.eb)
* libglvnd/1.6.0-GCCcore-12.3.0 (libglvnd-1.6.0-GCCcore-12.3.0.eb)
* lz4/1.9.4-GCCcore-12.3.0 (lz4-1.9.4-GCCcore-12.3.0.eb)
* zstd/1.5.5-GCCcore-12.3.0 (zstd-1.5.5-GCCcore-12.3.0.eb)
* libunwind/1.6.2-GCCcore-12.3.0 (libunwind-1.6.2-GCCcore-12.3.0.eb)
* LLVM/16.0.6-GCCcore-12.3.0 (LLVM-16.0.6-GCCcore-12.3.0.eb)
* Mesa/23.1.4-GCCcore-12.3.0 (Mesa-23.1.4-GCCcore-12.3.0.eb)
* libGLU/9.0.3-GCCcore-12.3.0 (libGLU-9.0.3-GCCcore-12.3.0.eb)
* Qt5/5.15.10-GCCcore-12.3.0 (Qt5-5.15.10-GCCcore-12.3.0.eb)
```