### PR TITLE
{2023.06}[GCCcore/13.2.0] Wayland v1.22.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -53,4 +53,5 @@ easyconfigs:
   - giflib-5.2.1-GCCcore-13.2.0.eb
   - OpenJPEG-2.5.0-GCCcore-13.2.0.eb
   - libwebp-1.3.2-GCCcore-13.2.0.eb
+  - Wayland-1.22.0-GCCcore-13.2.0.eb
 


### PR DESCRIPTION
Required for `check_missing_installations.sh` #462 