### PR TITLE
Fix Highway hook: change optarch in `pre_prepare_hook` and reset it in `post_prepare_hook`

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -323,6 +323,8 @@ def post_prepare_hook_highway_handle_test_compilation_issues(self, *args, **kwar
     if self.name == 'Highway':
         tcname, tcversion = self.toolchain.name, self.toolchain.version
         cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
+        # note: keep condition in sync with the one used in 
+        # pre_prepare_hook_highway_handle_test_compilation_issues
         if self.version in ['1.0.4'] and tcname == 'GCCcore' and tcversion == '12.3.0':
             if cpu_target == CPU_TARGET_NEOVERSE_N1:
                 update_build_option('optarch', self.orig_optarch)

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -116,6 +116,9 @@ def pre_prepare_hook(self, *args, **kwargs):
         print_msg("Updated rpath_override_dirs (to allow overriding MPI family %s): %s",
                   mpi_family, rpath_override_dirs)
 
+    if self.name in PRE_PREPARE_HOOKS:
+        PRE_PREPARE_HOOKS[self.name](self, *args, **kwargs)
+
 
 def post_prepare_hook_gcc_prefixed_ld_rpath_wrapper(self, *args, **kwargs):
     """
@@ -290,7 +293,7 @@ def parse_hook_lammps_remove_deps_for_CI_aarch64(ec, *args, **kwargs):
         raise EasyBuildError("LAMMPS-specific hook triggered for non-LAMMPS easyconfig?!")
 
 
-def parse_hook_highway_handle_test_compilation_issues(ec, eprefix):
+def pre_prepare_hook_highway_handle_test_compilation_issues(self, *args, **kwargs):
     """
     Solve issues with compiling or running the tests on both
     neoverse_n1 and neoverse_v1 with Highway 1.0.4 and GCC 12.3.0:
@@ -298,17 +301,29 @@ def parse_hook_highway_handle_test_compilation_issues(ec, eprefix):
       - for neoverse_v1 we completely disable the tests
     cfr. https://github.com/EESSI/software-layer/issues/469
     """
-    if ec.name == 'Highway':
-        tcname, tcversion = ec['toolchain']['name'], ec['toolchain']['version']
+    if self.name == 'Highway':
+        tcname, tcversion = self.toolchain.name, self.toolchain.version
         cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
-        if ec.version in ['1.0.4'] and tcname == 'GCCcore' and tcversion == '12.3.0':
+        if self.version in ['1.0.4'] and tcname == 'GCCcore' and tcversion == '12.3.0':
             if cpu_target == CPU_TARGET_NEOVERSE_V1:
-                ec.update('configopts', '-DHWY_ENABLE_TESTS=OFF')
+                self.cfg.update('configopts', '-DHWY_ENABLE_TESTS=OFF')
             if cpu_target == CPU_TARGET_NEOVERSE_N1:
+                self.orig_optarch = build_option('optarch')
                 update_build_option('optarch', OPTARCH_GENERIC)
     else:
         raise EasyBuildError("Highway-specific hook triggered for non-Highway easyconfig?!")
 
+
+def post_prepare_hook_highway_handle_test_compilation_issues(self, *args, **kwargs):
+    """
+    Post-prepare hook for Highway to reset optarch build option.
+    """
+    if self.name == 'Highway':
+        tcname, tcversion = self.toolchain.name, self.toolchain.version
+        cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
+        if self.version in ['1.0.4'] and tcname == 'GCCcore' and tcversion == '12.3.0':
+            if cpu_target == CPU_TARGET_NEOVERSE_N1:
+                update_build_option('optarch', self.orig_optarch)
 
 def pre_configure_hook(self, *args, **kwargs):
     """Main pre-configure hook: trigger custom functions based on software name."""
@@ -629,7 +644,6 @@ PARSE_HOOKS = {
     'casacore': parse_hook_casacore_disable_vectorize,
     'CGAL': parse_hook_cgal_toolchainopts_precise,
     'fontconfig': parse_hook_fontconfig_add_fonts,
-    'Highway': parse_hook_highway_handle_test_compilation_issues,
     'LAMMPS': parse_hook_lammps_remove_deps_for_CI_aarch64,
     'OpenBLAS': parse_hook_openblas_relax_lapack_tests_num_errors,
     'pybind11': parse_hook_pybind11_replace_catch2,
@@ -637,8 +651,13 @@ PARSE_HOOKS = {
     'UCX': parse_hook_ucx_eprefix,
 }
 
+PRE_PREPARE_HOOKS = {
+    'Highway': pre_prepare_hook_highway_handle_test_compilation_issues,
+}
+
 POST_PREPARE_HOOKS = {
     'GCCcore': post_prepare_hook_gcc_prefixed_ld_rpath_wrapper,
+    'Highway': post_prepare_hook_highway_handle_test_compilation_issues,
 }
 
 PRE_CONFIGURE_HOOKS = {

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -304,6 +304,8 @@ def pre_prepare_hook_highway_handle_test_compilation_issues(self, *args, **kwarg
     if self.name == 'Highway':
         tcname, tcversion = self.toolchain.name, self.toolchain.version
         cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
+        # note: keep condition in sync with the one used in 
+        # post_prepare_hook_highway_handle_test_compilation_issues
         if self.version in ['1.0.4'] and tcname == 'GCCcore' and tcversion == '12.3.0':
             if cpu_target == CPU_TARGET_NEOVERSE_V1:
                 self.cfg.update('configopts', '-DHWY_ENABLE_TESTS=OFF')


### PR DESCRIPTION
Since the hook is changing a general build option (for setting `optarch=GENERIC`), it has to be reset afterwards. See https://github.com/EESSI/software-layer/pull/529#pullrequestreview-1976123494.

Tested it interactively for Haswell, Neoverse N1+V1. We could also let the bot do it, but then we'll need to add a rebuild easystack file.