### PR TITLE
{2023.06}[foss/2023a] snakemake 8.4.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -15,3 +15,6 @@ easyconfigs:
       options:
         from-pr: 19573
   - scikit-learn-1.3.1-gfbf-2023a.eb
+  - snakemake-8.4.2-foss-2023a.eb:
+      options:
+        from-pr: 19646


### PR DESCRIPTION
```
11 out of 81 required modules missing:

* GitPython/3.1.40-GCCcore-12.3.0 (GitPython-3.1.40-GCCcore-12.3.0.eb)
* GLPK/5.0-GCCcore-12.3.0 (GLPK-5.0-GCCcore-12.3.0.eb)
* wrapt/1.15.0-gfbf-2023a (wrapt-1.15.0-gfbf-2023a.eb)
* CoinUtils/2.11.10-GCC-12.3.0 (CoinUtils-2.11.10-GCC-12.3.0.eb)
* Osi/0.108.9-GCC-12.3.0 (Osi-0.108.9-GCC-12.3.0.eb)
* MUMPS/5.6.1-foss-2023a-metis (MUMPS-5.6.1-foss-2023a-metis.eb)
* Clp/1.17.9-foss-2023a (Clp-1.17.9-foss-2023a.eb)
* Cgl/0.60.8-foss-2023a (Cgl-0.60.8-foss-2023a.eb)
* Cbc/2.10.11-foss-2023a (Cbc-2.10.11-foss-2023a.eb)
* PuLP/2.8.0-foss-2023a (PuLP-2.8.0-foss-2023a.eb)
* snakemake/8.4.2-foss-2023a (snakemake-8.4.2-foss-2023a.eb)
```