### PR TITLE
Don't update Lmod cache in software installation script

### DIFF
--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -247,7 +247,7 @@ fi
 
 ### add packages here
 
-echo ">> Creating/updating Lmod cache..."
+echo ">> Creating/updating Lmod RC file..."
 export LMOD_CONFIG_DIR="${EASYBUILD_INSTALLPATH}/.lmod"
 lmod_rc_file="$LMOD_CONFIG_DIR/lmodrc.lua"
 lmodrc_changed=$(cat ${pr_diff} | grep '^+++' | cut -f2 -d' ' | sed 's@^[a-z]/@@g' | grep '^create_lmodrc.py$' > /dev/null; echo $?)

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -265,7 +265,5 @@ if [ ! -f "$lmod_sitepackage_file" ] || [ "${sitepackage_changed}" == '0' ]; the
     check_exit_code $? "$lmod_sitepackage_file created" "Failed to create $lmod_sitepackage_file"
 fi
 
-$TOPDIR/update_lmod_cache.sh ${EPREFIX} ${EASYBUILD_INSTALLPATH}
-
 echo ">> Cleaning up ${TMPDIR}..."
 rm -r ${TMPDIR}


### PR DESCRIPTION
This is now done on the Stratum 0 to ensure that the Lmod cache gets updated for every software that's being ingested (and to prevent it from being overwritten by an older version of the cache): 
https://github.com/EESSI/filesystem-layer/pull/175