### PR TITLE
{2023.06}[foss/2023a] OpenFOAM v11

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -46,3 +46,6 @@ easyconfigs:
   - ALL-0.9.2-foss-2023a.eb:
       options:
         from-pr: 19455
+  - OpenFOAM-11-foss-2023a.eb:
+      options:
+        from-pr: 19545

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -46,6 +46,3 @@ easyconfigs:
   - ALL-0.9.2-foss-2023a.eb:
       options:
         from-pr: 19455
-  - OpenFOAM-11-foss-2023a.eb:
-      options:
-        from-pr: 19545

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - OpenFOAM-11-foss-2023a.eb:
+      options:
+        from-pr: 19545


### PR DESCRIPTION
Similar to #404, and an attempt to circumvent the ongoing issues with `OpenFOAM` v10 in said PR.

Once we have test reports at https://github.com/easybuilders/easybuild-easyconfigs/pull/19545 we should be able to build it on the EESSI bot. I'm leaving the PR as a draft until then. 

```
10 out of 112 required modules missing:

* METIS/5.1.0-GCCcore-12.3.0 (METIS-5.1.0-GCCcore-12.3.0.eb)
* CGAL/5.6-GCCcore-12.3.0 (CGAL-5.6-GCCcore-12.3.0.eb)
* libgd/2.3.3-GCCcore-12.3.0 (libgd-2.3.3-GCCcore-12.3.0.eb)
* libcerf/2.3-GCCcore-12.3.0 (libcerf-2.3-GCCcore-12.3.0.eb)
* Lua/5.4.6-GCCcore-12.3.0 (Lua-5.4.6-GCCcore-12.3.0.eb)
* SCOTCH/7.0.3-gompi-2023a (SCOTCH-7.0.3-gompi-2023a.eb)
* Pango/1.50.14-GCCcore-12.3.0 (Pango-1.50.14-GCCcore-12.3.0.eb)
* ParaView/5.11.2-foss-2023a (ParaView-5.11.2-foss-2023a.eb)
* gnuplot/5.4.8-GCCcore-12.3.0 (gnuplot-5.4.8-GCCcore-12.3.0.eb)
* OpenFOAM/11-foss-2023a (OpenFOAM-11-foss-2023a.eb)
```