### PR TITLE
{2023.06}[2022b] R-bundle-Bioconductor v3.16

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
@@ -11,4 +11,3 @@ easyconfigs:
   - R-4.2.2-foss-2022b.eb:
       options:
         from-pr: 20238
-  - R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2022b.yml
@@ -11,3 +11,4 @@ easyconfigs:
   - R-4.2.2-foss-2022b.eb:
       options:
         from-pr: 20238
+  - R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -1,0 +1,5 @@
+easyconfigs:
+  - R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb:
+      options:
+        from-pr: 20379
+

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -2,4 +2,3 @@ easyconfigs:
   - R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb:
       options:
         from-pr: 20379
-


### PR DESCRIPTION
```
9 out of 172 required modules missing:

* intltool/0.51.0-GCCcore-12.2.0 (intltool-0.51.0-GCCcore-12.2.0.eb)
* RapidJSON/1.1.0-GCCcore-12.2.0 (RapidJSON-1.1.0-GCCcore-12.2.0.eb)
* gperf/3.1-GCCcore-12.2.0 (gperf-3.1-GCCcore-12.2.0.eb)
* RE2/2023-03-01-GCCcore-12.2.0 (RE2-2023-03-01-GCCcore-12.2.0.eb)
* utf8proc/2.8.0-GCCcore-12.2.0 (utf8proc-2.8.0-GCCcore-12.2.0.eb)
* Arrow/11.0.0-gfbf-2022b (Arrow-11.0.0-gfbf-2022b.eb)
* DBus/1.15.2-GCCcore-12.2.0 (DBus-1.15.2-GCCcore-12.2.0.eb)
* arrow-R/11.0.0.3-foss-2022b-R-4.2.2 (arrow-R-11.0.0.3-foss-2022b-R-4.2.2.eb)
* R-bundle-Bioconductor/3.16-foss-2022b-R-4.2.2 (R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb)
```