### PR TITLE
make `link_nvidia_host_libraries.sh` script a bit more robust, in case target of host_injections directory is a non-existing directory

### DIFF
--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -205,7 +205,7 @@ ${EESSI_PREFIX}/scripts/gpu_support/nvidia/install_cuda_host_injections.sh -c 12
 # use PR patch file to determine in which easystack files stuff was added
 changed_easystacks=$(cat ${pr_diff} | grep '^+++' | cut -f2 -d' ' | sed 's@^[a-z]/@@g' | grep '^easystacks/.*yml$' | egrep -v 'known-issues|missing') 
 if [ -z ${changed_easystacks} ]; then
-    echo "No missing installations"  # Ensure the bot report success, as there was nothing to be build here
+    echo "No missing installations, party time!"  # Ensure the bot report success, as there was nothing to be build here
 else
     for easystack_file in ${changed_easystacks}; do
     

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -203,42 +203,47 @@ ${EESSI_PREFIX}/scripts/gpu_support/nvidia/install_cuda_host_injections.sh -c 12
 # ${EESSI_PREFIX}/scripts/gpu_support/nvidia/link_nvidia_host_libraries.sh
 
 # use PR patch file to determine in which easystack files stuff was added
-for easystack_file in $(cat ${pr_diff} | grep '^+++' | cut -f2 -d' ' | sed 's@^[a-z]/@@g' | grep '^easystacks/.*yml$' | egrep -v 'known-issues|missing'); do
-
-    echo -e "Processing easystack file ${easystack_file}...\n\n"
-
-    # determine version of EasyBuild module to load based on EasyBuild version included in name of easystack file
-    eb_version=$(echo ${easystack_file} | sed 's/.*eb-\([0-9.]*\).*/\1/g')
-
-    # load EasyBuild module (will be installed if it's not available yet)
-    source ${TOPDIR}/load_easybuild_module.sh ${eb_version}
-
-    ${EB} --show-config
-
-    echo_green "All set, let's start installing some software with EasyBuild v${eb_version} in ${EASYBUILD_INSTALLPATH}..."
-
-    if [ -f ${easystack_file} ]; then
-        echo_green "Feeding easystack file ${easystack_file} to EasyBuild..."
-
-        ${EB} --easystack ${TOPDIR}/${easystack_file} --robot
-        ec=$?
-
-        # copy EasyBuild log file if EasyBuild exited with an error
-        if [ ${ec} -ne 0 ]; then
-            eb_last_log=$(unset EB_VERBOSE; eb --last-log)
-            # copy to current working directory
-            cp -a ${eb_last_log} .
-            echo "Last EasyBuild log file copied from ${eb_last_log} to ${PWD}"
-            # copy to build logs dir (with context added)
-            copy_build_log "${eb_last_log}" "${build_logs_dir}"
+changed_easystacks=$(cat ${pr_diff} | grep '^+++' | cut -f2 -d' ' | sed 's@^[a-z]/@@g' | grep '^easystacks/.*yml$' | egrep -v 'known-issues|missing') 
+if [ -z ${changed_easystacks} ]; then
+    echo "No missing installations"  # Ensure the bot report success, as there was nothing to be build here
+else
+    for easystack_file in ${changed_easystacks}; do
+    
+        echo -e "Processing easystack file ${easystack_file}...\n\n"
+    
+        # determine version of EasyBuild module to load based on EasyBuild version included in name of easystack file
+        eb_version=$(echo ${easystack_file} | sed 's/.*eb-\([0-9.]*\).*/\1/g')
+    
+        # load EasyBuild module (will be installed if it's not available yet)
+        source ${TOPDIR}/load_easybuild_module.sh ${eb_version}
+    
+        ${EB} --show-config
+    
+        echo_green "All set, let's start installing some software with EasyBuild v${eb_version} in ${EASYBUILD_INSTALLPATH}..."
+    
+        if [ -f ${easystack_file} ]; then
+            echo_green "Feeding easystack file ${easystack_file} to EasyBuild..."
+    
+            ${EB} --easystack ${TOPDIR}/${easystack_file} --robot
+            ec=$?
+    
+            # copy EasyBuild log file if EasyBuild exited with an error
+            if [ ${ec} -ne 0 ]; then
+                eb_last_log=$(unset EB_VERBOSE; eb --last-log)
+                # copy to current working directory
+                cp -a ${eb_last_log} .
+                echo "Last EasyBuild log file copied from ${eb_last_log} to ${PWD}"
+                # copy to build logs dir (with context added)
+                copy_build_log "${eb_last_log}" "${build_logs_dir}"
+            fi
+    
+            $TOPDIR/check_missing_installations.sh ${TOPDIR}/${easystack_file}
+        else
+            fatal_error "Easystack file ${easystack_file} not found!"
         fi
-
-        $TOPDIR/check_missing_installations.sh ${TOPDIR}/${easystack_file}
-    else
-        fatal_error "Easystack file ${easystack_file} not found!"
-    fi
-
-done
+    
+    done
+fi
 
 ### add packages here
 


### PR DESCRIPTION
If the target of the `host_injections` variant symlink, you get the following puzzling error:

```
$ ls -l ${EESSI_CVMFS_REPO}/host_injections
lrwxrwxrwx 1 cvmfs cvmfs 23 Oct  3 13:51 /cvmfs/software.eessi.io/host_injections -> /tmp/opt/eessi

$ scripts/gpu_support/nvidia/link_nvidia_host_libraries.sh
Found ldconfig in the following locations:
- /sbin/ldconfig
- /usr/sbin/ldconfig
Using first version
Found NVIDIA GPU driver version 535.129.03
Found host CUDA version 12.2
Creating /cvmfs/software.eessi.io/host_injections/nvidia/x86_64/host (real path /tmp/opt/eessi/nvidia/x86_64/host) failed with:
 mkdir: cannot create directory ‘/cvmfs/software.eessi.io/host_injections’: File exists
ERROR: No write permissions to directory /cvmfs/software.eessi.io/host_injections/nvidia/x86_64/host
```

works fine if the target does exist:

```
$ mkdir /tmp/opt/eessi
$ scripts/gpu_support/nvidia/link_nvidia_host_libraries.sh
Found ldconfig in the following locations:
- /sbin/ldconfig
- /usr/sbin/ldconfig
Using first version
Found NVIDIA GPU driver version 535.129.03
Found host CUDA version 12.2
Downloading latest version of nvliblist.conf from Apptainer to /tmp/tmp.Ko6VDH8wev/nvliblist.conf
Host NVIDIA gpu drivers linked successfully for EESSI
```

The extra block of code with `host_injections_target` makes sure the target of the `host_injections` variant symlink is an existing directory.

If you don't have permissions, you'll also get a clearer error now (though the confusing one is still there):

```
Creating /opt/eessi (real path /opt/eessi) failed with:
 mkdir: cannot create directory ‘/opt/eessi’: Permission denied
Creating /cvmfs/software.eessi.io/host_injections/nvidia/x86_64/host (real path /opt/eessi/nvidia/x86_64/host) failed with:
 mkdir: cannot create directory ‘/cvmfs/software.eessi.io/host_injections’: File exists
ERROR: No write permissions to directory /cvmfs/software.eessi.io/host_injections/nvidia/x86_64/host
```

I've also added some extra informative messages, like mentioning GPU driver version that was found, etc., and muted the useless download progress output produced by `curl` by using `--silent`.