### PR TITLE
Add `psm2` to filtered dependencies for `2023.06`

### DIFF
--- a/configure_easybuild
+++ b/configure_easybuild
@@ -32,6 +32,12 @@ if [[ "$EESSI_CPU_FAMILY" == "aarch64" ]]; then
     DEPS_TO_FILTER="${DEPS_TO_FILTER},Yasm"
 fi
 
+# Version 23.06 of EESSI ships PSM2 in the compat layer, so we can filter this out while retaining support for OFA fabric
+# (longer term this is probably not the right move as PSM2 should be configured with accelerator support, hence the restricted version)
+if [[ "$EESSI_VERSION" == "2023.06" ]]; then
+    DEPS_TO_FILTER="${DEPS_TO_FILTER},psm2"
+fi
+
 export EASYBUILD_FILTER_DEPS=$DEPS_TO_FILTER
 
 export EASYBUILD_MODULE_EXTENSIONS=1


### PR DESCRIPTION
`PSM2` was introduced as a dependency of `libfabric` in https://github.com/easybuilders/easybuild-easyconfigs/pull/20501. 

We already have PSM2 in the compat layer, so we can filter this dependency out, but longer term we probably actually want it since it should be built with accelerator support.