### PR TITLE
{2023.06}[foss/2022b] WRF v4.4.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
@@ -4,3 +4,4 @@ easyconfigs:
   - waLBerla-6.1-foss-2022b.eb:
       options:
         from-pr: 19324
+  - WRF-4.4.1-foss-2022b-dmpar.eb


### PR DESCRIPTION
```
4 out of 71 required modules missing:

* tcsh/6.24.07-GCCcore-12.2.0 (tcsh-6.24.07-GCCcore-12.2.0.eb)
* time/1.9-GCCcore-12.2.0 (time-1.9-GCCcore-12.2.0.eb)
* netCDF-Fortran/4.6.0-gompi-2022b (netCDF-Fortran-4.6.0-gompi-2022b.eb)
* WRF/4.4.1-foss-2022b-dmpar (WRF-4.4.1-foss-2022b-dmpar.eb)
```