### PR TITLE
{2023.06}[gompi/2023a,gompi/2023b] OSU Microbenchmarks v 7.1.1, OSU Microbenchmarks v 7.2 w/ CUDA 12.1.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -34,3 +34,5 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19996
         from-pr: 19996
   - dask-2023.9.2-foss-2023a.eb
+  - OSU-Micro-Benchmarks-7.2-gompi-2023a-CUDA-12.1.1.eb
+  - OSU-Micro-Benchmarks-7.2-gompi-2023b.eb


### PR DESCRIPTION
```

5 out of 24 required modules missing:

* GDRCopy/2.3.1-GCCcore-12.3.0 (GDRCopy-2.3.1-GCCcore-12.3.0.eb)
* UCX-CUDA/1.14.1-GCCcore-12.3.0-CUDA-12.1.1 (UCX-CUDA-1.14.1-GCCcore-12.3.0-CUDA-12.1.1.eb)
* NCCL/2.18.3-GCCcore-12.3.0-CUDA-12.1.1 (NCCL-2.18.3-GCCcore-12.3.0-CUDA-12.1.1.eb)
* UCC-CUDA/1.2.0-GCCcore-12.3.0-CUDA-12.1.1 (UCC-CUDA-1.2.0-GCCcore-12.3.0-CUDA-12.1.1.eb)
* OSU-Micro-Benchmarks/7.2-gompi-2023a-CUDA-12.1.1 (OSU-Micro-Benchmarks-7.2-gompi-2023a-CUDA-12.1.1.eb)
```