### PR TITLE
{2023.06-pilot}[foss/2022a] ImageMagick/7.1.0-37

### DIFF
--- a/eessi-2023.06-eb-4.8.2-2022a.yml
+++ b/eessi-2023.06-eb-4.8.2-2022a.yml
@@ -19,3 +19,4 @@ easyconfigs:
       options:
         from-pr: 19226
   - matplotlib-3.5.2-foss-2022a.eb
+  - ImageMagick-7.1.0-37-GCCcore-11.3.0.eb


### PR DESCRIPTION
Desperate attempt to figure out why ImageMagick-7.1.0-37-GCCcore-11.3.0.eb is not building for NESSI. See https://github.com/NorESSI/software-layer/pull/189

Because `foss/2022a` is not available in `software.eessi.io/2023.06` this PR targets the pilot repository.