### PR TITLE
Rebuild `hatchling 1.18.0`, `Python 3.11.*`, `Python-bundle-PyPI-2023.*` to solve `setuptools_scm` issue

### DIFF
--- a/EESSI-remove-software.sh
+++ b/EESSI-remove-software.sh
@@ -116,8 +116,9 @@ if [ $EUID -eq 0 ]; then
                     rm -rf ${app_module}
                     # if the parent dir of this application is now empty, remove it too to work around a weird issue with the overlay
                     # see https://github.com/EESSI/software-layer/pull/546#issuecomment-2067018216
-                    if [ ! -n "$(dirname ${app_dir})" ]; then
-                        rmdir "$(dirname ${app_dir})"
+                    app_dir_parent=$(dirname "${app_dir}")
+                    if [ ! -n "$(ls -A ${app_dir_parent})" ]; then
+                        rmdir "${app_dir_parent}"
                     fi
                 done
             else

--- a/EESSI-remove-software.sh
+++ b/EESSI-remove-software.sh
@@ -113,8 +113,8 @@ if [ $EUID -eq 0 ]; then
                     app_module=${EASYBUILD_INSTALLPATH}/modules/all/${app}.lua
                     echo_yellow "Removing ${app_dir} and ${app_module}..."
                     #rm -rf ${app_dir}
-                    #rm -rf ${app_module}
-                    chmod -R u+w ${app_dir} ${app_module}
+                    rm -rf ${app_module}
+                    chmod -R u+w ${app_dir}
                 done
             else
                 fatal_error "Easystack file ${easystack_file} not found!"

--- a/EESSI-remove-software.sh
+++ b/EESSI-remove-software.sh
@@ -112,8 +112,9 @@ if [ $EUID -eq 0 ]; then
                     app_dir=${EASYBUILD_INSTALLPATH}/software/${app}
                     app_module=${EASYBUILD_INSTALLPATH}/modules/all/${app}.lua
                     echo_yellow "Removing ${app_dir} and ${app_module}..."
-                    rm -rf ${app_dir}
-                    rm -rf ${app_module}
+                    #rm -rf ${app_dir}
+                    #rm -rf ${app_module}
+                    chmod -R u+w ${app_dir} ${app_module}
                 done
             else
                 fatal_error "Easystack file ${easystack_file} not found!"

--- a/EESSI-remove-software.sh
+++ b/EESSI-remove-software.sh
@@ -112,9 +112,8 @@ if [ $EUID -eq 0 ]; then
                     app_dir=${EASYBUILD_INSTALLPATH}/software/${app}
                     app_module=${EASYBUILD_INSTALLPATH}/modules/all/${app}.lua
                     echo_yellow "Removing ${app_dir} and ${app_module}..."
-                    #rm -rf ${app_dir}
+                    rm -rf ${app_dir}
                     rm -rf ${app_module}
-                    chmod -R u+w ${app_dir}
                 done
             else
                 fatal_error "Easystack file ${easystack_file} not found!"

--- a/EESSI-remove-software.sh
+++ b/EESSI-remove-software.sh
@@ -114,6 +114,11 @@ if [ $EUID -eq 0 ]; then
                     echo_yellow "Removing ${app_dir} and ${app_module}..."
                     rm -rf ${app_dir}
                     rm -rf ${app_module}
+                    # if the parent dir of this application is now empty, remove it too to work around a weird issue with the overlay
+                    # see https://github.com/EESSI/software-layer/pull/546#issuecomment-2067018216
+                    if [ ! -n "$(dirname ${app_dir})" ]; then
+                        rmdir "$(dirname ${app_dir})"
+                    fi
                 done
             else
                 fatal_error "Easystack file ${easystack_file} not found!"

--- a/EESSI-remove-software.sh
+++ b/EESSI-remove-software.sh
@@ -114,12 +114,6 @@ if [ $EUID -eq 0 ]; then
                     echo_yellow "Removing ${app_dir} and ${app_module}..."
                     rm -rf ${app_dir}
                     rm -rf ${app_module}
-                    # if the parent dir of this application is now empty, remove it too to work around a weird issue with the overlay
-                    # see https://github.com/EESSI/software-layer/pull/546#issuecomment-2067018216
-                    app_dir_parent=$(dirname "${app_dir}")
-                    if [ ! -n "$(ls -A ${app_dir_parent})" ]; then
-                        rmdir "${app_dir_parent}"
-                    fi
                 done
             else
                 fatal_error "Easystack file ${easystack_file} not found!"

--- a/easystacks/software.eessi.io/2023.06/rebuilds/20240419-eb-4.9.1-move-setuptools_scm-from-hatchling-to-Python.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20240419-eb-4.9.1-move-setuptools_scm-from-hatchling-to-Python.yml
@@ -1,0 +1,13 @@
+# 2024-04-19
+# Move setuptools_scm extension from hatchling to Python by rebuilding
+# all affected modules with EasyBuild 4.9.1.
+# This solves an issue with pyarrow, which is part of the Arrow installation.
+# https://github.com/easybuilders/easybuild-easyconfigs/pull/19777
+# https://github.com/easybuilders/easybuild-easyconfigs/issues/19849
+easyconfigs:
+  - hatchling-1.18.0-GCCcore-12.3.0.eb
+  - hatchling-1.18.0-GCCcore-13.2.0.eb
+  - Python-bundle-PyPI-2023.06-GCCcore-12.3.0.eb
+  - Python-bundle-PyPI-2023.10-GCCcore-13.2.0.eb
+  - Python-3.11.3-GCCcore-12.3.0.eb
+  - Python-3.11.5-GCCcore-13.2.0.eb

--- a/easystacks/software.eessi.io/2023.06/rebuilds/20240419-eb-4.9.1-move-setuptools_scm-from-hatchling-to-Python.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20240419-eb-4.9.1-move-setuptools_scm-from-hatchling-to-Python.yml
@@ -1,10 +1,13 @@
 # 2024-04-19
 # Move setuptools_scm extension from hatchling to Python by rebuilding
-# the affected modules in the 2023b toolchain with EasyBuild 4.9.1.
+# all affected modules with EasyBuild 4.9.1.
 # This solves an issue with pyarrow, which is part of the Arrow installation.
 # https://github.com/easybuilders/easybuild-easyconfigs/pull/19777
 # https://github.com/easybuilders/easybuild-easyconfigs/issues/19849
 easyconfigs:
+  - hatchling-1.18.0-GCCcore-12.3.0.eb
   - hatchling-1.18.0-GCCcore-13.2.0.eb
+  - Python-bundle-PyPI-2023.06-GCCcore-12.3.0.eb
   - Python-bundle-PyPI-2023.10-GCCcore-13.2.0.eb
+  - Python-3.11.3-GCCcore-12.3.0.eb
   - Python-3.11.5-GCCcore-13.2.0.eb

--- a/easystacks/software.eessi.io/2023.06/rebuilds/20240419-eb-4.9.1-move-setuptools_scm-from-hatchling-to-Python.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20240419-eb-4.9.1-move-setuptools_scm-from-hatchling-to-Python.yml
@@ -1,13 +1,10 @@
 # 2024-04-19
 # Move setuptools_scm extension from hatchling to Python by rebuilding
-# all affected modules with EasyBuild 4.9.1.
+# the affected modules in the 2023a toolchain with EasyBuild 4.9.1.
 # This solves an issue with pyarrow, which is part of the Arrow installation.
 # https://github.com/easybuilders/easybuild-easyconfigs/pull/19777
 # https://github.com/easybuilders/easybuild-easyconfigs/issues/19849
 easyconfigs:
   - hatchling-1.18.0-GCCcore-12.3.0.eb
-  - hatchling-1.18.0-GCCcore-13.2.0.eb
   - Python-bundle-PyPI-2023.06-GCCcore-12.3.0.eb
-  - Python-bundle-PyPI-2023.10-GCCcore-13.2.0.eb
   - Python-3.11.3-GCCcore-12.3.0.eb
-  - Python-3.11.5-GCCcore-13.2.0.eb

--- a/easystacks/software.eessi.io/2023.06/rebuilds/20240419-eb-4.9.1-move-setuptools_scm-from-hatchling-to-Python.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20240419-eb-4.9.1-move-setuptools_scm-from-hatchling-to-Python.yml
@@ -1,10 +1,10 @@
 # 2024-04-19
 # Move setuptools_scm extension from hatchling to Python by rebuilding
-# the affected modules in the 2023a toolchain with EasyBuild 4.9.1.
+# the affected modules in the 2023b toolchain with EasyBuild 4.9.1.
 # This solves an issue with pyarrow, which is part of the Arrow installation.
 # https://github.com/easybuilders/easybuild-easyconfigs/pull/19777
 # https://github.com/easybuilders/easybuild-easyconfigs/issues/19849
 easyconfigs:
-  - hatchling-1.18.0-GCCcore-12.3.0.eb
-  - Python-bundle-PyPI-2023.06-GCCcore-12.3.0.eb
-  - Python-3.11.3-GCCcore-12.3.0.eb
+  - hatchling-1.18.0-GCCcore-13.2.0.eb
+  - Python-bundle-PyPI-2023.10-GCCcore-13.2.0.eb
+  - Python-3.11.5-GCCcore-13.2.0.eb


### PR DESCRIPTION
During the installation of R-bundle-Bioconductor with EB 4.9.1 in #533, I ran into the same issue as reported in https://github.com/easybuilders/easybuild-easyconfigs/issues/19849. In order to fix it, we have to apply the changes from https://github.com/easybuilders/easybuild-easyconfigs/pull/19777, which involves a reinstallation of some modules.