### PR TITLE
move OSU-Micro-Benchmarks 2023b to 2023b easystack

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -35,7 +35,6 @@ easyconfigs:
         from-pr: 19996
   - dask-2023.9.2-foss-2023a.eb
   - OSU-Micro-Benchmarks-7.2-gompi-2023a-CUDA-12.1.1.eb
-  - OSU-Micro-Benchmarks-7.2-gompi-2023b.eb
   - JupyterNotebook-7.0.2-GCCcore-12.3.0.eb
   - ImageMagick-7.1.1-15-GCCcore-12.3.0.eb:
       options:

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -57,3 +57,4 @@ easyconfigs:
   - Qt5-5.15.13-GCCcore-13.2.0.eb:
       options:
         from-pr: 20201
+  - OSU-Micro-Benchmarks-7.2-gompi-2023b.eb


### PR DESCRIPTION
Thanks to @TopRichard for spotting this. This should just be a cosmetic change, so no need to rebuild anything.