### PR TITLE
{2023.06}[foss/2022b] R v4.2.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - R-4.2.2-foss-2022b.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
@@ -8,4 +8,6 @@ easyconfigs:
   - ImageMagick-7.1.0-53-GCCcore-12.2.0.eb:
       options:
         from-pr: 20086
-  - R-4.2.2-foss-2022b.eb
+  - R-4.2.2-foss-2022b.eb:
+      options:
+        from-pr: 20238


### PR DESCRIPTION
Trying to add R/4.2.2 to software.eessi.io/2023.06.

Missing modules:
```
63 out of 137 required modules missing:

* libxslt/1.1.37-GCCcore-12.2.0 (libxslt-1.1.37-GCCcore-12.2.0.eb)
* nettle/3.8.1-GCCcore-12.2.0 (nettle-3.8.1-GCCcore-12.2.0.eb)
* jbigkit/2.1-GCCcore-12.2.0 (jbigkit-2.1-GCCcore-12.2.0.eb)
* Xvfb/21.1.6-GCCcore-12.2.0 (Xvfb-21.1.6-GCCcore-12.2.0.eb)
* Tk/8.6.12-GCCcore-12.2.0 (Tk-8.6.12-GCCcore-12.2.0.eb)
* libdeflate/1.15-GCCcore-12.2.0 (libdeflate-1.15-GCCcore-12.2.0.eb)
* LibTIFF/4.4.0-GCCcore-12.2.0 (LibTIFF-4.4.0-GCCcore-12.2.0.eb)
* NLopt/2.7.1-GCCcore-12.2.0 (NLopt-2.7.1-GCCcore-12.2.0.eb)
* libogg/1.3.5-GCCcore-12.2.0 (libogg-1.3.5-GCCcore-12.2.0.eb)
* FLAC/1.4.2-GCCcore-12.2.0 (FLAC-1.4.2-GCCcore-12.2.0.eb)
* libvorbis/1.3.7-GCCcore-12.2.0 (libvorbis-1.3.7-GCCcore-12.2.0.eb)
* UDUNITS/2.2.28-GCCcore-12.2.0 (UDUNITS-2.2.28-GCCcore-12.2.0.eb)
* libopus/1.3.1-GCCcore-12.2.0 (libopus-1.3.1-GCCcore-12.2.0.eb)
* Szip/2.1.1-GCCcore-12.2.0 (Szip-2.1.1-GCCcore-12.2.0.eb)
* GSL/2.7-GCC-12.2.0 (GSL-2.7-GCC-12.2.0.eb)
* LAME/3.100-GCCcore-12.2.0 (LAME-3.100-GCCcore-12.2.0.eb)
* libsndfile/1.2.0-GCCcore-12.2.0 (libsndfile-1.2.0-GCCcore-12.2.0.eb)
* GLPK/5.0-GCCcore-12.2.0 (GLPK-5.0-GCCcore-12.2.0.eb)
* LittleCMS/2.14-GCCcore-12.2.0 (LittleCMS-2.14-GCCcore-12.2.0.eb)
* MPFR/4.2.0-GCCcore-12.2.0 (MPFR-4.2.0-GCCcore-12.2.0.eb)
* ATK/2.38.0-GCCcore-12.2.0 (ATK-2.38.0-GCCcore-12.2.0.eb)
* GEOS/3.11.1-GCC-12.2.0 (GEOS-3.11.1-GCC-12.2.0.eb)
* Gdk-Pixbuf/2.42.10-GCCcore-12.2.0 (Gdk-Pixbuf-2.42.10-GCCcore-12.2.0.eb)
* PCRE/8.45-GCCcore-12.2.0 (PCRE-8.45-GCCcore-12.2.0.eb)
* FriBidi/1.0.12-GCCcore-12.2.0 (FriBidi-1.0.12-GCCcore-12.2.0.eb)
* at-spi2-core/2.46.0-GCCcore-12.2.0 (at-spi2-core-2.46.0-GCCcore-12.2.0.eb)
* Pango/1.50.12-GCCcore-12.2.0 (Pango-1.50.12-GCCcore-12.2.0.eb)
* libgit2/1.5.0-GCCcore-12.2.0 (libgit2-1.5.0-GCCcore-12.2.0.eb)
* at-spi2-atk/2.38.0-GCCcore-12.2.0 (at-spi2-atk-2.38.0-GCCcore-12.2.0.eb)
* HDF5/1.14.0-gompi-2022b (HDF5-1.14.0-gompi-2022b.eb)
* netCDF/4.9.0-gompi-2022b (netCDF-4.9.0-gompi-2022b.eb)
* libepoxy/1.5.10-GCCcore-12.2.0 (libepoxy-1.5.10-GCCcore-12.2.0.eb)
* GTK3/3.24.35-GCCcore-12.2.0 (GTK3-3.24.35-GCCcore-12.2.0.eb)
* Ghostscript/10.0.0-GCCcore-12.2.0 (Ghostscript-10.0.0-GCCcore-12.2.0.eb)
* ImageMagick/7.1.0-53-GCCcore-12.2.0 (ImageMagick-7.1.0-53-GCCcore-12.2.0.eb)
* googletest/1.12.1-GCCcore-12.2.0 (googletest-1.12.1-GCCcore-12.2.0.eb)
* nlohmann_json/3.11.2-GCCcore-12.2.0 (nlohmann_json-3.11.2-GCCcore-12.2.0.eb)
* PROJ/9.1.1-GCCcore-12.2.0 (PROJ-9.1.1-GCCcore-12.2.0.eb)
* libgeotiff/1.7.1-GCCcore-12.2.0 (libgeotiff-1.7.1-GCCcore-12.2.0.eb)
* hypothesis/6.68.2-GCCcore-12.2.0 (hypothesis-6.68.2-GCCcore-12.2.0.eb)
* libtirpc/1.3.3-GCCcore-12.2.0 (libtirpc-1.3.3-GCCcore-12.2.0.eb)
* HDF/4.2.15-GCCcore-12.2.0 (HDF-4.2.15-GCCcore-12.2.0.eb)
* CFITSIO/4.2.0-GCCcore-12.2.0 (CFITSIO-4.2.0-GCCcore-12.2.0.eb)
* gfbf/2022b (gfbf-2022b.eb)
* Boost/1.81.0-GCC-12.2.0 (Boost-1.81.0-GCC-12.2.0.eb)
* Eigen/3.4.0-GCCcore-12.2.0 (Eigen-3.4.0-GCCcore-12.2.0.eb)
* giflib/5.2.1-GCCcore-12.2.0 (giflib-5.2.1-GCCcore-12.2.0.eb)
* arpack-ng/3.8.0-foss-2022b (arpack-ng-3.8.0-foss-2022b.eb)
* Catch2/2.13.9-GCCcore-12.2.0 (Catch2-2.13.9-GCCcore-12.2.0.eb)
* Armadillo/11.4.3-foss-2022b (Armadillo-11.4.3-foss-2022b.eb)
* pybind11/2.10.3-GCCcore-12.2.0 (pybind11-2.10.3-GCCcore-12.2.0.eb)
* SciPy-bundle/2023.02-gfbf-2022b (SciPy-bundle-2023.02-gfbf-2022b.eb)
* json-c/0.16-GCCcore-12.2.0 (json-c-0.16-GCCcore-12.2.0.eb)
* Xerces-C++/3.2.4-GCCcore-12.2.0 (Xerces-C++-3.2.4-GCCcore-12.2.0.eb)
* Imath/3.1.6-GCCcore-12.2.0 (Imath-3.1.6-GCCcore-12.2.0.eb)
* OpenEXR/3.1.5-GCCcore-12.2.0 (OpenEXR-3.1.5-GCCcore-12.2.0.eb)
* Qhull/2020.2-GCCcore-12.2.0 (Qhull-2020.2-GCCcore-12.2.0.eb)
* Highway/1.0.3-GCCcore-12.2.0 (Highway-1.0.3-GCCcore-12.2.0.eb)
* Brunsli/0.1-GCCcore-12.2.0 (Brunsli-0.1-GCCcore-12.2.0.eb)
* LERC/4.0.0-GCCcore-12.2.0 (LERC-4.0.0-GCCcore-12.2.0.eb)
* OpenJPEG/2.5.0-GCCcore-12.2.0 (OpenJPEG-2.5.0-GCCcore-12.2.0.eb)
* GDAL/3.6.2-foss-2022b (GDAL-3.6.2-foss-2022b.eb)
* R/4.2.2-foss-2022b (R-4.2.2-foss-2022b.eb)

```