### PR TITLE
{2023.06}[foss/2023b] SciPy-bundle v2023.11

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -1,3 +1,4 @@
 easyconfigs:
   - GCC-13.2.0.eb
   - foss-2023b.eb
+  - SciPy-bundle-2023.11-gfbf-2023b.eb

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -367,15 +367,15 @@ def pre_test_hook_ignore_failing_tests_SciPybundle(self, *args, **kwargs):
         FAILED optimize/tests/test_linprog.py::TestLinprogIPSparse::test_bug_6139 - A...
         FAILED optimize/tests/test_linprog.py::TestLinprogIPSparsePresolve::test_bug_6139
         = 2 failed, 30554 passed, 2064 skipped, 10992 deselected, 76 xfailed, 7 xpassed, 40 warnings in 380.27s (0:06:20) =
-    In versions 2023.07, 2 failing tests in scipy 1.11.1:
+    In versions 2023.07 and 2023.11, 2 failing tests in scipy 1.11.1 and 1.11.4:
         FAILED scipy/spatial/tests/test_distance.py::TestPdist::test_pdist_correlation_iris
         FAILED scipy/spatial/tests/test_distance.py::TestPdist::test_pdist_correlation_iris_float32
         = 2 failed, 54409 passed, 3016 skipped, 223 xfailed, 13 xpassed, 10917 warnings in 892.04s (0:14:52) =
     In previous versions we were not as strict yet on the numpy/SciPy tests
     """
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
-    if self.name == 'SciPy-bundle' and self.version in ['2021.10', '2023.07'] and cpu_target == CPU_TARGET_NEOVERSE_V1:
-        self.cfg['testopts'] = "|| echo ignoring failing tests" 
+    if self.name == 'SciPy-bundle' and self.version in ['2021.10', '2023.07', '2023.11'] and cpu_target == CPU_TARGET_NEOVERSE_V1:
+        self.cfg['testopts'] = "|| echo ignoring failing tests"
 
 
 def pre_single_extension_hook(ext, *args, **kwargs):


### PR DESCRIPTION
```
19 out of 65 required modules missing:

* patchelf/0.18.0-GCCcore-13.2.0 (patchelf-0.18.0-GCCcore-13.2.0.eb)
* hatchling/1.18.0-GCCcore-13.2.0 (hatchling-1.18.0-GCCcore-13.2.0.eb)
* scikit-build/0.17.6-GCCcore-13.2.0 (scikit-build-0.17.6-GCCcore-13.2.0.eb)
* flit/3.9.0-GCCcore-13.2.0 (flit-3.9.0-GCCcore-13.2.0.eb)
* virtualenv/20.24.6-GCCcore-13.2.0 (virtualenv-20.24.6-GCCcore-13.2.0.eb)
* setuptools-rust/1.8.0-GCCcore-13.2.0 (setuptools-rust-1.8.0-GCCcore-13.2.0.eb)
* git/2.42.0-GCCcore-13.2.0 (git-2.42.0-GCCcore-13.2.0.eb)
* Eigen/3.4.0-GCCcore-13.2.0 (Eigen-3.4.0-GCCcore-13.2.0.eb)
* Catch2/2.13.9-GCCcore-13.2.0 (Catch2-2.13.9-GCCcore-13.2.0.eb)
* Rust/1.73.0-GCCcore-13.2.0 (Rust-1.73.0-GCCcore-13.2.0.eb)
* gfbf/2023b (gfbf-2023b.eb)
* cffi/1.15.1-GCCcore-13.2.0 (cffi-1.15.1-GCCcore-13.2.0.eb)
* cryptography/41.0.5-GCCcore-13.2.0 (cryptography-41.0.5-GCCcore-13.2.0.eb)
* poetry/1.6.1-GCCcore-13.2.0 (poetry-1.6.1-GCCcore-13.2.0.eb)
* Python-bundle-PyPI/2023.10-GCCcore-13.2.0 (Python-bundle-PyPI-2023.10-GCCcore-13.2.0.eb)
* pybind11/2.11.1-GCCcore-13.2.0 (pybind11-2.11.1-GCCcore-13.2.0.eb)
* hypothesis/6.90.0-GCCcore-13.2.0 (hypothesis-6.90.0-GCCcore-13.2.0.eb)
* meson-python/0.15.0-GCCcore-13.2.0 (meson-python-0.15.0-GCCcore-13.2.0.eb)
* SciPy-bundle/2023.11-gfbf-2023b (SciPy-bundle-2023.11-gfbf-2023b.eb)
```