### PR TITLE
Only run OSU test for now in test step. 

### DIFF
--- a/test_suite.sh
+++ b/test_suite.sh
@@ -175,7 +175,15 @@ else
 fi
 
 # List the tests we want to run
-export REFRAME_ARGS='--tag CI --tag 1_node --nocolor'
+export REFRAME_FLAGS='--nocolor'
+export REFRAME_TAGS='--tag CI --tag 1_node'
+# Limit test names to relevant tests
+# For now, we limit to OSU.
+# In the future, we should create some mapping between module names of modules that are deployed.
+# E.g. if TensorFlow was deployed, we want to run with `-n TensorFlow`. If OpenMPI was deployed
+# we want to run with `-n OSU`, or maybe even `-n OSU -n GROMACS.*foss` to also test _one_ OpenMPI application
+export REFRAME_INCLUDE_PATTERNS='-n OSU'
+export REFRAME_ARGS="${REFRAME_FLAGS} ${REFRAME_TAGS} ${REFRAME_INCLUDE_PATTERNS}"
 echo "Listing tests: reframe ${REFRAME_ARGS} --list"
 reframe ${REFRAME_ARGS} --list
 if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
As the test suite is growing, the test step would start taking longer and longer. This is particularly annoying if you want to do small tweaks during a build. 

In the (near) future, we should make some mapping to determine which tests to run for which software installations. E.g. if your tarball contains a new TensorFlow module, you probably want to run the TensorFlow test (`-n TensorFlow`). If your tarball contains OpenMPI, you probably want to run `OSU` and maybe one MPI-based application (i.e. `-n OSU -n GROMACS.*foss` for example).