### PR TITLE
{2023.06}[foss/2023a] dask v2023.9.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -29,4 +29,7 @@ easyconfigs:
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19554
       options:
         from-pr: 19554
-  - dask-2023.9.2-foss-2023a.eb
+  - dask-2023.9.2-foss-2023a.eb:
+      options:
+        from-pr: 19996
+ 

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -29,3 +29,4 @@ easyconfigs:
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19554
       options:
         from-pr: 19554
+  - dask-2023.9.2-foss-2023a.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -29,6 +29,7 @@ easyconfigs:
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19554
       options:
         from-pr: 19554
-  - dask-2023.9.2-foss-2023a.eb:
+  - Pillow-SIMD-9.5.0-GCCcore-12.3.0.eb:
       options:
         from-pr: 19996
+  - dask-2023.9.2-foss-2023a.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -31,5 +31,6 @@ easyconfigs:
         from-pr: 19554
   - Pillow-SIMD-9.5.0-GCCcore-12.3.0.eb:
       options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19996
         from-pr: 19996
   - dask-2023.9.2-foss-2023a.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -32,4 +32,3 @@ easyconfigs:
   - dask-2023.9.2-foss-2023a.eb:
       options:
         from-pr: 19996
- 

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -204,19 +204,6 @@ def parse_hook_openblas_relax_lapack_tests_num_errors(ec, eprefix):
         raise EasyBuildError("OpenBLAS-specific hook triggered for non-OpenBLAS easyconfig?!")
 
 
-def parse_hook_Pillow_SIMD_harcoded_paths(ec, eprefix):
-    """Make Pillow-SIMD aware of sysroot."""
-    # patch setup.py to prefix hardcoded /usr/* and /lib paths with value of %(sysroot) template
-    # (which will be empty if EasyBuild is not configured to use an alternate sysroot);
-    # see also https://gitlab.com/eessi/support/-/issues/9
-    if ec.name == 'Pillow-SIMD':
-        ec.update('preinstallopts', """sed -i 's@"/usr/@"%(sysroot)s/usr/@g' setup.py && """)
-        ec.update('preinstallopts', """sed -i 's@"/lib@"%(sysroot)s/lib@g' setup.py && """)
-        print_msg("Using custom configure options for %s: %s", ec.name, ec['preinstallopts'])
-    else:
-        raise EasyBuildError("Pillow-SIMD-specific hook triggered for non-Pillow-SIMD easyconfig?!")
-
-
 def parse_hook_pybind11_replace_catch2(ec, eprefix):
     """
     Replace Catch2 build dependency in pybind11 easyconfigs with one that doesn't use system toolchain.
@@ -595,7 +582,6 @@ PARSE_HOOKS = {
     'CGAL': parse_hook_cgal_toolchainopts_precise,
     'fontconfig': parse_hook_fontconfig_add_fonts,
     'OpenBLAS': parse_hook_openblas_relax_lapack_tests_num_errors,
-    'Pillow-SIMD' : parse_hook_Pillow_SIMD_harcoded_paths,
     'pybind11': parse_hook_pybind11_replace_catch2,
     'Qt5': parse_hook_qt5_check_qtwebengine_disable,
     'UCX': parse_hook_ucx_eprefix,

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -205,6 +205,7 @@ def parse_hook_openblas_relax_lapack_tests_num_errors(ec, eprefix):
 
 
 def parse_hook_Pillow_SIMD_harcoded_paths(ec, eprefix):
+    """Make Pillow-SIMD aware of sysroot."""
     # patch setup.py to prefix hardcoded /usr/* and /lib paths with value of %(sysroot) template
     # (which will be empty if EasyBuild is not configured to use an alternate sysroot);
     # see also https://gitlab.com/eessi/support/-/issues/9
@@ -249,6 +250,7 @@ def parse_hook_qt5_check_qtwebengine_disable(ec, eprefix):
 
 
 def parse_hook_ucx_eprefix(ec, eprefix):
+    """Make UCX aware of compatibility layer via additional configuration options."""
     if ec.name == 'UCX':
         ec.update('configopts', '--with-sysroot=%s' % eprefix)
         ec.update('configopts', '--with-rdmacm=%s' % os.path.join(eprefix, 'usr'))

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -204,6 +204,18 @@ def parse_hook_openblas_relax_lapack_tests_num_errors(ec, eprefix):
         raise EasyBuildError("OpenBLAS-specific hook triggered for non-OpenBLAS easyconfig?!")
 
 
+def parse_hook_Pillow_SIMD_harcoded_paths(ec, eprefix):
+    # patch setup.py to prefix hardcoded /usr/* and /lib paths with value of %(sysroot) template
+    # (which will be empty if EasyBuild is not configured to use an alternate sysroot);
+    # see also https://gitlab.com/eessi/support/-/issues/9
+    if ec.name == 'Pillow-SIMD':
+        ec.update('preinstallopts', """sed -i 's@"/usr/@"%(sysroot)s/usr/@g' setup.py && """)
+        ec.update('preinstallopts', """sed -i 's@"/lib@"%(sysroot)s/lib@g' setup.py && """)
+        print_msg("Using custom configure options for %s: %s", ec.name, ec['preinstallopts'])
+    else:
+        raise EasyBuildError("Pillow-SIMD-specific hook triggered for non-Pillow-SIMD easyconfig?!")
+
+
 def parse_hook_pybind11_replace_catch2(ec, eprefix):
     """
     Replace Catch2 build dependency in pybind11 easyconfigs with one that doesn't use system toolchain.
@@ -237,7 +249,6 @@ def parse_hook_qt5_check_qtwebengine_disable(ec, eprefix):
 
 
 def parse_hook_ucx_eprefix(ec, eprefix):
-    """Make UCX aware of compatibility layer via additional configuration options."""
     if ec.name == 'UCX':
         ec.update('configopts', '--with-sysroot=%s' % eprefix)
         ec.update('configopts', '--with-rdmacm=%s' % os.path.join(eprefix, 'usr'))
@@ -582,6 +593,7 @@ PARSE_HOOKS = {
     'CGAL': parse_hook_cgal_toolchainopts_precise,
     'fontconfig': parse_hook_fontconfig_add_fonts,
     'OpenBLAS': parse_hook_openblas_relax_lapack_tests_num_errors,
+    'Pillow-SIMD' : parse_hook_Pillow_SIMD_harcoded_paths,
     'pybind11': parse_hook_pybind11_replace_catch2,
     'Qt5': parse_hook_qt5_check_qtwebengine_disable,
     'UCX': parse_hook_ucx_eprefix,


### PR DESCRIPTION
Adding dask to software.eessi.io.
```
5 out of 86 required modules missing:

* tornado/6.3.2-GCCcore-12.3.0 (tornado-6.3.2-GCCcore-12.3.0.eb)
* libwebp/1.3.1-GCCcore-12.3.0 (libwebp-1.3.1-GCCcore-12.3.0.eb)
* Pillow-SIMD/9.5.0-GCCcore-12.3.0 (Pillow-SIMD-9.5.0-GCCcore-12.3.0.eb)
* bokeh/3.2.2-foss-2023a (bokeh-3.2.2-foss-2023a.eb)
* dask/2023.9.2-foss-2023a (dask-2023.9.2-foss-2023a.eb)

```