### PR TITLE
{2023.06}[GCCcore/12.3.0] at-spi2-core 2.49.91

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -2,3 +2,4 @@ easyconfigs:
   - OpenFOAM-11-foss-2023a.eb:
       options:
         from-pr: 19545
+  - at-spi2-core-2.49.91-GCCcore-12.3.0.eb

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -343,7 +343,7 @@ def pre_configure_hook_atspi2core_filter_ld_library_path(self, *args, **kwargs):
     """
     if self.name == 'at-spi2-core':
         if build_option('filter_env_vars') and 'LD_LIBRARY_PATH' in build_option('filter_env_vars'):
-            sed_cmd = 'sed -i "s/gir_extra_args = \[/gir_extra_args = \[\\n  \'--lib-dirs-envvar=FILTER_LD_LIBRARY_PATH\',/g" %(start_dir)s/atspi/meson.build && ')
+            sed_cmd = 'sed -i "s/gir_extra_args = \[/gir_extra_args = \[\\n  \'--lib-dirs-envvar=FILTER_LD_LIBRARY_PATH\',/g" %(start_dir)s/atspi/meson.build && '
             self.cfg.update('preconfigopts', sed_cmd)
     else:
         raise EasyBuildError("at-spi2-core-specific hook triggered for non-at-spi2-core easyconfig?!")

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -335,6 +335,19 @@ def pre_configure_hook_LAMMPS_aarch64(self, *args, **kwargs):
         raise EasyBuildError("LAMMPS-specific hook triggered for non-LAMMPS easyconfig?!")
 
 
+def pre_configure_hook_atspi2core_filter_ld_library_path(self, *args, **kwargs):
+    """
+    pre-configure hook for at-spi2-core:
+    - instruct GObject-Introspection's g-ir-scanner tool to not set $LD_LIBRARY_PATH
+      when EasyBuild is configured to filter it
+    """
+    if self.name == 'at-spi2-core':
+        if build_option('filter_env_vars') and 'LD_LIBRARY_PATH' in build_option('filter_env_vars'):
+            self.cfg.update('preconfigopts', 'sed -i "s/gir_extra_args = \[/gir_extra_args = \[\\n  \'--lib-dirs-envvar=FILTER_LD_LIBRARY_PATH\',/g" %(start_dir)s/atspi/meson.build && ')
+    else:
+        raise EasyBuildError("at-spi2-core-specific hook triggered for non-at-spi2-core easyconfig?!")
+
+
 def pre_test_hook(self,*args, **kwargs):
     """Main pre-test hook: trigger custom functions based on software name."""
     if self.name in PRE_TEST_HOOKS:
@@ -551,6 +564,7 @@ PRE_CONFIGURE_HOOKS = {
     'OpenBLAS': pre_configure_hook_openblas_optarch_generic,
     'WRF': pre_configure_hook_wrf_aarch64,
     'LAMMPS': pre_configure_hook_LAMMPS_aarch64,
+    'at-spi2-core': pre_configure_hook_atspi2core_filter_ld_library_path,
 }
 
 PRE_TEST_HOOKS = {

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -339,7 +339,8 @@ def pre_configure_hook_atspi2core_filter_ld_library_path(self, *args, **kwargs):
     """
     pre-configure hook for at-spi2-core:
     - instruct GObject-Introspection's g-ir-scanner tool to not set $LD_LIBRARY_PATH
-      when EasyBuild is configured to filter it
+      when EasyBuild is configured to filter it, see:
+      https://github.com/EESSI/software-layer/issues/196
     """
     if self.name == 'at-spi2-core':
         if build_option('filter_env_vars') and 'LD_LIBRARY_PATH' in build_option('filter_env_vars'):

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -343,7 +343,8 @@ def pre_configure_hook_atspi2core_filter_ld_library_path(self, *args, **kwargs):
     """
     if self.name == 'at-spi2-core':
         if build_option('filter_env_vars') and 'LD_LIBRARY_PATH' in build_option('filter_env_vars'):
-            self.cfg.update('preconfigopts', 'sed -i "s/gir_extra_args = \[/gir_extra_args = \[\\n  \'--lib-dirs-envvar=FILTER_LD_LIBRARY_PATH\',/g" %(start_dir)s/atspi/meson.build && ')
+            sed_cmd = 'sed -i "s/gir_extra_args = \[/gir_extra_args = \[\\n  \'--lib-dirs-envvar=FILTER_LD_LIBRARY_PATH\',/g" %(start_dir)s/atspi/meson.build && ')
+            self.cfg.update('preconfigopts', sed_cmd)
     else:
         raise EasyBuildError("at-spi2-core-specific hook triggered for non-at-spi2-core easyconfig?!")
 


### PR DESCRIPTION
Split off from #428, trying to fix the `at-spi2-core` issue (and should fix #196 for `at-spi2-core`, though other apps depending on `GObject-Introspection` could have similar issues). Also see https://gitlab.com/eessi/support/-/issues/29.

```
1 out of 32 required modules missing:

* at-spi2-core/2.49.91-GCCcore-12.3.0 (at-spi2-core-2.49.91-GCCcore-12.3.0.eb)
```