### PR TITLE
Add fix for permissions set on Lmod SitePackage

### DIFF
--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -181,7 +181,7 @@ try:
     os.makedirs(os.path.dirname(sitepackage_path), exist_ok=True)
     with open(sitepackage_path, 'w') as fp:
         fp.write(hook_txt)
-    # Make sure that the created Lmod file has "read" permissions for the "other" UNIX group
+    # Make sure that the created Lmod file has "read/write" for the user/group and "read" permissions for others
     os.chmod(sitepackage_path, S_IREAD|S_IWRITE|S_IRGRP|S_IWGRP|S_IROTH)
 
 except (IOError, OSError) as err:

--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -4,6 +4,7 @@
 #
 import os
 import sys
+from stat import S_IREAD, S_IWRITE, S_IRGRP, S_IWGRP, S_IROTH
 
 DOT_LMOD = '.lmod'
 
@@ -180,6 +181,8 @@ try:
     os.makedirs(os.path.dirname(sitepackage_path), exist_ok=True)
     with open(sitepackage_path, 'w') as fp:
         fp.write(hook_txt)
+    # Make sure that the created Lmod file has "read" permissions for the "other" UNIX group
+    os.chmod(sitepackage_path, S_IREAD|S_IWRITE|S_IRGRP|S_IWGRP|S_IROTH)
 
 except (IOError, OSError) as err:
     error("Failed to create %s: %s" % (sitepackage_path, err))


### PR DESCRIPTION
The current implementation of the `create_lmodsitepackage.py` script misses setting up the `read` permissions for the `other` UNIX group on the generated `SitePackage.lua` script:
```shell
$ ls -l /cvmfs/software.eessi.io/host_injections/2023.06/.lmod/SitePackage.lua
-rw-r----- 1 jenkins jenkins 2054 Apr  3 17:42 /cvmfs/software.eessi.io/host_injections/2023.06/.lmod/SitePackage.lua
```
As a result, users may experience errors like:
```shell
/cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/usr/bin/lua5.1: cannot open /cvmfs/software.eessi.io/host_injections/2023.06/.lmod/SitePackage.lua: Permission denied
```
This PR fixes an issue by setting `664` permissions after the file is created.