### PR TITLE
{2023.06}[foss/2022b] waLBerla v6.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
@@ -1,6 +1,6 @@
 easyconfigs:
   - SciPy-bundle-2023.02-gfbf-2022b.eb
   - GDAL-3.6.2-foss-2022b.eb
-  - waLBerla-6.1-foss-2022b.eb 19324
+  - waLBerla-6.1-foss-2022b.eb
       options:
-        from-pr: 19252
+        from-pr: 19324

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
@@ -1,3 +1,6 @@
 easyconfigs:
   - SciPy-bundle-2023.02-gfbf-2022b.eb
   - GDAL-3.6.2-foss-2022b.eb
+  - waLBerla-6.1-foss-2022b.eb 19324
+      options:
+        from-pr: 19252

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
@@ -1,6 +1,6 @@
 easyconfigs:
   - SciPy-bundle-2023.02-gfbf-2022b.eb
   - GDAL-3.6.2-foss-2022b.eb
-  - waLBerla-6.1-foss-2022b.eb
+  - waLBerla-6.1-foss-2022b.eb:
       options:
         from-pr: 19324


### PR DESCRIPTION
Adds a minimal installation for `waLBerla` which does not contain the Python bindings or builds the benchmarks. The tutorials, however, are built and installed.

```
2 out of 43 required modules missing:

* Boost.MPI/1.81.0-gompi-2022b (Boost.MPI-1.81.0-gompi-2022b.eb)
* waLBerla/6.1-foss-2022b (waLBerla-6.1-foss-2022b.eb)
```