### PR TITLE
Add possibility to ignore certain hooks on local modules

### DIFF
--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -20,14 +20,24 @@ local function read_file(path)
 end
 
 local function from_eessi_prefix(t)
+    -- eessi_prefix is the prefix with official EESSI modules
+    -- e.g. /cvmfs/software.eessi.io/versions/2023.06
     local eessi_prefix = os.getenv("EESSI_PREFIX")
+    -- eessi_prefix_host_injections is the prefix with site-extensions (i.e. additional modules)
+    -- to the official EESSI modules, e.g. /cvmfs/software.eessi.io/host_injections/2023.06
+    local eessi_prefix_host_injections = string.gsub(eessi_prefix, 'versions', 'host_injections')
+    -- eessi_prefix_user_home is the prefix with user-extensions (i.e. additional modules)
+    -- to the offocial EESSI modules, e.g. $HOME/eessi/versions/2023.06
+    local eessi_prefix_user_home = string.gsub(eessi_prefix, os.getenv("EESSI_CVMFS_REPO"), pathJoin(os.getenv("HOME"), "eessi"))
     -- If EESSI_PREFIX wasn't defined, we cannot check if this module was from the EESSI environment
     -- In that case, we assume it isn't, otherwise EESSI_PREFIX would (probably) have been set
     if eessi_prefix == nil then
         return False
     else
-        -- Check if the full modulepath starts with the eessi_prefix
-        return t.fn:find( "^" .. eessi_prefix) ~= nil
+        -- Check if the full modulepath starts with the eessi_prefix_*
+        return string.find(t.fn, "^" .. eessi_prefix) ~= nil or
+        string.find(t.fn, "^" .. eessi_prefix_host_injections) ~= nil or
+        string.find(t.fn, "^" .. eessi_prefix_user_home) ~= nil
     end
 end
 

--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -23,6 +23,10 @@ local function from_eessi_prefix(t)
     -- eessi_prefix is the prefix with official EESSI modules
     -- e.g. /cvmfs/software.eessi.io/versions/2023.06
     local eessi_prefix = os.getenv("EESSI_PREFIX")
+
+    -- NOTE: exact paths for site and user extensions aren't final, so may need to be updated later.
+    -- See https://github.com/EESSI/software-layer/pull/371
+
     -- eessi_prefix_host_injections is the prefix with site-extensions (i.e. additional modules)
     -- to the official EESSI modules, e.g. /cvmfs/software.eessi.io/host_injections/2023.06
     local eessi_prefix_host_injections = string.gsub(eessi_prefix, 'versions', 'host_injections')

--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -24,24 +24,20 @@ local function from_eessi_prefix(t)
     -- e.g. /cvmfs/software.eessi.io/versions/2023.06
     local eessi_prefix = os.getenv("EESSI_PREFIX")
 
-    -- NOTE: exact paths for site and user extensions aren't final, so may need to be updated later.
-    -- See https://github.com/EESSI/software-layer/pull/371
-
-    -- eessi_prefix_host_injections is the prefix with site-extensions (i.e. additional modules)
-    -- to the official EESSI modules, e.g. /cvmfs/software.eessi.io/host_injections/2023.06
-    local eessi_prefix_host_injections = string.gsub(eessi_prefix, 'versions', 'host_injections')
-    -- eessi_prefix_user_home is the prefix with user-extensions (i.e. additional modules)
-    -- to the offocial EESSI modules, e.g. $HOME/eessi/versions/2023.06
-    local eessi_prefix_user_home = string.gsub(eessi_prefix, os.getenv("EESSI_CVMFS_REPO"), pathJoin(os.getenv("HOME"), "eessi"))
     -- If EESSI_PREFIX wasn't defined, we cannot check if this module was from the EESSI environment
     -- In that case, we assume it isn't, otherwise EESSI_PREFIX would (probably) have been set
     if eessi_prefix == nil then
         return False
     else
-        -- Check if the full modulepath starts with the eessi_prefix_*
-        return string.find(t.fn, "^" .. eessi_prefix) ~= nil or
-        string.find(t.fn, "^" .. eessi_prefix_host_injections) ~= nil or
-        string.find(t.fn, "^" .. eessi_prefix_user_home) ~= nil
+        -- NOTE: exact paths for site so may need to be updated later.
+        -- See https://github.com/EESSI/software-layer/pull/371
+
+        -- eessi_prefix_host_injections is the prefix with site-extensions (i.e. additional modules)
+        -- to the official EESSI modules, e.g. /cvmfs/software.eessi.io/host_injections/2023.06
+        local eessi_prefix_host_injections = string.gsub(eessi_prefix, 'versions', 'host_injections')
+        
+       -- Check if the full modulepath starts with the eessi_prefix_*
+        return string.find(t.fn, "^" .. eessi_prefix) ~= nil or string.find(t.fn, "^" .. eessi_prefix_host_injections) ~= nil
     end
 end
 


### PR DESCRIPTION
We don't want to be prevented from loading local CUDA modules because of the EESSI hook. See https://github.com/EESSI/software-layer/issues/523

This PR makes sense that the CUDA hooks are only applied if the module being loaded comes from the EESSI prefix.

I.e. before this change:

```
# Module from local software stack:
{EESSI 2023.06} [casparl@gcn6 software-layer]$ module load CUDA/11.7.0
Lmod has detected the following error:
You requested to load CUDA  but while the module file exists, the actual software is not entirely shipped with EESSI due to licencing.
You will need to install a full copy of the CUDA SDK where EESSI can find it.
For more information on how to do this, see https://www.eessi.io/docs/gpu/.

While processing the following module(s):
    Module fullname  Module Filename
    ---------------  ---------------
    CUDA/11.7.0      /sw/arch/RHEL8/EB_production/2022/modulefiles/system/CUDA/11.7.0.lua
```

After this change:
```
{EESSI 2023.06} [casparl@gcn6 software-layer]$ module load CUDA/11.7.0
{EESSI 2023.06} [casparl@gcn6 software-layer]$ 
```

Fixes https://github.com/EESSI/software-layer/issues/523