### PR TITLE
{2023.06}[foss/2023a] QuantumESPRESSO 7.3.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -71,3 +71,9 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20238
         from-pr: 20238
+  - QuantumESPRESSO-7.3.1-foss-2023a.eb:
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20138
+      # see https://github.com/easybuilders/easybuild-easyblocks/pull/3257
+      options:
+        from-pr: 20138
+        include-easyblocks-from-pr: 3257


### PR DESCRIPTION
Replaces #504 (but note that that PR uses the older configuremake easyblock which currently has more extensive test support in QE)