### PR TITLE
also check for missing installations in `x86_64/amd/zen4` subdirectory

### DIFF
--- a/.github/workflows/test-software.eessi.io.yml
+++ b/.github/workflows/test-software.eessi.io.yml
@@ -17,6 +17,7 @@ jobs:
         - aarch64/neoverse_v1
         - x86_64/amd/zen2
         - x86_64/amd/zen3
+        - x86_64/amd/zen4
         - x86_64/intel/haswell
         - x86_64/intel/skylake_avx512
         - x86_64/generic


### PR DESCRIPTION
This will fail until all software installations for `x86_64/amd/zen4` are in place, and we just got started with that in:

* #547 