### PR TITLE
{2023.06}[2023a] JupyterNotebook v7.0.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -36,3 +36,4 @@ easyconfigs:
   - dask-2023.9.2-foss-2023a.eb
   - OSU-Micro-Benchmarks-7.2-gompi-2023a-CUDA-12.1.1.eb
   - OSU-Micro-Benchmarks-7.2-gompi-2023b.eb
+  - JupyterNotebook-7.0.2-GCCcore-12.3.0.eb


### PR DESCRIPTION
```
 5 out of 43 required modules missing:

* maturin/1.1.0-GCCcore-12.3.0 (maturin-1.1.0-GCCcore-12.3.0.eb)
* PyZMQ/25.1.1-GCCcore-12.3.0 (PyZMQ-25.1.1-GCCcore-12.3.0.eb)
* jupyter-server/2.7.2-GCCcore-12.3.0 (jupyter-server-2.7.2-GCCcore-12.3.0.eb)
* JupyterLab/4.0.5-GCCcore-12.3.0 (JupyterLab-4.0.5-GCCcore-12.3.0.eb)
* JupyterNotebook/7.0.2-GCCcore-12.3.0 (JupyterNotebook-7.0.2-GCCcore-12.3.0.eb)
```