### PR TITLE
{2023.06}{GCCcore/12.3.0} BWA 0.7.17.20220923

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -49,6 +49,6 @@ easyconfigs:
   - CDO-2.2.2-gompi-2023a.eb:
       options:
         from-pr: 19735
-  - BWA-0.7.17.20220923-GCCcore-12.3.0.eb:
+  - BWA-0.7.17-20220923-GCCcore-12.3.0.eb:
       options: 
         from-pr: 19820 

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -49,3 +49,6 @@ easyconfigs:
   - CDO-2.2.2-gompi-2023a.eb:
       options:
         from-pr: 19735
+  - BWA-0.7.17.20220923-GCCcore-12.3.0.eb:
+      options: 
+        from-pr: 19820 


### PR DESCRIPTION
Re-taking @kErica 's [work](https://github.com/EESSI/software-layer/pull/429), adding latest BWA

edit:
```
1 out of 3 required modules missing:

* BWA/0.7.17.20220923-GCCcore-12.3.0 (BWA-0.7.17.20220923-GCCcore-12.3.0.eb)
```

