### PR TITLE
{2023.06}[foss/2023a] PyTorch v2.1.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - PyTorch-2.1.2-foss-2023a.eb:
+      options:
+        from-pr: 19480

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -1,4 +1,4 @@
 easyconfigs:
   - PyTorch-2.1.2-foss-2023a.eb:
       options:
-        from-pr: 19480
+        from-pr: 19573

--- a/eessi-2023.06-known-issues.yml
+++ b/eessi-2023.06-known-issues.yml
@@ -1,3 +1,11 @@
+- aarch64/generic:
+  - PyTorch-2.1.2-foss-2023a:
+    - issue: https://github.com/EESSI/software-layer/issues/461
+    - info: "8 failing tests (out of 209539) on aarch64/*"
+- aarch64/neoverse_n1:
+  - PyTorch-2.1.2-foss-2023a:
+    - issue: https://github.com/EESSI/software-layer/issues/461
+    - info: "8 failing tests (out of 209539) on aarch64/*"
 - aarch64/neoverse_v1:
   - ESPResSo-4.2.1-foss-2023a:
       - issue: https://github.com/EESSI/software-layer/issues/363

--- a/eessi-2023.06-known-issues.yml
+++ b/eessi-2023.06-known-issues.yml
@@ -17,6 +17,9 @@
   - OpenBLAS-0.3.21-GCC-12.2.0:
     - issue: https://github.com/EESSI/software-layer/issues/314
     - info: "Increased number of numerical errors in OpenBLAS test suite (344 vs max. 150 on x86_64/*)"
+  - PyTorch-2.1.2-foss-2023a:
+    - issue: https://github.com/EESSI/software-layer/issues/461
+    - info: "8 failing tests (out of 209539) on aarch64/*"
   - SciPy-bundle-2023.02-gfbf-2022b:
     - issue: https://github.com/EESSI/software-layer/issues/318
     - info: "numpy built with -march=armv8.4-a instead of -mcpu=native (no SVE) + 2 failing tests (vs 50005 passed) in scipy test suite"


### PR DESCRIPTION
```
15 out of 96 required modules missing:

* libyaml/0.2.5-GCCcore-12.3.0 (libyaml-0.2.5-GCCcore-12.3.0.eb)
* PyYAML/6.0-GCCcore-12.3.0 (PyYAML-6.0-GCCcore-12.3.0.eb)
* GMP/6.2.1-GCCcore-12.3.0 (GMP-6.2.1-GCCcore-12.3.0.eb)
* MPFR/4.2.0-GCCcore-12.3.0 (MPFR-4.2.0-GCCcore-12.3.0.eb)
* pytest-shard/0.1.2-GCCcore-12.3.0 (pytest-shard-0.1.2-GCCcore-12.3.0.eb)
* pytest-flakefinder/1.1.0-GCCcore-12.3.0 (pytest-flakefinder-1.1.0-GCCcore-12.3.0.eb)
* pytest-rerunfailures/12.0-GCCcore-12.3.0 (pytest-rerunfailures-12.0-GCCcore-12.3.0.eb)
* expecttest/0.1.5-GCCcore-12.3.0 (expecttest-0.1.5-GCCcore-12.3.0.eb)
* networkx/3.1-gfbf-2023a (networkx-3.1-gfbf-2023a.eb)
* Z3/4.12.2-GCCcore-12.3.0-Python-3.11.3 (Z3-4.12.2-GCCcore-12.3.0-Python-3.11.3.eb)
* MPC/1.3.1-GCCcore-12.3.0 (MPC-1.3.1-GCCcore-12.3.0.eb)
* gmpy2/2.1.5-GCC-12.3.0 (gmpy2-2.1.5-GCC-12.3.0.eb)
* sympy/1.12-gfbf-2023a (sympy-1.12-gfbf-2023a.eb)
* Pillow/10.0.0-GCCcore-12.3.0 (Pillow-10.0.0-GCCcore-12.3.0.eb)
* PyTorch/2.1.2-foss-2023a (PyTorch-2.1.2-foss-2023a.eb)
```