### PR TITLE
{2023.06}[gfbf/2023a] R 4.3.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -29,3 +29,6 @@ easyconfigs:
   - LoopTools-2.15-GCC-12.3.0.eb:
       options:
         from-pr: 19397
+  - R-4.3.2-gfbf-2023a.eb:
+      options:
+        from-pr: 19185


### PR DESCRIPTION
Attempt to add `R/4.3.2` to `software.eessi.io/2023.06`.

License:
- SPDX identifier: `GPL-2.0-or-later`
- Source: https://www.r-project.org/COPYING

Missing installations:
```
8 out of 63 required modules missing:

* jbigkit/2.1-GCCcore-12.3.0 (jbigkit-2.1-GCCcore-12.3.0.eb)
* libdeflate/1.18-GCCcore-12.3.0 (libdeflate-1.18-GCCcore-12.3.0.eb)
* LibTIFF/4.5.0-GCCcore-12.3.0 (LibTIFF-4.5.0-GCCcore-12.3.0.eb)
* Tk/8.6.13-GCCcore-12.3.0 (Tk-8.6.13-GCCcore-12.3.0.eb)
* PCRE/8.45-GCCcore-12.3.0 (PCRE-8.45-GCCcore-12.3.0.eb)
* libgit2/1.7.1-GCCcore-12.3.0 (libgit2-1.7.1-GCCcore-12.3.0.eb)
* FriBidi/1.0.12-GCCcore-12.3.0 (FriBidi-1.0.12-GCCcore-12.3.0.eb)
* R/4.3.2-gfbf-2023a (R-4.3.2-gfbf-2023a.eb)
```

Overlap with #427:
- `jbigkit/2.1-GCCcore-12.3.0 (jbigkit-2.1-GCCcore-12.3.0.eb)`
- `libdeflate/1.18-GCCcore-12.3.0 (libdeflate-1.18-GCCcore-12.3.0.eb)`
- `LibTIFF/4.5.0-GCCcore-12.3.0 (LibTIFF-4.5.0-GCCcore-12.3.0.eb)`