### PR TITLE
Rename `pilot` task in CI

### DIFF
--- a/.github/workflows/test-software.eessi.io.yml
+++ b/.github/workflows/test-software.eessi.io.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
-  pilot:
+  check_missing:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
Just noticed that it still names the tasks `pilot`:
https://github.com/EESSI/software-layer/actions/runs/7146486024/job/19464252799?pr=419
Renaming this to `check_missing`. Or should it be even shorter, in order to not cut off the version and CPU target in the different tasks?