### PR TITLE
Prepend EESSI version to PS1 instead of overriding PS1

### DIFF
--- a/init/bash
+++ b/init/bash
@@ -13,7 +13,7 @@ source $(dirname "$BASH_SOURCE")/eessi_environment_variables
 # only continue if setting EESSI environment variables worked fine
 if [ $? -eq 0 ]; then
 
-    export PS1="[EESSI $EESSI_VERSION]$PS1"
+    export PS1="{EESSI $EESSI_VERSION}$PS1"
 
     # add location of commands provided by compat layer to $PATH;
     # see https://github.com/EESSI/software-layer/issues/52

--- a/init/bash
+++ b/init/bash
@@ -13,7 +13,7 @@ source $(dirname "$BASH_SOURCE")/eessi_environment_variables
 # only continue if setting EESSI environment variables worked fine
 if [ $? -eq 0 ]; then
 
-    export PS1="{EESSI $EESSI_VERSION}$PS1"
+    export PS1="{EESSI $EESSI_VERSION} $PS1"
 
     # add location of commands provided by compat layer to $PATH;
     # see https://github.com/EESSI/software-layer/issues/52

--- a/init/bash
+++ b/init/bash
@@ -13,7 +13,7 @@ source $(dirname "$BASH_SOURCE")/eessi_environment_variables
 # only continue if setting EESSI environment variables worked fine
 if [ $? -eq 0 ]; then
 
-    export PS1="[EESSI $EESSI_VERSION] $ "
+    export PS1="[EESSI $EESSI_VERSION]$PS1"
 
     # add location of commands provided by compat layer to $PATH;
     # see https://github.com/EESSI/software-layer/issues/52


### PR DESCRIPTION
While testing EESSI I noticed PS1 is overridden which I don't find very convenient. 

With current settings I get this $PS1 when I enable EESSI:

```
source /cvmfs/software.eessi.io/versions/2023.06/init/bash
[EESSI 2023.06] $
```

With this change I prepend EESSI version to my existing $PS1

```
 source /tmp/bash
[EESSI 2023.06][escobar@sei68 ~]$
```