### PR TITLE
{2023.06}[foss/2023a] LHAPDF v6.5.4

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -23,3 +23,6 @@ easyconfigs:
         from-pr: 19339
   - Qt5-5.15.10-GCCcore-12.3.0.eb
   - OSU-Micro-Benchmarks-7.1-1-gompi-2023a.eb
+  - LHAPDF-6.5.4-GCC-12.3.0.eb
+      options:
+        from-pr: 19363

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -23,6 +23,6 @@ easyconfigs:
         from-pr: 19339
   - Qt5-5.15.10-GCCcore-12.3.0.eb
   - OSU-Micro-Benchmarks-7.1-1-gompi-2023a.eb
-  - LHAPDF-6.5.4-GCC-12.3.0.eb
+  - LHAPDF-6.5.4-GCC-12.3.0.eb:
       options:
         from-pr: 19363


### PR DESCRIPTION
License info:
- SPDX identifier: `GPL-3.0-only`
- obtained from https://gitlab.com/hepcedar/lhapdf/