### PR TITLE
stick to x86_64/amd/zen3 when AMD Genoa (Zen4) is detected, until optimized software installations are available for Zen4

### DIFF
--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -48,6 +48,14 @@ if [ -d $EESSI_PREFIX ]; then
     fi
     if [ ! -z $EESSI_SOFTWARE_SUBDIR ]; then
 
+        # use x86_64/amd/zen3 for now when AMD Genoa (Zen4) CPU is detected,
+        # since optimized software installations for Zen4 are a work-in-progress,
+        # see https://gitlab.com/eessi/support/-/issues/37
+        if [[ "${EESSI_SOFTWARE_SUBDIR}" == "x86_64/amd/zen4" ]]; then
+            export EESSI_SOFTWARE_SUBDIR="x86_64/amd/zen3"
+            echo -e "\e[33mSticking to ${EESSI_SOFTWARE_SUBDIR} for now, since optimized installations for AMD Genoa (Zen4) are a work in progress, see https://gitlab.com/eessi/support/-/issues/37 for more information\e[0m"
+        fi
+
         show_msg "Using ${EESSI_SOFTWARE_SUBDIR} as software subdirectory."
         export EESSI_SOFTWARE_PATH=$EESSI_PREFIX/software/$EESSI_OS_TYPE/$EESSI_SOFTWARE_SUBDIR
 


### PR DESCRIPTION
Tested, works like a charm (extra text is in yellow):

```
Found EESSI repo @ /cvmfs/software.eessi.io/versions/2023.06!
archdetect says x86_64/amd/zen4
Sticking to x86_64/amd/zen3 for now, since optimized installations for AMD Genoa (Zen4) are a work in progress, see https://gitlab.com/eessi/support/-/issues/37 for more information
Using x86_64/amd/zen3 as software subdirectory.
...
$ echo $MODULEPATH
/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/modules/all
```