### PR TITLE
{2023.06}[gompi/2023b] netCDF v4.9.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -2,3 +2,6 @@ easyconfigs:
   - GCC-13.2.0.eb
   - foss-2023b.eb
   - SciPy-bundle-2023.11-gfbf-2023b.eb
+  - netCDF-4.9.2-gompi-2023b.eb:
+      options:
+        from-pr: 19534

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -380,7 +380,7 @@ def pre_test_hook_ignore_failing_tests_SciPybundle(self, *args, **kwargs):
 
 def pre_test_hook_ignore_failing_tests_netCDF(self, *args, **kwargs):
     """
-    Pre-test hook for SciPy-bundle: skip failing tests for selected netCDF versions on neoverse_v1
+    Pre-test hook for netCDF: skip failing tests for selected netCDF versions on neoverse_v1
     cfr. https://github.com/EESSI/software-layer/issues/425
     The following tests are problematic:
         163 - nc_test4_run_par_test (Timeout)

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -378,6 +378,18 @@ def pre_test_hook_ignore_failing_tests_SciPybundle(self, *args, **kwargs):
     if self.name == 'SciPy-bundle' and self.version in scipy_bundle_versions and cpu_target == CPU_TARGET_NEOVERSE_V1:
         self.cfg['testopts'] = "|| echo ignoring failing tests"
 
+def pre_test_hook_ignore_failing_tests_netCDF(self, *args, **kwargs):
+    """
+    Pre-test hook for SciPy-bundle: skip failing tests for selected netCDF versions on neoverse_v1
+    cfr. https://github.com/EESSI/software-layer/issues/425
+    The following tests are problematic:
+        163 - nc_test4_run_par_test (Timeout)
+        190 - h5_test_run_par_tests (Timeout)
+    A few other tests are skipped in the easyconfig and patches for similar issues, see above issue for details.
+    """
+    cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
+    if self.name == 'netCDF' and self.version == '4.9.2' and cpu_target == CPU_TARGET_NEOVERSE_V1:
+        self.cfg['testopts'] = "|| echo ignoring failing tests" 
 
 def pre_single_extension_hook(ext, *args, **kwargs):
     """Main pre-extension: trigger custom functions based on software name."""
@@ -557,6 +569,7 @@ PRE_TEST_HOOKS = {
     'ESPResSo': pre_test_hook_ignore_failing_tests_ESPResSo,
     'FFTW.MPI': pre_test_hook_ignore_failing_tests_FFTWMPI,
     'SciPy-bundle': pre_test_hook_ignore_failing_tests_SciPybundle,
+    'netCDF': pre_test_hook_ignore_failing_tests_netCDF,
 }
 
 PRE_SINGLE_EXTENSION_HOOKS = {

--- a/eessi-2023.06-known-issues.yml
+++ b/eessi-2023.06-known-issues.yml
@@ -1,0 +1,4 @@
+- aarch64/neoverse_v1:
+  - netCDF-4.9.2-GCC-12.3.0/GCC-13.2.0:
+      - issue: https://github.com/EESSI/software-layer/issues/425
+      - info: "netCDF intermittent test failures"

--- a/eessi-2023.06-known-issues.yml
+++ b/eessi-2023.06-known-issues.yml
@@ -1,4 +1,7 @@
 - aarch64/neoverse_v1:
-  - netCDF-4.9.2-GCC-12.3.0/GCC-13.2.0:
+  - netCDF-4.9.2-gompi-2023a.eb:
+      - issue: https://github.com/EESSI/software-layer/issues/425
+      - info: "netCDF intermittent test failures"
+  - netCDF-4.9.2-gompi-2023b.eb:
       - issue: https://github.com/EESSI/software-layer/issues/425
       - info: "netCDF intermittent test failures"


### PR DESCRIPTION
Trying to add netCDF/4.9.2-gompi/2023b to software.eessi.io/2023.06.

Missing modules:
```
10 out of 31 required modules missing:

* Bison/3.8.2-GCCcore-13.2.0 (Bison-3.8.2-GCCcore-13.2.0.eb)
* Szip/2.1.1-GCCcore-13.2.0 (Szip-2.1.1-GCCcore-13.2.0.eb)
* libiconv/1.17-GCCcore-13.2.0 (libiconv-1.17-GCCcore-13.2.0.eb)
* Doxygen/1.9.8-GCCcore-13.2.0 (Doxygen-1.9.8-GCCcore-13.2.0.eb)
* gzip/1.13-GCCcore-13.2.0 (gzip-1.13-GCCcore-13.2.0.eb)
* lz4/1.9.4-GCCcore-13.2.0 (lz4-1.9.4-GCCcore-13.2.0.eb)
* zstd/1.5.5-GCCcore-13.2.0 (zstd-1.5.5-GCCcore-13.2.0.eb)
* HDF5/1.14.3-gompi-2023b (HDF5-1.14.3-gompi-2023b.eb)
* netCDF/4.9.2-gompi-2023b (netCDF-4.9.2-gompi-2023b.eb)
* netCDF-C++4/4.3.1-gompi-2023b (netCDF-C++4-4.3.1-gompi-2023b.eb)
```