### PR TITLE
{2023.06}[2022b] SciPy-bundle v2023.02

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - SciPy-bundle-2023.02-gfbf-2022b.eb

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -394,21 +394,19 @@ def pre_single_extension_isoband(ext, *args, **kwargs):
         ext.cfg['preinstallopts'] = "sed -i 's/SIGSTKSZ/32768/g' src/testthat/vendor/catch.h && "
 
 
-def pre_single_extension_scipy(ext, *args, **kwargs):
+def pre_single_extension_numpy(ext, *args, **kwargs):
     """
-    Pre-extension hook for scipy, to change -march=native to -march=armv8.4-a for scipy 1.10.x when buidling for
+    Pre-extension hook for numpy, to change -march=native to -march=armv8.4-a for scipy 1.10.x when buidling for
     aarch64/neoverse_v1 CPU target.
     """
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
-    if ext.name == 'scipy' and ext.version == '1.10.1' and cpu_target == CPU_TARGET_NEOVERSE_V1:
-        cflags = os.getenv('CFLAGS')
-        if '-mcpu=native' in cflags:
-            cflags = cflags.replace('-mcpu=native', '-march=armv8.4-a')
-            ext.cfg.update('configopts', ' '.join([
-                "-Dc_args='%s'" % cflags,
-                "-Dcpp_args='%s'" % cflags,
-                "-Dfortran_args='%s'" % cflags,
-            ]))
+    if ext.name == 'numpy' and ext.version == '1.24.2' and cpu_target == CPU_TARGET_NEOVERSE_V1:
+        # unsure which of these actually matter for numpy, so changing all of them
+        for envvar in ('CFLAGS', 'CXXFLAGS', 'F90FLAGS', 'FFLAGS'):
+            value = os.getenv(envvar)
+            if '-mcpu=native' in value:
+                value = value.replace('-mcpu=native', '-march=armv8.4-a')
+                env.setvar(envvar, value)
 
 
 def pre_single_extension_testthat(ext, *args, **kwargs):
@@ -548,7 +546,7 @@ PRE_TEST_HOOKS = {
 
 PRE_SINGLE_EXTENSION_HOOKS = {
     'isoband': pre_single_extension_isoband,
-    'scipy': pre_single_extension_scipy,
+    'numpy': pre_single_extension_numpy,
     'testthat': pre_single_extension_testthat,
 }
 

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -403,7 +403,7 @@ def pre_single_extension_isoband(ext, *args, **kwargs):
 
 def pre_single_extension_numpy(ext, *args, **kwargs):
     """
-    Pre-extension hook for numpy, to change -march=native to -march=armv8.4-a for scipy 1.10.x
+    Pre-extension hook for numpy, to change -march=native to -march=armv8.4-a for numpy 1.24.2
     when building for aarch64/neoverse_v1 CPU target.
     """
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -367,21 +367,28 @@ def pre_test_hook_ignore_failing_tests_SciPybundle(self, *args, **kwargs):
         FAILED optimize/tests/test_linprog.py::TestLinprogIPSparse::test_bug_6139 - A...
         FAILED optimize/tests/test_linprog.py::TestLinprogIPSparsePresolve::test_bug_6139
         = 2 failed, 30554 passed, 2064 skipped, 10992 deselected, 76 xfailed, 7 xpassed, 40 warnings in 380.27s (0:06:20) =
-    In versions 2023.07 and 2023.11, 2 failing tests in scipy 1.11.1 and 1.11.4:
+    In versions 2023.02, 2023.07, and 2023.11, 2 failing tests in scipy (versions 1.10.1, 1.11.1, 1.11.4):
         FAILED scipy/spatial/tests/test_distance.py::TestPdist::test_pdist_correlation_iris
         FAILED scipy/spatial/tests/test_distance.py::TestPdist::test_pdist_correlation_iris_float32
         = 2 failed, 54409 passed, 3016 skipped, 223 xfailed, 13 xpassed, 10917 warnings in 892.04s (0:14:52) =
     In previous versions we were not as strict yet on the numpy/SciPy tests
     """
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
-    if self.name == 'SciPy-bundle' and self.version in ['2021.10', '2023.07', '2023.11'] and cpu_target == CPU_TARGET_NEOVERSE_V1:
+    scipy_bundle_versions = ('2021.10', '2023.02', '2023.07', '2023.11')
+    if self.name == 'SciPy-bundle' and self.version in scipy_bundle_versions and cpu_target == CPU_TARGET_NEOVERSE_V1:
         self.cfg['testopts'] = "|| echo ignoring failing tests"
 
 
 def pre_single_extension_hook(ext, *args, **kwargs):
-    """Main pre-configure hook: trigger custom functions based on software name."""
+    """Main pre-extension: trigger custom functions based on software name."""
     if ext.name in PRE_SINGLE_EXTENSION_HOOKS:
         PRE_SINGLE_EXTENSION_HOOKS[ext.name](ext, *args, **kwargs)
+
+
+def post_single_extension_hook(ext, *args, **kwargs):
+    """Main post-extension hook: trigger custom functions based on software name."""
+    if ext.name in POST_SINGLE_EXTENSION_HOOKS:
+        POST_SINGLE_EXTENSION_HOOKS[ext.name](ext, *args, **kwargs)
 
 
 def pre_single_extension_isoband(ext, *args, **kwargs):
@@ -396,17 +403,25 @@ def pre_single_extension_isoband(ext, *args, **kwargs):
 
 def pre_single_extension_numpy(ext, *args, **kwargs):
     """
-    Pre-extension hook for numpy, to change -march=native to -march=armv8.4-a for scipy 1.10.x when buidling for
-    aarch64/neoverse_v1 CPU target.
+    Pre-extension hook for numpy, to change -march=native to -march=armv8.4-a for scipy 1.10.x
+    when building for aarch64/neoverse_v1 CPU target.
     """
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
     if ext.name == 'numpy' and ext.version == '1.24.2' and cpu_target == CPU_TARGET_NEOVERSE_V1:
+        # note: this hook is called before build environment is set up (by calling toolchain.prepare()),
+        # so environment variables like $CFLAGS are not defined yet
         # unsure which of these actually matter for numpy, so changing all of them
-        for envvar in ('CFLAGS', 'CXXFLAGS', 'F90FLAGS', 'FFLAGS'):
-            value = os.getenv(envvar)
-            if '-mcpu=native' in value:
-                value = value.replace('-mcpu=native', '-march=armv8.4-a')
-                env.setvar(envvar, value)
+        ext.orig_optarch = build_option('optarch')
+        update_build_option('optarch', 'march=armv8.4-a')
+
+
+def post_single_extension_numpy(ext, *args, **kwargs):
+    """
+    Post-extension hook for numpy, to reset 'optarch' build option.
+    """
+    cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
+    if ext.name == 'numpy' and ext.version == '1.24.2' and cpu_target == CPU_TARGET_NEOVERSE_V1:
+        update_build_option('optarch', ext.orig_optarch)
 
 
 def pre_single_extension_testthat(ext, *args, **kwargs):
@@ -548,6 +563,10 @@ PRE_SINGLE_EXTENSION_HOOKS = {
     'isoband': pre_single_extension_isoband,
     'numpy': pre_single_extension_numpy,
     'testthat': pre_single_extension_testthat,
+}
+
+POST_SINGLE_EXTENSION_HOOKS = {
+    'numpy': post_single_extension_numpy,
 }
 
 POST_SANITYCHECK_HOOKS = {


### PR DESCRIPTION
Opening a dedicated PR to take some load away from #419, which shows significantly more failing tests on `neoverse_v1`.

```
6 out of 34 required modules missing:

* Eigen/3.4.0-GCCcore-12.2.0 (Eigen-3.4.0-GCCcore-12.2.0.eb)
* Catch2/2.13.9-GCCcore-12.2.0 (Catch2-2.13.9-GCCcore-12.2.0.eb)
* pybind11/2.10.3-GCCcore-12.2.0 (pybind11-2.10.3-GCCcore-12.2.0.eb)
* hypothesis/6.68.2-GCCcore-12.2.0 (hypothesis-6.68.2-GCCcore-12.2.0.eb)
* gfbf/2022b (gfbf-2022b.eb)
* SciPy-bundle/2023.02-gfbf-2022b (SciPy-bundle-2023.02-gfbf-2022b.eb)
```