### PR TITLE
{2023.06} foss/2022b

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - foss-2022b.eb


### PR DESCRIPTION
Added a new easystack for `2022b` with only `foss/2022b` for now.