### PR TITLE
zen4-only {2023.06}[system] EasyBuild v4.9.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.1-001-system.yml
+++ b/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.1-001-system.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - EasyBuild-4.9.1.eb:
+      options:
+        from-pr: 20299


### PR DESCRIPTION
Add EasyBuild v4.9.1 to `zen4` software subdir.

Only build for `zen4` on cluster ...

SPDX license identifier: `GPL-2.0-only`

Missing packages:
```
```