### PR TITLE
use `--from-commit` instead of `--from-pr` for installations done with EasyBuild v4.9.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-001-system.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-001-system.yml
@@ -1,4 +1,5 @@
 easyconfigs:
   - EasyBuild-4.9.1.eb:
       options:
-        from-pr: 20299
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20299
+        from-commit: f8de136f996518c621a7de4c2763b779332b0d72

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -1,4 +1,5 @@
 easyconfigs:
   - R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb:
       options:
-        from-pr: 20379
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20379
+        from-commit: 968654eef0a4984fc82e475ae4739eb42d8a2275

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -3,4 +3,5 @@ easyconfigs:
   - SAMtools-1.18-GCC-12.3.0.eb
   - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
       options:
-        from-pr: 20379
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20379
+        from-commit: 968654eef0a4984fc82e475ae4739eb42d8a2275

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
@@ -1,4 +1,5 @@
 easyconfigs:
   - GROMACS-2024.1-foss-2023b.eb:
       options:
-        from-pr: 20439
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20439
+        from-commit: 231b705ab06fdc6fc777d2c53667c483cdc6fc79


### PR DESCRIPTION
This doesn't affect the ingested installations at all, but going forward we should use `--from-commit` instead of `--from-pr`, and simply use the last commit in the (merged) PR