### PR TITLE
make sure that software directory that corresponds to `$EESSI_SOFTWARE_SUBDIR_OVERRIDE` exists

### DIFF
--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -143,6 +143,8 @@ if [ -z $EESSI_SOFTWARE_SUBDIR_OVERRIDE ]; then
   echo ">> Determined \$EESSI_SOFTWARE_SUBDIR_OVERRIDE via 'eessi_software_subdir.py $DETECTION_PARAMETERS' script"
 else
   echo ">> Picking up pre-defined \$EESSI_SOFTWARE_SUBDIR_OVERRIDE: ${EESSI_SOFTWARE_SUBDIR_OVERRIDE}"
+  # make sure directory exists (since it's expected by init/eessi_environment_variables when using archdetect)
+  mkdir -p ${EESSI_PREFIX}/software/${EESSI_OS_TYPE}/${EESSI_SOFTWARE_SUBDIR_OVERRIDE}
 fi
 
 # Set all the EESSI environment variables (respecting $EESSI_SOFTWARE_SUBDIR_OVERRIDE)


### PR DESCRIPTION
Fix for a small but annoying issue that I bumped into when testing builds for the new `amd/zen4` CPU target.

`/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4` must exist before `init/eessi_environment_variables` is sourced, because there's a check in there whether the subdirectory that `archdetect` produces (which is determined by `$EESSI_SOFTWARE_SUBDIR_OVERRIDE`) corresponds to an existing directory.

Without this, we hit:

```
>> Determining software subdirectory to use for current build host...
>> Picking up pre-defined $EESSI_SOFTWARE_SUBDIR_OVERRIDE: x86_64/amd/zen4
ERROR: no value set for $EESSI_SOFTWARE_SUBDIR
ERROR: Failed to determine software subdirectory?!
```