### PR TITLE
{2023.06}[foss/2023a] QuantumESPRESSO 7.3

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -55,4 +55,4 @@ easyconfigs:
   - QuantumESPRESSO-7.3-foss-2023a.eb:
       options:
         from-pr: 20105
-        include-easyblocks-from-pr: 3241
+        include-easyblocks-from-pr: 3258

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -49,3 +49,7 @@ easyconfigs:
   - PyOpenGL-3.1.7-GCCcore-12.3.0.eb:
       options:
         from-pr: 20007
+  - QuantumESPRESSO-7.3-foss-2023a.eb:
+      options:
+        from-pr: 20105
+        include-easyblocks-from-pr: 3241


### PR DESCRIPTION
Added Quantum Espresso 7.3 using easyconfig from 

https://github.com/easybuilders/easybuild-easyconfigs/pull/20105 (updated to https://github.com/easybuilders/easybuild-easyconfigs/pull/20306 to allow a single test failure)

and easyblock from

https://github.com/easybuilders/easybuild-easyblocks/pull/3241 (updated to https://github.com/easybuilders/easybuild-easyblocks/pull/3258)