### PR TITLE
{2023.06}[GCC/12.3.0] Boost 1.82.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -32,3 +32,4 @@ easyconfigs:
   - R-4.3.2-gfbf-2023a.eb:
       options:
         from-pr: 19185
+  - Boost-1.82.0-GCC-12.3.0.eb


### PR DESCRIPTION
First installing `Boost` v1.82.0 as a necessary dependency of #404 

```
1 out of 15 required modules missing:

* Boost/1.82.0-GCC-12.3.0 (Boost-1.82.0-GCC-12.3.0.eb)
```