### PR TITLE
[2023.06]{2023a} R-bundle-Bioconductor v3.18

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -71,3 +71,6 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20238
         from-pr: 20238
+  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
+      options:
+        from-pr: 20379

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -67,4 +67,6 @@ easyconfigs:
   - MODFLOW-6.4.4-foss-2023a.eb:
       options:
         from-pr: 20142
-  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb
+  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
+      options:
+        from-pr: 19949

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -71,6 +71,3 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20238
         from-pr: 20238
-  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
-      options:
-        from-pr: 20316

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -73,4 +73,4 @@ easyconfigs:
         from-pr: 20238
   - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
       options:
-        from-pr: 19949
+        from-pr: 20316

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -57,3 +57,4 @@ easyconfigs:
   - Highway-1.0.4-GCCcore-12.3.0.eb
   - ELPA-2023.05.001-foss-2023a.eb
   - libxc-6.2.2-GCC-12.3.0.eb
+  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -71,6 +71,3 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20238
         from-pr: 20238
-  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
-      options:
-        from-pr: 20379

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -1,2 +1,5 @@
 easyconfigs:
   - ncdu-1.18-GCC-12.3.0.eb
+  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
+      options:
+        from-pr: 20379

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -1,5 +1,2 @@
 easyconfigs:
   - ncdu-1.18-GCC-12.3.0.eb
-  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
-      options:
-        from-pr: 20379

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -1,3 +1,6 @@
 easyconfigs:
   - ncdu-1.18-GCC-12.3.0.eb
   - SAMtools-1.18-GCC-12.3.0.eb
+  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
+      options:
+        from-pr: 20379


### PR DESCRIPTION
```
5 out of 156 required modules missing:

* RapidJSON/1.1.0-20230928-GCCcore-12.3.0 (RapidJSON-1.1.0-20230928-GCCcore-12.3.0.eb)
* utf8proc/2.8.0-GCCcore-12.3.0 (utf8proc-2.8.0-GCCcore-12.3.0.eb)
* Arrow/14.0.1-gfbf-2023a (Arrow-14.0.1-gfbf-2023a.eb)
* arrow-R/14.0.1-foss-2023a-R-4.3.2 (arrow-R-14.0.1-foss-2023a-R-4.3.2.eb)
* R-bundle-Bioconductor/3.18-foss-2023a-R-4.3.2 (R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb)
```