### PR TITLE
update init scripts for pilot repository to print deprecation warning & use `software.eessi.io` instead

### DIFF
--- a/versions/2021.12/init/Magic_Castle/bash
+++ b/versions/2021.12/init/Magic_Castle/bash
@@ -1,0 +1,13 @@
+/cvmfs/pilot.eessi-hpc.org/versions/2021.12/init/print_deprecation_warning.sh
+
+if [ ! -z ${EESSI_FORCE_PILOT} ]; then
+    echo "Setting up the pilot repository, because \$EESSI_FORCE_PILOT is set..."
+    source /cvmfs/pilot.eessi-hpc.org/versions/2021.12/init/bash.force
+elif [ ! -d /cvmfs/software.eessi.io/versions/2023.06 ]; then
+    echo "Setting up the pilot repository, because the production repository (software.eessi.io) is not available on your system..."
+    echo "(see https://www.eessi.io/docs/getting_access/is_eessi_accessible/ for more information)"
+else
+    echo "Automatically switching to version 2023.06 of the production repository (software.eessi.io)..."
+    source /cvmfs/software.eessi.io/versions/2023.06/init/bash
+fi
+source /cvmfs/pilot.eessi-hpc.org/versions/2021.12/init/Magic_Castle/bash

--- a/versions/2021.12/init/Magic_Castle/bash
+++ b/versions/2021.12/init/Magic_Castle/bash
@@ -2,12 +2,12 @@
 
 if [ ! -z ${EESSI_FORCE_PILOT} ]; then
     echo "Setting up the pilot repository, because \$EESSI_FORCE_PILOT is set..."
-    source /cvmfs/pilot.eessi-hpc.org/versions/2021.12/init/bash.force
+    source /cvmfs/pilot.eessi-hpc.org/versions/2021.12/init/Magic_Castle/bash.force
 elif [ ! -d /cvmfs/software.eessi.io/versions/2023.06 ]; then
     echo "Setting up the pilot repository, because the production repository (software.eessi.io) is not available on your system..."
     echo "(see https://www.eessi.io/docs/getting_access/is_eessi_accessible/ for more information)"
+    source /cvmfs/pilot.eessi-hpc.org/versions/2021.12/init/Magic_Castle/bash.force
 else
     echo "Automatically switching to version 2023.06 of the production repository (software.eessi.io)..."
-    source /cvmfs/software.eessi.io/versions/2023.06/init/bash
+    source /cvmfs/software.eessi.io/versions/2023.06/init/Magic_Castle/bash
 fi
-source /cvmfs/pilot.eessi-hpc.org/versions/2021.12/init/Magic_Castle/bash

--- a/versions/2021.12/init/bash
+++ b/versions/2021.12/init/bash
@@ -6,6 +6,7 @@ if [ ! -z ${EESSI_FORCE_PILOT} ]; then
 elif [ ! -d /cvmfs/software.eessi.io/versions/2023.06 ]; then
     echo "Setting up the pilot repository, because the production repository (software.eessi.io) is not available on your system..."
     echo "(see https://www.eessi.io/docs/getting_access/is_eessi_accessible/ for more information)"
+    source /cvmfs/pilot.eessi-hpc.org/versions/2021.12/init/bash.force
 else
     echo "Automatically switching to version 2023.06 of the production repository (software.eessi.io)..."
     source /cvmfs/software.eessi.io/versions/2023.06/init/bash

--- a/versions/2021.12/init/bash
+++ b/versions/2021.12/init/bash
@@ -1,0 +1,12 @@
+/cvmfs/pilot.eessi-hpc.org/versions/2021.12/init/print_deprecation_warning.sh
+
+if [ ! -z ${EESSI_FORCE_PILOT} ]; then
+    echo "Setting up the pilot repository, because \$EESSI_FORCE_PILOT is set..."
+    source /cvmfs/pilot.eessi-hpc.org/versions/2021.12/init/bash.force
+elif [ ! -d /cvmfs/software.eessi.io/versions/2023.06 ]; then
+    echo "Setting up the pilot repository, because the production repository (software.eessi.io) is not available on your system..."
+    echo "(see https://www.eessi.io/docs/getting_access/is_eessi_accessible/ for more information)"
+else
+    echo "Automatically switching to version 2023.06 of the production repository (software.eessi.io)..."
+    source /cvmfs/software.eessi.io/versions/2023.06/init/bash
+fi

--- a/versions/2021.12/init/print_deprecation_warning.sh
+++ b/versions/2021.12/init/print_deprecation_warning.sh
@@ -20,6 +20,9 @@ echo_yellow_stderr "to prepare your environment for using the EESSI production r
 echo_yellow_stderr
 echo_yellow_stderr "See also https://eessi.github.io/docs/using_eessi/setting_up_environment."
 echo_yellow_stderr
+echo_yellow_stderr "If you have any questions or if you need any help, please open a support ticket:"
+echo_yellow_stderr "https://www.eessi.io/docs/support"
+echo_yellow_stderr
 echo_yellow_stderr "This script will now try to automatically switch to the production repository,"
 echo_yellow_stderr "unless it's not available or if \$EESSI_FORCE_PILOT is set."
 echo_yellow_stderr

--- a/versions/2021.12/init/print_deprecation_warning.sh
+++ b/versions/2021.12/init/print_deprecation_warning.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+function echo_yellow_stderr() {
+    echo -e "\e[33m${1}\e[0m" >&2
+}
+
+echo_yellow_stderr
+echo_yellow_stderr "WARNING: the EESSI pilot repository is deprecated and no longer supported."
+echo_yellow_stderr
+echo_yellow_stderr "We strongly recommend to switch to the EESSI production repository (software.eessi.io)."
+echo_yellow_stderr "See https://www.eessi.io/docs/repositories/software.eessi.io/ for more information."
+echo_yellow_stderr
+echo_yellow_stderr "You can find instructions for making the production repository available at:"
+echo_yellow_stderr "https://www.eessi.io/docs/getting_access/is_eessi_accessible/"
+echo_yellow_stderr
+echo_yellow_stderr "If the production repository is available on your system, please run"
+echo_yellow_stderr
+echo_yellow_stderr "    source /cvmfs/software.eessi.io/versions/2023.06/init/bash"
+echo_yellow_stderr
+echo_yellow_stderr "to prepare your environment for using the EESSI production repository."
+echo_yellow_stderr
+echo_yellow_stderr "See also https://eessi.github.io/docs/using_eessi/setting_up_environment."
+echo_yellow_stderr
+echo_yellow_stderr "This script will now try to automatically switch to the production repository,"
+echo_yellow_stderr "unless it's not available or if \$EESSI_FORCE_PILOT is set."
+echo_yellow_stderr
+echo_yellow_stderr

--- a/versions/2023.06/init/Magic_Castle/bash
+++ b/versions/2023.06/init/Magic_Castle/bash
@@ -1,0 +1,13 @@
+/cvmfs/pilot.eessi-hpc.org/versions/2023.06/init/print_deprecation_warning.sh
+
+if [ ! -z ${EESSI_FORCE_PILOT} ]; then
+    echo "Setting up the pilot repository, because \$EESSI_FORCE_PILOT is set..."
+    source /cvmfs/pilot.eessi-hpc.org/versions/2023.06/init/Magic_Castle/bash.force
+elif [ ! -d /cvmfs/software.eessi.io/versions/2023.06 ]; then
+    echo "Setting up the pilot repository, because the production repository (software.eessi.io) is not available on your system..."
+    echo "(see https://www.eessi.io/docs/getting_access/is_eessi_accessible/ for more information)"
+    source /cvmfs/pilot.eessi-hpc.org/versions/2023.06/init/Magic_Castle/bash.force
+else
+    echo "Automatically switching to version 2023.06 of the production repository (software.eessi.io)..."
+    source /cvmfs/software.eessi.io/versions/2023.06/init/Magic_Castle/bash
+fi

--- a/versions/2023.06/init/bash
+++ b/versions/2023.06/init/bash
@@ -1,0 +1,13 @@
+/cvmfs/pilot.eessi-hpc.org/versions/2023.06/init/print_deprecation_warning.sh
+
+if [ ! -z ${EESSI_FORCE_PILOT} ]; then
+    echo "Setting up the pilot repository, because \$EESSI_FORCE_PILOT is set..."
+    source /cvmfs/pilot.eessi-hpc.org/versions/2023.06/init/bash.force
+elif [ ! -d /cvmfs/software.eessi.io/versions/2023.06 ]; then
+    echo "Setting up the pilot repository, because the production repository (software.eessi.io) is not available on your system..."
+    echo "(see https://www.eessi.io/docs/getting_access/is_eessi_accessible/ for more information)"
+    source /cvmfs/pilot.eessi-hpc.org/versions/2023.06/init/bash.force
+else
+    echo "Automatically switching to version 2023.06 of the production repository (software.eessi.io)..."
+    source /cvmfs/software.eessi.io/versions/2023.06/init/bash
+fi

--- a/versions/2023.06/init/print_deprecation_warning.sh
+++ b/versions/2023.06/init/print_deprecation_warning.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+function echo_yellow_stderr() {
+    echo -e "\e[33m${1}\e[0m" >&2
+}
+
+echo_yellow_stderr
+echo_yellow_stderr "WARNING: the EESSI pilot repository is deprecated and no longer supported."
+echo_yellow_stderr
+echo_yellow_stderr "We strongly recommend to switch to the EESSI production repository (software.eessi.io)."
+echo_yellow_stderr "See https://www.eessi.io/docs/repositories/software.eessi.io/ for more information."
+echo_yellow_stderr
+echo_yellow_stderr "You can find instructions for making the production repository available at:"
+echo_yellow_stderr "https://www.eessi.io/docs/getting_access/is_eessi_accessible/"
+echo_yellow_stderr
+echo_yellow_stderr "If the production repository is available on your system, please run"
+echo_yellow_stderr
+echo_yellow_stderr "    source /cvmfs/software.eessi.io/versions/2023.06/init/bash"
+echo_yellow_stderr
+echo_yellow_stderr "to prepare your environment for using the EESSI production repository."
+echo_yellow_stderr
+echo_yellow_stderr "See also https://eessi.github.io/docs/using_eessi/setting_up_environment."
+echo_yellow_stderr
+echo_yellow_stderr "If you have any questions or if you need any help, please open a support ticket:"
+echo_yellow_stderr "https://www.eessi.io/docs/support"
+echo_yellow_stderr
+echo_yellow_stderr "This script will now try to automatically switch to the production repository,"
+echo_yellow_stderr "unless it's not available or if \$EESSI_FORCE_PILOT is set."
+echo_yellow_stderr
+echo_yellow_stderr


### PR DESCRIPTION
I've only done it for 2021.12 for now. Once it's reviewed, I'll clone the files for pilot version 2023.06.

This will now print a deprecation message (in yellow font), and try to automatically source the `init` file of the 2023.06 version of the production repo. If that's not available, or if `$EESSI_FORCE_PILOT` is set, it will go ahead and source the original init script (which is now assumed to be renamed to `bash.force`).