### PR TITLE
Allow defining lmod hooks in host injections

### DIFF
--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -77,7 +77,7 @@ local function load_sitespecific_hooks()
     local archSitePackage = archHostInjections .. "/.lmod/SitePackage.lua"
 
     -- If the file exists, run it
-    if isDir(archSitePackage)
+    if isDir(archSitePackage) then
         dofile(archSitePackage)
     end
     


### PR DESCRIPTION
Fixes https://github.com/EESSI/software-layer/issues/456

For proper testing, we want [this fix](https://github.com/EESSI/software-layer/pull/524) to be deployed first _or_ you need to make sure to unset `LMOD_RC` (after sourcing the EESSI environment). Otherwise, you'll find that no matter what local change you make, you are always executing the EESSI hook (and only the EESSI hook), since the `LMOD_RC` is still set :)

Because our _current_ lmod version doesn't support registering multiple hooks yet (only supported from version 8.7.36 onwards, see [here](https://github.com/TACC/Lmod/pull/696#issuecomment-1998765722)), the person implementing the site-specific hook needs to define a combined function that _also_ calls the EESSI hook (if he/she wants to _append_ to the EESSI hook's functionality, of course you can always simply overwrite it).

The easiest way to test this PR is to do the following:
```
python3 create_lmodsitepackage.py .
export LMOD_PACKAGE_PATH=$PWD/.lmod
```
This generates the `SitePackage.py` in your current dir, in a `.lmod` subdir, then point the `LMOD_PACKAGE_PATH` to it. You can check that it gets picked up correctly by running `module --config` and looking for the `Site Pkg location` field. If you want, you can add some `LmodMessage("somemessage")` messages to this `SitePackage.py` to see when certain parts of it are executed.

Then, put two dummy hooks in place in the `host_injections` prefix, e.g.:

```
$ cat /cvmfs/software.eessi.io/host_injections/2023.06/.lmod/SitePackage.lua
require("strict")
local hook = require("Hook")

LmodMessage("Load host SitePackage.lua")

function site_specific_load_hook(t)
    local frameStk  = require("FrameStk"):singleton()
    local mt        = frameStk:mt()
    local simpleName = string.match(t.modFullName, "(.-)/")
    LmodMessage("Site-specific load hook called, loading " .. simpleName)
end

local function combined_load_hook(t)
    LmodMessage("Defining combined load hook")
    -- Assuming this SitePackage.lua was called from EESSI's SitePackage.lua
    -- the eessi_load_hook function is defined, and should be called
    if eessi_load_hook ~= nil then
        eessi_load_hook(t)
    end
    site_specific_load_hook(t)
end

hook.register("load", combined_load_hook)
$ cat /cvmfs/software.eessi.io/host_injections/2023.06/software/linux/x86_64/amd/zen2/.lmod/SitePackage.lua
require("strict")
local hook = require("Hook")

LmodMessage("Load architecture-specific SitePackage.lua")

local function architecture_specific_load_hook(t)
    local frameStk  = require("FrameStk"):singleton()
    local mt        = frameStk:mt()
    local simpleName = string.match(t.modFullName, "(.-)/")
    LmodMessage("Architecture-specific load hook called, loading " .. simpleName)
end

local function combined_load_hook(t)
    LmodMessage("Defining combined load hook in arch-specific SitePackage.lua")
    -- Assuming this SitePackage.lua was called from EESSI's SitePackage.lua
    -- the eessi_load_hook function is defined, and should be called
    if eessi_load_hook ~= nil then
        eessi_load_hook(t)
    end
    if site_specific_load_hook ~= nil then
        site_specific_load_hook(t)
    end
    architecture_specific_load_hook(t)
end

hook.register("load", combined_load_hook)
```

Now, to test it:
```
$ module load GCCcore/12.3.0
Loading EESSI's SitePackage.lua
Load host SitePackage.lua
Load architecture-specific SitePackage.lua
Defining combined load hook in arch-specific SitePackage.lua
EESSI load hook called, loading GCCcore
Site-specific load hook called, loading GCCcore
Architecture-specific load hook called, loading GCCcore
```
(as you can see, I added some print statements to check the order in which they are executed, and to see if all are executed). IMPORTANT: all the functions that have to be used in other translation units (e.g. the `eessi_load_hook` and `site_specific_load_hook`) need to be defined _without_ a `local` keyword (for obvious reasons :)).

Similarly, if a site wants their host or architecture specific hook to just _overwrite_ the EESSI hook, they could do:

```
$ cat /cvmfs/software.eessi.io/host_injections/2023.06/.lmod/SitePackage.lua
require("strict")
local hook = require("Hook")

LmodMessage("Load host SitePackage.lua")

local function site_specific_load_hook(t)
    local frameStk  = require("FrameStk"):singleton()
    local mt        = frameStk:mt()
    local simpleName = string.match(t.modFullName, "(.-)/")
    LmodMessage("Site-specific load hook called, loading " .. simpleName)
end

hook.register("load", site_specific_load_hook)
```

Note that once we have Lmod version 8.7.36 or later, things become much simpler if you want to append:

```
$ cat /cvmfs/software.eessi.io/host_injections/2023.06/.lmod/SitePackage.lua
require("strict")
local hook = require("Hook")

LmodMessage("Load host SitePackage.lua")

local function site_specific_load_hook(t)
    local frameStk  = require("FrameStk"):singleton()
    local mt        = frameStk:mt()
    local simpleName = string.match(t.modFullName, "(.-)/")
    LmodMessage("Site-specific load hook called, loading " .. simpleName)
end

hook.register("load", site_specific_load_hook, "append")
```

The big advantage here is that the person implementing the site specific hook does not need to know the _name_ of the EESSI hook in order to append to it.