### PR TITLE
{2023.06}[GCCcore/13.2.0] Qt5 v5.15.13

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -8,3 +8,6 @@ easyconfigs:
   - matplotlib-3.8.2-gfbf-2023b.eb:
       options:
         from-pr: 19552
+  - Qt5-5.15.11-GCCcore-13.2.0.eb:
+      options:
+        from-pr: 19320


### PR DESCRIPTION
Attempt for building Qt5 v5.15.11 GCCcore-13.2.0
```
21 out of 55 required modules missing:

* PCRE2/10.42-GCCcore-13.2.0 (PCRE2-10.42-GCCcore-13.2.0.eb)
* re2c/3.1-GCCcore-13.2.0 (re2c-3.1-GCCcore-13.2.0.eb)
* double-conversion/3.3.0-GCCcore-13.2.0 (double-conversion-3.3.0-GCCcore-13.2.0.eb)
* GLib/2.78.1-GCCcore-13.2.0 (GLib-2.78.1-GCCcore-13.2.0.eb)
* graphite2/1.3.14-GCCcore-13.2.0 (graphite2-1.3.14-GCCcore-13.2.0.eb)
* pixman/0.42.2-GCCcore-13.2.0 (pixman-0.42.2-GCCcore-13.2.0.eb)
* cairo/1.18.0-GCCcore-13.2.0 (cairo-1.18.0-GCCcore-13.2.0.eb)
* GObject-Introspection/1.78.1-GCCcore-13.2.0 (GObject-Introspection-1.78.1-GCCcore-13.2.0.eb)
* HarfBuzz/8.2.2-GCCcore-13.2.0 (HarfBuzz-8.2.2-GCCcore-13.2.0.eb)
* Mako/1.2.4-GCCcore-13.2.0 (Mako-1.2.4-GCCcore-13.2.0.eb)
* snappy/1.1.10-GCCcore-13.2.0 (snappy-1.1.10-GCCcore-13.2.0.eb)
* NSPR/4.35-GCCcore-13.2.0 (NSPR-4.35-GCCcore-13.2.0.eb)
* NSS/3.94-GCCcore-13.2.0 (NSS-3.94-GCCcore-13.2.0.eb)
* libdrm/2.4.117-GCCcore-13.2.0 (libdrm-2.4.117-GCCcore-13.2.0.eb)
* nodejs/20.9.0-GCCcore-13.2.0 (nodejs-20.9.0-GCCcore-13.2.0.eb)
* libglvnd/1.7.0-GCCcore-13.2.0 (libglvnd-1.7.0-GCCcore-13.2.0.eb)
* libunwind/1.6.2-GCCcore-13.2.0 (libunwind-1.6.2-GCCcore-13.2.0.eb)
* LLVM/16.0.6-GCCcore-13.2.0 (LLVM-16.0.6-GCCcore-13.2.0.eb)
* Mesa/23.1.9-GCCcore-13.2.0 (Mesa-23.1.9-GCCcore-13.2.0.eb)
* libGLU/9.0.3-GCCcore-13.2.0 (libGLU-9.0.3-GCCcore-13.2.0.eb)
* Qt5/5.15.13-GCCcore-13.2.0 (Qt5-5.15.13-GCCcore-13.2.0.eb)

```
