### PR TITLE
{2023.06}[foss/2023b] WSClean 3.4 + DP3 6.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -12,6 +12,10 @@ easyconfigs:
       options:
         from-pr: 19840
         include-easyblocks-from-pr: 3088
+  - arpack-ng-3.9.0-foss-2023b.eb:
+      options:
+        from-pr: 19840
+        include-easyblocks-from-pr: 3088
   - Armadillo-12.8.0-foss-2023b.eb:
       options:
         from-pr: 19840

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -16,15 +16,15 @@ easyconfigs:
       options:
         from-pr: 19840
         include-easyblocks-from-pr: 3088
-  - DP3-6.0-foss-2023b.eb:
-      options:
-        from-pr: 19840
-        include-easyblocks-from-pr: 3088
-  - IDG-1.2.0-foss-2023b.eb:
+  - IDG-1.2.e0-foss-2023b.eb:
       options:
         from-pr: 19840
         include-easyblocks-from-pr: 3088
   - EveryBeam-0.5.2-foss-2023b.eb:
+      options:
+        from-pr: 19840
+        include-easyblocks-from-pr: 3088
+  - DP3-6.0-foss-2023b.eb:
       options:
         from-pr: 19840
         include-easyblocks-from-pr: 3088

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -10,11 +10,11 @@ easyconfigs:
         from-pr: 19552
   - AOFlagger-3.4.0-foss-2023b.eb:
       options:
-        from:pr: 19840
+        from-pr: 19840
         include-easyblocks-from-pr: 3088
   - casacore-3.5.0-foss-2023b.eb:
       options:
-        from:pr: 19840
+        from-pr: 19840
         include-easyblocks-from-pr: 3088
   - DP3-6.0-foss-2023b.eb:
       options:

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -16,7 +16,7 @@ easyconfigs:
       options:
         from-pr: 19840
         include-easyblocks-from-pr: 3088
-  - IDG-1.2.e0-foss-2023b.eb:
+  - IDG-1.2.0-foss-2023b.eb:
       options:
         from-pr: 19840
         include-easyblocks-from-pr: 3088

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -8,9 +8,27 @@ easyconfigs:
   - matplotlib-3.8.2-gfbf-2023b.eb:
       options:
         from-pr: 19552
+  - AOFlagger-3.4.0-foss-2023b.eb:
+      options:
+        from:pr: 19840
+        include-easyblocks-from-pr: 3088
+  - casacore-3.5.0-foss-2023b.eb:
+      options:
+        from:pr: 19840
+        include-easyblocks-from-pr: 3088
   - DP3-6.0-foss-2023b.eb:
       options:
         from-pr: 19840
+        include-easyblocks-from-pr: 3088
+  - IDG-1.2.0-foss-2023b.eb:
+      options:
+        from-pr: 19840
+        include-easyblocks-from-pr: 3088
+  - EveryBeam-0.5.2-foss-2023b.eb:
+      options:
+        from-pr: 19840
+        include-easyblocks-from-pr: 3088
   - WSClean-3.4-foss-2023b.eb:
       options:
         from-pr: 19840
+        include-easyblocks-from-pr: 3088

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -12,6 +12,10 @@ easyconfigs:
       options:
         from-pr: 19840
         include-easyblocks-from-pr: 3088
+  - Armadillo-12.8.0-foss-2023b.eb:
+      options:
+        from-pr: 19840
+        include-easyblocks-from-pr: 3088
   - casacore-3.5.0-foss-2023b.eb:
       options:
         from-pr: 19840

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -8,3 +8,33 @@ easyconfigs:
   - matplotlib-3.8.2-gfbf-2023b.eb:
       options:
         from-pr: 19552
+  - AOFlagger-3.4.0-foss-2023b.eb:
+      options:
+        from-pr: 19840
+        # Exclude Lua from `filter-deps` as the compat layer version is too old for the software
+        filter-deps:
+          - Autoconf
+          - Automake
+          - Autotools
+          - binutils
+          - bzip2
+          - DBus
+          - flex
+          - gettext
+          - gperf
+          - help2man
+          - intltool
+          - libreadline
+          - libtool
+          - ncurses
+          - M4
+          - makeinfo
+          - util-linux
+          - XZ
+          - zlib
+  - DP3-6.0-foss-2023b.eb:
+      options:
+        from-pr: 19840
+  - WSClean-3.4-foss-2023b.eb:
+      options:
+        from-pr: 19840

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -8,30 +8,6 @@ easyconfigs:
   - matplotlib-3.8.2-gfbf-2023b.eb:
       options:
         from-pr: 19552
-  - AOFlagger-3.4.0-foss-2023b.eb:
-      options:
-        from-pr: 19840
-        # Exclude Lua from `filter-deps` as the compat layer version is too old for the software
-        filter-deps:
-          - Autoconf
-          - Automake
-          - Autotools
-          - binutils
-          - bzip2
-          - DBus
-          - flex
-          - gettext
-          - gperf
-          - help2man
-          - intltool
-          - libreadline
-          - libtool
-          - ncurses
-          - M4
-          - makeinfo
-          - util-linux
-          - XZ
-          - zlib
   - DP3-6.0-foss-2023b.eb:
       options:
         from-pr: 19840

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -12,10 +12,6 @@ easyconfigs:
       options:
         from-pr: 19840
         include-easyblocks-from-pr: 3088
-  - Armadillo-12.8.0-foss-2023b.eb:
-      options:
-        from-pr: 19840
-        include-easyblocks-from-pr: 3088
   - casacore-3.5.0-foss-2023b.eb:
       options:
         from-pr: 19840

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -177,7 +177,7 @@ def parse_hook_casacore_disable_vectorize(ec, eprefix):
                 ec['toolchainopts']['vectorize'] = False
                 print_msg("Changed toochainopts for %s: %s", ec.name, ec['toolchainopts'])
             else:
-                print_msg("Not changing option vectorize for %s on non-AARCH64", ec.name)
+                print_msg("Not changing option vectorize for %s on non-neoverse_v1", ec.name)
         else:
             print_msg("Not changing option vectorize for %s %s %s", ec.name, ec.version, ec.toolchain)
     else:

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -174,6 +174,8 @@ def parse_hook_casacore_disable_vectorize(ec, eprefix):
         ):
             cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
             if cpu_target == CPU_TARGET_NEOVERSE_V1:
+                if not hasattr(ec, 'toolchainopts'):
+                    ec['toolchainopts'] = {}
                 ec['toolchainopts']['vectorize'] = False
                 print_msg("Changed toochainopts for %s: %s", ec.name, ec['toolchainopts'])
             else:

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -186,32 +186,6 @@ def parse_hook_casacore_disable_vectorize(ec, eprefix):
         raise EasyBuildError("casacore-specific hook triggered for non-casacore easyconfig?!")
 
 
-def parse_hook_dp3_enable_relaxed_vector_conversions(ec, eprefix):
-    """
-    Enable lax vector conversion for DP3 on aarch64/neoverse_v1
-    Compiling DP3 6.0 with GCC 13.2.0 (foss-2023b) gives a conversion error when building for aarch64/neoverse_v1.
-    See also, https://github.com/EESSI/software-layer/pull/479
-    """
-    if ec.name == 'DP3':
-        tcname, tcversion = ec['toolchain']['name'], ec['toolchain']['version']
-        if (
-            LooseVersion(ec.version) == LooseVersion('6.0') and
-            tcname == 'foss' and tcversion == '2023b'
-        ):
-            cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
-            if cpu_target == CPU_TARGET_NEOVERSE_V1:
-                if not hasattr(ec, 'configopts'):
-                    ec['configopts'] = ""
-                ec['configopts'] += ' -DCMAKE_CXX_FLAGS="$CXXFLAGS -flax-vector-conversions" '
-                print_msg("Changed configopts for %s: %s", ec.name, ec['configopts'])
-            else:
-                print_msg("Not changing configopts for %s on non-neoverse_v1", ec.name)
-        else:
-            print_msg("Not changing configopts for %s %s %s", ec.name, ec.version, ec.toolchain)
-    else:
-        raise EasyBuildError("DP3-specific hook triggered for non-DP3 easyconfig?!")
-
-
 def parse_hook_cgal_toolchainopts_precise(ec, eprefix):
     """Enable 'precise' rather than 'strict' toolchain option for CGAL on POWER."""
     if ec.name == 'CGAL':
@@ -633,7 +607,6 @@ def inject_gpu_property(ec):
 PARSE_HOOKS = {
     'casacore': parse_hook_casacore_disable_vectorize,
     'CGAL': parse_hook_cgal_toolchainopts_precise,
-    'DP3': parse_hook_dp3_enable_relaxed_vector_conversions,
     'fontconfig': parse_hook_fontconfig_add_fonts,
     'OpenBLAS': parse_hook_openblas_relax_lapack_tests_num_errors,
     'pybind11': parse_hook_pybind11_replace_catch2,

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -178,7 +178,6 @@ def parse_hook_casacore_disable_vectorize(ec, eprefix):
                 print_msg("Not changing option vectorize for %s on non-AARCH64", ec.name)
         else:
             print_msg("Not changing option vectorize for %s %s %s", ec.name, ec.version, ec.toolchain)
-
     else:
         raise EasyBuildError("casacore-specific hook triggered for non-casacore easyconfig?!")
 

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -172,7 +172,8 @@ def parse_hook_casacore_disable_vectorize(ec, eprefix):
             LooseVersion(ec.version) == LooseVersion('3.5.0') and
             tcname == 'foss' and tcversion == '2023b'
         ):
-            if get_cpu_architecture() == CPU_TARGET_NEOVERSE_V1:
+            cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
+            if cpu_target == CPU_TARGET_NEOVERSE_V1:
                 ec['toolchainopts']['vectorize'] = False
                 print_msg("Changed toochainopts for %s: %s", ec.name, ec['toolchainopts'])
             else:

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -159,10 +159,11 @@ def post_prepare_hook(self, *args, **kwargs):
     if self.name in POST_PREPARE_HOOKS:
         POST_PREPARE_HOOKS[self.name](self, *args, **kwargs)
 
+
 def parse_hook_casacore_disable_vectorize(ec, eprefix):
     """
     Disable 'vectorize' toolchain option for casacore 3.5.0 on aarch64/neoverse_v1
-    Compiling casacore 3.5.0 with GCC 13.2.0 (foss-2023) gives an error when building for aarch64/neoverse_v1.
+    Compiling casacore 3.5.0 with GCC 13.2.0 (foss-2023b) gives an error when building for aarch64/neoverse_v1.
     See also, https://github.com/EESSI/software-layer/pull/479
     """
     if ec.name == 'casacore':
@@ -180,6 +181,7 @@ def parse_hook_casacore_disable_vectorize(ec, eprefix):
             print_msg("Not changing option vectorize for %s %s %s", ec.name, ec.version, ec.toolchain)
     else:
         raise EasyBuildError("casacore-specific hook triggered for non-casacore easyconfig?!")
+
 
 def parse_hook_cgal_toolchainopts_precise(ec, eprefix):
     """Enable 'precise' rather than 'strict' toolchain option for CGAL on POWER."""


### PR DESCRIPTION
Adding WSClean and DP3 to software.eessi.io.

Including the AOFlagger dependency because of previous issues with an older Lua version in the compat layer.