### PR TITLE
{2023.06}[GCCcore/13.2.0] libwebp v1.3.2, OpenJPEG v2.5.0, LittleCMS v2.15

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -49,3 +49,6 @@ easyconfigs:
   - libspatialindex-1.9.3-GCCcore-13.2.0.eb:
       options:
         from-pr: 19922
+  - libwebp-1.3.2-GCCcore-13.2.0.eb
+  - OpenJPEG-2.5.0-GCCcore-13.2.0.eb
+  - LittleCMS-2.15-GCCcore-13.2.0.eb


### PR DESCRIPTION
[easybuild/easyconfigs/p/Pillow/Pillow-10.2.0-GCCcore-13.2.0.eb](https://github.com/easybuilders/easybuild-easyconfigs/pull/20195/files#diff-48aff6bfce4a1c759d6a93c70f37a97c0a299a4c71bc2f27729f6c09855226ea) has been updated with additional dependencies which are causing check_missing_installation failures

```
Missing packages :

* LittleCMS/2.15-GCCcore-13.2.0 (LittleCMS-2.15-GCCcore-13.2.0.eb) 
* libwebp/1.3.2-GCCcore-13.2.0 (libwebp-1.3.2-GCCcore-13.2.0.eb)
* giflib/5.2.1-GCCcore-13.2.0 (giflib-5.2.1-GCCcore-13.2.0.eb)
* OpenJPEG/2.5.0-GCCcore-13.2.0 (OpenJPEG-2.5.0-GCCcore-13.2.0.eb)
```