### PR TITLE
replace Z3 dependency for `PyTorch-2.1.2-foss-2023a.eb`

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -249,6 +249,30 @@ def parse_hook_pybind11_replace_catch2(ec, eprefix):
             build_deps[idx] = (catch2_name, catch2_version)
 
 
+def parse_hook_pytorch_replace_z3(ec, eprefix):
+    """
+    Replace Z3 dependency in PyTorch/2.1.2 easyconfig to work around a change
+    of the Z3 eb/module name
+    cfr. https://github.com/easybuilders/easybuild-easyconfigs/pull/20050
+    """
+    # this is mainly necessary to avoid that --missing keeps reporting Z3/4.12.2
+    # is missing, because previously it was Z3/4.12.2-GCCcore-12.3.0-Python-3.11.3
+    if ec.name == 'PyTorch' and ec.version in ['2.1.2']:
+        deps = ec['dependencies']
+        z3_dep = None
+        z3_name, z3_version, z3_suffix = ('Z3', '4.12.2', '-Python-3.11.3')
+        print_msg("scanning dependencies of %s/%s for %s/%s",
+                  ec.name, ec.version, z3_name, z3_version)
+        for idx, dep in enumerate(deps):
+            if dep[0] == z3_name and dep[1] == z3_version:
+                z3_dep = dep
+                break
+        if z3_dep and len(z3_dep) == 2:
+            deps[idx] = (z3_name, z3_version, z3_suffix)
+            print_msg("replaced dependency %s/%s with %s/%s/%s for %s%s",
+                      z3_name, z3_version, z3_name, z3_version, z3_suffix, ec.name, ec.version)
+
+
 def parse_hook_qt5_check_qtwebengine_disable(ec, eprefix):
     """
     Disable check for QtWebEngine in Qt5 as workaround for problem with determining glibc version.
@@ -610,6 +634,7 @@ PARSE_HOOKS = {
     'fontconfig': parse_hook_fontconfig_add_fonts,
     'OpenBLAS': parse_hook_openblas_relax_lapack_tests_num_errors,
     'pybind11': parse_hook_pybind11_replace_catch2,
+    'PyTorch': parse_hook_pytorch_replace_z3,
     'Qt5': parse_hook_qt5_check_qtwebengine_disable,
     'UCX': parse_hook_ucx_eprefix,
     'LAMMPS': parse_hook_lammps_remove_deps_for_CI_aarch64,


### PR DESCRIPTION
A recent change to the easyconfig `PyTorch-2.1.2-foss-2023a.eb` (see https://github.com/easybuilders/easybuild-easyconfigs/pull/20050) lets the check for missing installations fail, for example, see
https://github.com/EESSI/software-layer/actions/runs/8268611041/job/22621916438?pr=500#step:4:2130

This PR adds a hook that attempts to replace the dependency for Z3 with the version that was used before (with suffix `-Python-3.11.3`).

CI should not fail anymore. However, running `eb` with `--missing` prints messages that the dependency has been replaced, but the renamed dependency is then not listed anymore. Running with `--dry-run` does show the renamed dependency. Not sure if this behaviour is expected or not.