### PR TITLE
Rebuild GCCcore-12.3.0 and 13.2.0 to fix aarch64 vectorization issue

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20240328-eb-4.9.0-GCCcore-fix-aarch64-vectorization.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20240328-eb-4.9.0-GCCcore-fix-aarch64-vectorization.yml
@@ -1,0 +1,15 @@
+# 2024-03-28
+# Rebuild GCCcore to fix a compiler bug in the tree-vectorizer
+# We encountered it in https://github.com/EESSI/software-layer/pull/479#issuecomment-1957091774
+# and https://github.com/EESSI/software-layer/pull/507#issuecomment-2011724613
+# Upstream issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111478
+# Upstream fix: https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=e5f1956498251a4973d52c8aad3faf34d0443169
+# Fix in EasyBuild https://github.com/easybuilders/easybuild-easyconfigs/pull/19974
+# https://github.com/easybuilders/easybuild-easyconfigs/pull/20218
+easyconfigs:
+  - GCCcore-12.3.0.eb:
+      options:
+        from-pr: 20218
+  - GCCcore-13.2.0.eb:
+      options:
+        from-pr: 19974


### PR DESCRIPTION
[This PR](https://github.com/EESSI/software-layer/pull/507#issuecomment-2024132529) shows that rebuilding GCCcore indeed fixes the vectorization issue we've seen on ARM.

This issue was also encountered [here](https://github.com/EESSI/software-layer/pull/479#issuecomment-1957091774). Now that we've encountered it twice, we concluded it's a pattern, and there is sufficient reason for a rebuild.