### PR TITLE
{2023.06}[GCCcore/12.3.0] FFmpeg 6.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -32,3 +32,4 @@ easyconfigs:
   - R-4.3.2-gfbf-2023a.eb:
       options:
         from-pr: 19185
+  - FFmpeg-6.0-GCCcore-12.3.0.eb


### PR DESCRIPTION
First installing FFmpeg v6.0 as a necessary dependency of #404
```
7 out of 34 required modules missing:

* ffnvcodec/12.0.16.0 (ffnvcodec-12.0.16.0.eb)
* x264/20230226-GCCcore-12.3.0 (x264-20230226-GCCcore-12.3.0.eb)
* LAME/3.100-GCCcore-12.3.0 (LAME-3.100-GCCcore-12.3.0.eb)
* Yasm/1.3.0-GCCcore-12.3.0 (Yasm-1.3.0-GCCcore-12.3.0.eb)
* x265/3.5-GCCcore-12.3.0 (x265-3.5-GCCcore-12.3.0.eb)
* SDL2/2.28.2-GCCcore-12.3.0 (SDL2-2.28.2-GCCcore-12.3.0.eb)
* FFmpeg/6.0-GCCcore-12.3.0 (FFmpeg-6.0-GCCcore-12.3.0.eb)
```