### PR TITLE
Explicitly set `$EESSI_CPU_FAMILY` in CI that checks missing installations

### DIFF
--- a/.github/workflows/test-software.eessi.io.yml
+++ b/.github/workflows/test-software.eessi.io.yml
@@ -35,6 +35,9 @@ jobs:
           run: |
               export EESSI_SOFTWARE_SUBDIR_OVERRIDE=${{matrix.EESSI_SOFTWARE_SUBDIR_OVERRIDE}}
               source /cvmfs/software.eessi.io/versions/${{matrix.EESSI_VERSION}}/init/bash
+              # set $EESSI_CPU_FAMILY to the CPU architecture that corresponds to $EESSI_SOFTWARE_SUBDIR_OVERRIDE (part before the first slash),
+              # to prevent issues with checks in the Easybuild configuration that use this variable
+              export EESSI_CPU_FAMILY=${EESSI_SOFTWARE_SUBDIR_OVERRIDE%%/*}
               module load EasyBuild
               which eb
               eb --version


### PR DESCRIPTION
This sets/overrides `$EESSI_CPU_FAMILY` to the part before the first slash of `$EESSI_SOFTWARE_SUBDIR_OVERRIDE`, as it's otherwise always set to the architecture of the runner (i.e. `x86_64`). This causes issues with checks in our EB configuration that use `$EESSI_CPU_FAMILY`, e.g. for filtering dependencies for `aarch64` CPUs, which in turn cause the CI to fail for these architectures. This just happened in #432 .