### PR TITLE
{2023.06}[gompi/2023a] netCDF 4.9.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -32,3 +32,4 @@ easyconfigs:
   - R-4.3.2-gfbf-2023a.eb:
       options:
         from-pr: 19185
+  - netCDF-4.9.2-gompi-2023a.eb


### PR DESCRIPTION
First installing `netCDF` v4.9.2 as a necessary dependency of #404

```
1 out of 30 required modules missing:

* netCDF/4.9.2-gompi-2023a (netCDF-4.9.2-gompi-2023a.eb)
```