### PR TITLE
{2023.06}[gfbf/2023b] matplotlib v3.8.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -5,3 +5,6 @@ easyconfigs:
   - netCDF-4.9.2-gompi-2023b.eb:
       options:
         from-pr: 19534
+  - matplotlib-3.8.2-gfbf-2023b.eb:
+      options:
+        from-pr: 19552


### PR DESCRIPTION
Trying to add matplotlib/3.8.2-gfbf/2023b to software.eessi.io/2023.06.

Missing modules:
```
16 out of 65 required modules missing:

* libpng/1.6.40-GCCcore-13.2.0 (libpng-1.6.40-GCCcore-13.2.0.eb)
* cppy/1.2.1-GCCcore-13.2.0 (cppy-1.2.1-GCCcore-13.2.0.eb)
* Qhull/2020.2-GCCcore-13.2.0 (Qhull-2020.2-GCCcore-13.2.0.eb)
* Brotli/1.1.0-GCCcore-13.2.0 (Brotli-1.1.0-GCCcore-13.2.0.eb)
* freetype/2.13.2-GCCcore-13.2.0 (freetype-2.13.2-GCCcore-13.2.0.eb)
* NASM/2.16.01-GCCcore-13.2.0 (NASM-2.16.01-GCCcore-13.2.0.eb)
* libjpeg-turbo/3.0.1-GCCcore-13.2.0 (libjpeg-turbo-3.0.1-GCCcore-13.2.0.eb)
* jbigkit/2.1-GCCcore-13.2.0 (jbigkit-2.1-GCCcore-13.2.0.eb)
* fontconfig/2.14.2-GCCcore-13.2.0 (fontconfig-2.14.2-GCCcore-13.2.0.eb)
* libdeflate/1.19-GCCcore-13.2.0 (libdeflate-1.19-GCCcore-13.2.0.eb)
* X11/20231019-GCCcore-13.2.0 (X11-20231019-GCCcore-13.2.0.eb)
* Tk/8.6.13-GCCcore-13.2.0 (Tk-8.6.13-GCCcore-13.2.0.eb)
* LibTIFF/4.6.0-GCCcore-13.2.0 (LibTIFF-4.6.0-GCCcore-13.2.0.eb)
* Tkinter/3.11.5-GCCcore-13.2.0 (Tkinter-3.11.5-GCCcore-13.2.0.eb)
* Pillow/10.2.0-GCCcore-13.2.0 (Pillow-10.2.0-GCCcore-13.2.0.eb)
* matplotlib/3.8.2-gfbf-2023b (matplotlib-3.8.2-gfbf-2023b.eb)