### PR TITLE
{2023.06}[foss/2023a] ESPResSo v4.2.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -1,4 +1,9 @@
 easyconfigs:
   - OpenFOAM-11-foss-2023a.eb:
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19545
       options:
         from-pr: 19545
+  - ESPResSo-4.2.1-foss-2023a.eb:
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19592    
+      options:
+        from-pr: 19592


### PR DESCRIPTION
```
12 out of 87 required modules missing:

* GSL/2.7-GCC-12.3.0 (GSL-2.7-GCC-12.3.0.eb)
* typing-extensions/4.9.0-GCCcore-12.3.0 (typing-extensions-4.9.0-GCCcore-12.3.0.eb)
* OpenPGM/5.2.122-GCCcore-12.3.0 (OpenPGM-5.2.122-GCCcore-12.3.0.eb)
* Pint/0.23-GCCcore-12.3.0 (Pint-0.23-GCCcore-12.3.0.eb)
* BeautifulSoup/4.12.2-GCCcore-12.3.0 (BeautifulSoup-4.12.2-GCCcore-12.3.0.eb)
* libsodium/1.0.18-GCCcore-12.3.0 (libsodium-1.0.18-GCCcore-12.3.0.eb)
* libxslt/1.1.38-GCCcore-12.3.0 (libxslt-1.1.38-GCCcore-12.3.0.eb)
* ZeroMQ/4.3.4-GCCcore-12.3.0 (ZeroMQ-4.3.4-GCCcore-12.3.0.eb)
* lxml/4.9.2-GCCcore-12.3.0 (lxml-4.9.2-GCCcore-12.3.0.eb)
* IPython/8.14.0-GCCcore-12.3.0 (IPython-8.14.0-GCCcore-12.3.0.eb)
* Boost.MPI/1.82.0-gompi-2023a (Boost.MPI-1.82.0-gompi-2023a.eb)
* ESPResSo/4.2.1-foss-2023a (ESPResSo-4.2.1-foss-2023a.eb)
```