### PR TITLE
{2023.06}[GCC/12.3.0] LoopTools 2.15

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -26,3 +26,6 @@ easyconfigs:
   - LHAPDF-6.5.4-GCC-12.3.0.eb:
       options:
         from-pr: 19363
+  - LoopTools-2.15-GCC-12.3.0.eb:
+      options:
+        from-pr: 19397


### PR DESCRIPTION
License info:

* SPDX identifier: `LGPL-3.0-or-later`
* obtained from https://feynarts.de/looptools/ (and `COPYING` source `.tar.gz`)

