### PR TITLE
Test 550 with GROMACS rebuild in #576

### DIFF
--- a/configure_easybuild
+++ b/configure_easybuild
@@ -35,7 +35,7 @@ fi
 # Version 23.06 of EESSI ships PSM2 in the compat layer, so we can filter this out while retaining support for OFA fabric
 # (longer term this is probably not the right move as PSM2 should be configured with accelerator support, hence the restricted version)
 if [[ "$EESSI_VERSION" == "2023.06" ]]; then
-    DEPS_TO_FILTER="${DEPS_TO_FILTER},psm2"
+    DEPS_TO_FILTER="${DEPS_TO_FILTER},PSM2"
 fi
 
 export EASYBUILD_FILTER_DEPS=$DEPS_TO_FILTER

--- a/configure_easybuild
+++ b/configure_easybuild
@@ -32,6 +32,12 @@ if [[ "$EESSI_CPU_FAMILY" == "aarch64" ]]; then
     DEPS_TO_FILTER="${DEPS_TO_FILTER},Yasm"
 fi
 
+# Version 23.06 of EESSI ships PSM2 in the compat layer, so we can filter this out while retaining support for OFA fabric
+# (longer term this is probably not the right move as PSM2 should be configured with accelerator support, hence the restricted version)
+if [[ "$EESSI_VERSION" == "2023.06" ]]; then
+    DEPS_TO_FILTER="${DEPS_TO_FILTER},psm2"
+fi
+
 export EASYBUILD_FILTER_DEPS=$DEPS_TO_FILTER
 
 export EASYBUILD_MODULE_EXTENSIONS=1

--- a/easystacks/software.eessi.io/2023.06/rebuilds/20240515-eb-4.9.1-GROMACS-correct-gmxapi-version.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20240515-eb-4.9.1-GROMACS-correct-gmxapi-version.yml
@@ -4,8 +4,13 @@
 # at https://gitlab.com/gromacs/gromacs/-/blob/v2024.1/python_packaging/gmxapi/src/gmxapi/version.py?ref_type=tags#L68,
 # the 2024.1 release includes gmxapi 0.5.0.
 #
+# This also introduced a new build dependency on scikit-build-core for GROMACS
+#
 # See https://github.com/easybuilders/easybuild-easyconfigs/pull/20522
 easyconfigs:
+  - scikit-build-core-0.9.3-GCCcore-13.2.0.eb:
+      options:
+        from-pr: 20526
   - GROMACS-2024.1-foss-2023b.eb:
       options:
         from-pr: 20522

--- a/easystacks/software.eessi.io/2023.06/rebuilds/20240515-eb-4.9.1-GROMACS-correct-gmxapi-version.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20240515-eb-4.9.1-GROMACS-correct-gmxapi-version.yml
@@ -1,0 +1,11 @@
+# 2024.05.15
+# Originally shipped version forgot to bump the gmxapi version and source
+# tarball, it was still using an older version from the 2023.3 tarball. Looking
+# at https://gitlab.com/gromacs/gromacs/-/blob/v2024.1/python_packaging/gmxapi/src/gmxapi/version.py?ref_type=tags#L68,
+# the 2024.1 release includes gmxapi 0.5.0.
+#
+# See https://github.com/easybuilders/easybuild-easyconfigs/pull/20522
+easyconfigs:
+  - GROMACS-2024.1-foss-2023b.eb:
+      options:
+        from-pr: 20522

--- a/easystacks/software.eessi.io/2023.06/rebuilds/20240515-eb-4.9.1-GROMACS-correct-gmxapi-version.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20240515-eb-4.9.1-GROMACS-correct-gmxapi-version.yml
@@ -10,7 +10,7 @@
 easyconfigs:
   - scikit-build-core-0.9.3-GCCcore-13.2.0.eb:
       options:
-        from-pr: 20526
+        from-commit: 61d07bff09afe63cfe1ae35dc58a0c8be01eed62
   - GROMACS-2024.1-foss-2023b.eb:
       options:
-        from-pr: 20522
+        from-commit: a0a467a88506c765a93a96b20d7a8fcb01d46b24


### PR DESCRIPTION
We are interested in verifying if the ReFrame tests run are using the updated GROMACS build. We probably have to inspect the log files on the build cluster for this.