### PR TITLE
{2023.06}[2023a] PyOpenGL 3.1.7

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -46,3 +46,4 @@ easyconfigs:
         # and we need to workaround the problem this creates,
         # see https://github.com/EESSI/software-layer/pull/501 for details
         from-pr: 20050
+  - PyOpenGL-3.1.7-GCCcore-12.3.0.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -46,4 +46,6 @@ easyconfigs:
         # and we need to workaround the problem this creates,
         # see https://github.com/EESSI/software-layer/pull/501 for details
         from-pr: 20050
-  - PyOpenGL-3.1.7-GCCcore-12.3.0.eb
+  - PyOpenGL-3.1.7-GCCcore-12.3.0.eb:
+      options:
+        from-pr: 20007


### PR DESCRIPTION
```
1 out of 36 required modules missing:

* PyOpenGL/3.1.7-GCCcore-12.3.0 (PyOpenGL-3.1.7-GCCcore-12.3.0.eb)
```