### PR TITLE
{2023.06}[foss/2023a] waLBerla 6.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -23,3 +23,6 @@ easyconfigs:
         from-pr: 19339
   - Qt5-5.15.10-GCCcore-12.3.0.eb
   - OSU-Micro-Benchmarks-7.1-1-gompi-2023a.eb
+  - waLBerla-6.1-foss-2023a.eb:
+      options:
+        from-pr: 19252


### PR DESCRIPTION
2 out of 61 required modules missing:

* Boost.MPI/1.79.0-gompi-2023a (Boost.MPI-1.79.0-gompi-2023a.eb)
* waLBerla/6.1-foss-2023a (waLBerla-6.1-foss-2023a.eb)