### PR TITLE
{2023.06}[2023b] LittleCMS v2.15, giflib v5.2.1, OpenJPEG v2.5.0, libwebp v1.3.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -49,3 +49,6 @@ easyconfigs:
   - libspatialindex-1.9.3-GCCcore-13.2.0.eb:
       options:
         from-pr: 19922
+  - LittleCMS-2.15-GCCcore-13.2.0.eb
+  - giflib-5.2.1-GCCcore-13.2.0.eb
+  - OpenJPEG-2.5.0-GCCcore-13.2.0.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -52,3 +52,5 @@ easyconfigs:
   - LittleCMS-2.15-GCCcore-13.2.0.eb
   - giflib-5.2.1-GCCcore-13.2.0.eb
   - OpenJPEG-2.5.0-GCCcore-13.2.0.eb
+  - libwebp-1.3.2-GCCcore-13.2.0.eb
+


### PR DESCRIPTION
This should fix the check_missing CI.