### PR TITLE
{2023.06}[gompi/2023b] CDO v2.2.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -8,3 +8,6 @@ easyconfigs:
   - matplotlib-3.8.2-gfbf-2023b.eb:
       options:
         from-pr: 19552
+  - CDO-2.2.2-gompi-2023b.eb:
+      options:
+        from-pr: 19792   


### PR DESCRIPTION
Adding CDO to software.eessi.io

lic --> https://spdx.org/licenses/BSD-3-Clause.html

```
9 out of 63 required modules missing:

* UDUNITS/2.2.28-GCCcore-13.2.0 (UDUNITS-2.2.28-GCCcore-13.2.0.eb)
* googletest/1.14.0-GCCcore-13.2.0 (googletest-1.14.0-GCCcore-13.2.0.eb)
* JasPer/4.0.0-GCCcore-13.2.0 (JasPer-4.0.0-GCCcore-13.2.0.eb)
* libaec/1.0.6-GCCcore-13.2.0 (libaec-1.0.6-GCCcore-13.2.0.eb)
* nlohmann_json/3.11.3-GCCcore-13.2.0 (nlohmann_json-3.11.3-GCCcore-13.2.0.eb)
* pkgconfig/1.5.5-GCCcore-13.2.0-python (pkgconfig-1.5.5-GCCcore-13.2.0-python.eb)
* PROJ/9.3.1-GCCcore-13.2.0 (PROJ-9.3.1-GCCcore-13.2.0.eb)
* ecCodes/2.31.0-gompi-2023b (ecCodes-2.31.0-gompi-2023b.eb)
* CDO/2.2.2-gompi-2023b (CDO-2.2.2-gompi-2023b.eb)
```