### PR TITLE
Fix lmodrc

### DIFF
--- a/create_lmodrc.py
+++ b/create_lmodrc.py
@@ -7,6 +7,7 @@ import sys
 
 DOT_LMOD = '.lmod'
 
+# LMOD_RC file is the place to define properties, see https://lmod.readthedocs.io/en/latest/145_properties.html
 TEMPLATE_LMOD_RC = """propT = {
 }
 scDescriptT = {

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -51,14 +51,23 @@ if [ -d $EESSI_PREFIX ]; then
         show_msg "Using ${EESSI_SOFTWARE_SUBDIR} as software subdirectory."
         export EESSI_SOFTWARE_PATH=$EESSI_PREFIX/software/$EESSI_OS_TYPE/$EESSI_SOFTWARE_SUBDIR
 
-        # Configure our LMOD_RC file
-        export LMOD_RC="$EESSI_SOFTWARE_PATH/.lmod/lmodrc.lua"
-        if [ -f $LMOD_RC ]; then
-          show_msg "Found Lmod configuration file at $LMOD_RC"
+        # Configure our LMOD
+        export LMOD_CONFIG_DIR="$EESSI_SOFTWARE_PATH/.lmod"
+        lmod_rc_file="$LMOD_CONFIG_DIR/lmodrc.lua"
+        if [ -f $lmod_rc_file ]; then
+          show_msg "Found Lmod configuration file at $lmod_rc_file"
         else
-          error "Lmod configuration file not found at $LMOD_RC"
+          error "Lmod configuration file not found at $lmod_rc_file"
         fi
 
+        export LMOD_PACKAGE_PATH="$EESSI_SOFTWARE_PATH/.lmod"
+        lmod_sitepackage_file="$LMOD_PACKAGE_PATH/SitePackage.lua"
+        if [ -f $lmod_sitepackage_file ]; then
+          show_msg "Found Lmod SitePackage.lua file at $lmod_sitepackage_file"
+        else
+          error "Lmod SitePackage.lua file not found at $lmod_sitepackage_file"
+        fi
+       
         if [ ! -z $EESSI_BASIC_ENV ]; then
           show_msg "Only setting up basic environment, so we're done"
         elif [ -d $EESSI_SOFTWARE_PATH ]; then
@@ -85,21 +94,6 @@ if [ -d $EESSI_PREFIX ]; then
             false
           fi
 
-          export LMOD_CONFIG_DIR="$EESSI_SOFTWARE_PATH/.lmod"
-          lmod_rc_file="$LMOD_CONFIG_DIR/lmodrc.lua"
-          if [ -f $lmod_rc_file ]; then
-            show_msg "Found Lmod configuration file at $lmod_rc_file"
-          else
-            error "Lmod configuration file not found at $lmod_rc_file"
-          fi
-
-          export LMOD_PACKAGE_PATH="$EESSI_SOFTWARE_PATH/.lmod"
-          lmod_sitepackage_file="$LMOD_PACKAGE_PATH/SitePackage.lua"
-          if [ -f $lmod_sitepackage_file ]; then
-            show_msg "Found Lmod SitePackage.lua file at $lmod_sitepackage_file"
-          else
-            error "Lmod SitePackage.lua file not found at $lmod_sitepackage_file"
-          fi
 
         else
           error "EESSI software layer at $EESSI_SOFTWARE_PATH not found!"


### PR DESCRIPTION
The deployment of https://github.com/EESSI/software-layer/pull/496#issuecomment-2023039405 was forgotten. We thought it happened in https://github.com/EESSI/software-layer/pull/511#issuecomment-2020146748 , but that didn't include the `lmodrc.lua` file for some reason. Thus, we are now stuck with duplication: both the `lmodrc.lua` and `SitePackage.lua` now contain hook definitions...

```
[casparl@tcn1 ~]$ cat /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/.lmod/lmodrc.lua | grep hook
local hook = require("Hook")
local function eessi_cuda_enabled_load_hook(t)
local function eessi_openmpi_load_hook(t)
-- Combine both functions into a single one, as we can only register one function as load hook in lmod
function eessi_load_hook(t)
    eessi_cuda_enabled_load_hook(t)
    eessi_openmpi_load_hook(t)
hook.register("load", eessi_load_hook)
[casparl@tcn1 ~]$ cat /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/.lmod/SitePackage.lua | grep hook
local hook = require("Hook")
local function eessi_cuda_enabled_load_hook(t)
-- Combine both functions into a single one, as we can only register one function as load hook in lmod
function eessi_load_hook(t)
    eessi_cuda_enabled_load_hook(t)
hook.register("load", eessi_load_hook)
```

We need to make some small change in order to convince the installation script to reinstall the `lmodrc` file. I've done that by simply adding a comment - not essential, but it doesn't hurt either.

Also, we forgot to remove setting the `LMOD_RC` environment variable. This is no longer needed, as we now set `LMOD_CONFIG_DIR` so that we allow host sites to still have something that comes 'later' in the search order (see search order on https://lmod.readthedocs.io/en/latest/145_properties.html ). Also, Alan moved setting the `LMOD_RC` outside of the if-condition for minimal EESSI environment. We should do the same for the full LMOD configuration, i.e. both for setting `LMOD_CONFIG_DIR` and `LMOD_PACKAGE_PATH`. That is done here.