### PR TITLE
fix check_missing_installations.sh when unmerged PR is used

### DIFF
--- a/check_missing_installations.sh
+++ b/check_missing_installations.sh
@@ -47,7 +47,7 @@ exit_code=${PIPESTATUS[0]}
 
 ok_msg="Command 'eb --missing ...' succeeded, analysing output..."
 fail_msg="Command 'eb --missing ...' failed, check log '${eb_missing_out}'"
-if [ "$exit_code" -ne 0 ] && [ ! -z $pr_exceptions ]; then
+if [ "$exit_code" -ne 0 ] && [ ! -z "$pr_exceptions" ]; then
     # We might have failed due to unmerged PRs. Try to make exceptions for --from-pr added in this PR
     # to software-layer, and see if then it passes. If so, we can report a more specific fail_msg
     # Note that if no --from-pr's were used in this PR, $pr_exceptions will be empty and we might as


### PR DESCRIPTION
fix for:
```
/project/60006/SHARED/jobs/2024.03/pr_505/event_080c27a0-e305-11ee-87e8-653634545886/run_000/linux_aarch64_neoverse_v1/eessi.io-2023.06-software/check_missing_installations.sh: line 50: [: ||: binary operator expected
```

(encountered in https://github.com/EESSI/software-layer/pull/505)