### PR TITLE
{2023.06}[GCCcore/13.2.0] Qt6 v6.6.3

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -57,3 +57,6 @@ easyconfigs:
   - Qt5-5.15.13-GCCcore-13.2.0.eb:
       options:
         from-pr: 20201
+  - Qt6-6.6.3-GCCcore-13.2.0.eb:
+      options:
+        from-pr: 20257  


### PR DESCRIPTION
Attempt for building Qt6 v6.6.3 GCCcore-13.2.0
```
10 out of 82 required modules missing:

* assimp/5.3.1-GCCcore-13.2.0 (assimp-5.3.1-GCCcore-13.2.0.eb)
* ffnvcodec/12.1.14.0 (ffnvcodec-12.1.14.0.eb)
* x264/20231019-GCCcore-13.2.0 (x264-20231019-GCCcore-13.2.0.eb)
* LAME/3.100-GCCcore-13.2.0 (LAME-3.100-GCCcore-13.2.0.eb)
* FriBidi/1.0.13-GCCcore-13.2.0 (FriBidi-1.0.13-GCCcore-13.2.0.eb)
* Yasm/1.3.0-GCCcore-13.2.0 (Yasm-1.3.0-GCCcore-13.2.0.eb)
* x265/3.5-GCCcore-13.2.0 (x265-3.5-GCCcore-13.2.0.eb)
* SDL2/2.28.5-GCCcore-13.2.0 (SDL2-2.28.5-GCCcore-13.2.0.eb)
* FFmpeg/6.0-GCCcore-13.2.0 (FFmpeg-6.0-GCCcore-13.2.0.eb)
* Qt6/6.6.3-GCCcore-13.2.0 (Qt6-6.6.3-GCCcore-13.2.0.eb)

```