### PR TITLE
{2023.06}[foss/2023a] Z3 4.12.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -40,3 +40,9 @@ easyconfigs:
   - ImageMagick-7.1.1-15-GCCcore-12.3.0.eb:
       options:
         from-pr: 20086
+  - Z3-4.12.2-GCCcore-12.3.0.eb:
+      options:
+        # The Z3 dependency of PyTorch had it's versionsuffix removed
+        # and we need to workaround the problem this creates,
+        # see https://github.com/EESSI/software-layer/pull/501 for details
+        from-pr: 20050


### PR DESCRIPTION
Via https://github.com/easybuilders/easybuild-easyconfigs/pull/20050 , the different Z3 easyconfigs have been consolidated. This means the version used as a dependency for PyTorch has been "corrected" so we need to dance around that for our CI purposes

```
 1 out of 14 required modules missing:

* Z3/4.12.2-GCCcore-12.3.0 (Z3-4.12.2-GCCcore-12.3.0.eb)
```