### PR TITLE
Workaround for LMOD only allowing a single hook to be registered, which made our first hook unused

### DIFF
--- a/create_lmodrc.py
+++ b/create_lmodrc.py
@@ -29,7 +29,7 @@ local function read_file(path)
     return content
 end
 
-local function cuda_enabled_load_hook(t)
+local function eessi_cuda_enabled_load_hook(t)
     local frameStk  = require("FrameStk"):singleton()
     local mt        = frameStk:mt()
     local simpleName = string.match(t.modFullName, "(.-)/")
@@ -94,7 +94,7 @@ local function cuda_enabled_load_hook(t)
     end
 end
 
-local function openmpi_load_hook(t)
+local function eessi_openmpi_load_hook(t)
     -- disable smcuda BTL when loading OpenMPI module for aarch64/neoverse_v1,
     -- to work around hang/crash due to bug in OpenMPI;
     -- see https://gitlab.com/eessi/support/-/issues/41
@@ -114,8 +114,8 @@ local function openmpi_load_hook(t)
     end
 end
 
-hook.register("load", cuda_enabled_load_hook)
-hook.register("load", openmpi_load_hook)
+hook.register("load", eessi_cuda_enabled_load_hook)
+hook.register("load", eessi_openmpi_load_hook)
 """
 
 def error(msg):

--- a/create_lmodrc.py
+++ b/create_lmodrc.py
@@ -114,8 +114,15 @@ local function eessi_openmpi_load_hook(t)
     end
 end
 
-hook.register("load", eessi_cuda_enabled_load_hook)
-hook.register("load", eessi_openmpi_load_hook)
+-- Combine both functions into a single one, as we can only register one function as load hook in lmod
+-- Also: make it non-local, so it can be imported and extended by other lmodrc files if needed
+function eessi_load_hook(t)
+    eessi_cuda_enabled_load_hook(t)
+    eessi_openmpi_load_hook(t)
+end
+
+
+hook.register("load", eessi_load_hook)
 """
 
 def error(msg):

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -85,6 +85,7 @@ if [ -d $EESSI_PREFIX ]; then
           # Allow for site-specific lmod configuration
           host_lmod_rc="${EESSI_PREFIX/versions/host_injections}"/.lmod/lmodrc.lua
           if [ -f $host_lmod_rc ]; then
+              show_msg "Found site Lmod configuration file at $LMOD_RC"
               export LMOD_RC="$host_lmod_rc"
           fi
 

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -82,6 +82,11 @@ if [ -d $EESSI_PREFIX ]; then
           else
             error "Lmod configuration file not found at $LMOD_RC"
           fi
+          # Allow for site-specific lmod configuration
+          host_lmod_rc="$EESSI_CVMFS_REPO"/host_injections/.lmod/lmodrc.lua
+          if [ -f $host_lmod_rc ]; then
+              export LMOD_RC="$host_lmod_rc"
+          fi
 
         else
           error "EESSI software layer at $EESSI_SOFTWARE_PATH not found!"

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -83,7 +83,7 @@ if [ -d $EESSI_PREFIX ]; then
             error "Lmod configuration file not found at $LMOD_RC"
           fi
           # Allow for site-specific lmod configuration
-          host_lmod_rc="${EESSI_PREFIX/versions/host_injections}/.lmod/lmodrc.lua
+          host_lmod_rc="${EESSI_PREFIX/versions/host_injections}"/.lmod/lmodrc.lua
           if [ -f $host_lmod_rc ]; then
               export LMOD_RC="$host_lmod_rc"
           fi

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -83,7 +83,7 @@ if [ -d $EESSI_PREFIX ]; then
             error "Lmod configuration file not found at $LMOD_RC"
           fi
           # Allow for site-specific lmod configuration
-          host_lmod_rc="$EESSI_CVMFS_REPO"/host_injections/.lmod/lmodrc.lua
+          host_lmod_rc="${EESSI_PREFIX/versions/host_injections}/.lmod/lmodrc.lua
           if [ -f $host_lmod_rc ]; then
               export LMOD_RC="$host_lmod_rc"
           fi

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -76,8 +76,8 @@ if [ -d $EESSI_PREFIX ]; then
             false
           fi
 
-          export LMOD_RC="$EESSI_SOFTWARE_PATH/.lmod/lmodrc.lua"
-          if [ -f $LMOD_RC ]; then
+          export LMOD_CONFIG_DIR="$EESSI_SOFTWARE_PATH/.lmod"
+          if [ -f $LMOD_CONFIG_DIR/lmodrc.lua ]; then
             show_msg "Found Lmod configuration file at $LMOD_RC"
           else
             error "Lmod configuration file not found at $LMOD_RC"

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -78,9 +78,9 @@ if [ -d $EESSI_PREFIX ]; then
 
           export LMOD_CONFIG_DIR="$EESSI_SOFTWARE_PATH/.lmod"
           if [ -f $LMOD_CONFIG_DIR/lmodrc.lua ]; then
-            show_msg "Found Lmod configuration file at $LMOD_RC"
+            show_msg "Found Lmod configuration file at $LMOD_CONFIG_DIR/lmodrc.lua"
           else
-            error "Lmod configuration file not found at $LMOD_RC"
+            error "Lmod configuration file not found at $LMOD_CONFIG_DIR/lmodrc.lua"
           fi
           # Allow for site-specific lmod configuration
           host_lmod_rc="${EESSI_PREFIX/versions/host_injections}"/.lmod/lmodrc.lua

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -76,17 +76,11 @@ if [ -d $EESSI_PREFIX ]; then
             false
           fi
 
-          export LMOD_CONFIG_DIR="$EESSI_SOFTWARE_PATH/.lmod"
-          if [ -f $LMOD_CONFIG_DIR/lmodrc.lua ]; then
-            show_msg "Found Lmod configuration file at $LMOD_CONFIG_DIR/lmodrc.lua"
+          export LMOD_RC="$EESSI_SOFTWARE_PATH/.lmod/lmodrc.lua"
+          if [ -f $LMOD_RC ]; then
+            show_msg "Found Lmod configuration file at $LMOD_RC"
           else
-            error "Lmod configuration file not found at $LMOD_CONFIG_DIR/lmodrc.lua"
-          fi
-          # Allow for site-specific lmod configuration
-          host_lmod_rc="${EESSI_PREFIX/versions/host_injections}"/.lmod/lmodrc.lua
-          if [ -f $host_lmod_rc ]; then
-              show_msg "Found site Lmod configuration file at $LMOD_RC"
-              export LMOD_RC="$host_lmod_rc"
+            error "Lmod configuration file not found at $LMOD_RC"
           fi
 
         else


### PR DESCRIPTION
Use LMOD_CONFIG_DIR instead of LMOD_RC to allow user overrides of what we specify in our RC file, see search order on https://lmod.readthedocs.io/en/latest/145_properties.html?highlight=lmod_rc#the-properties-file-lmodrc-lua . Also, prefix our hooks with eessi_ to avoid unintentional clashes in namespace between site lmod configuration and eessi lmod configuration