### PR TITLE
Rebuild EESSI-extend module to correctly handle `EESSI_SITE_INSTALL`

### DIFF
--- a/EESSI-extend-2023.06-easybuild.eb
+++ b/EESSI-extend-2023.06-easybuild.eb
@@ -92,7 +92,19 @@ elseif (os.getenv("EESSI_SITE_INSTALL") ~= nil) then
   if ((os.getenv("EESSI_PROJECT_INSTALL") ~= nil) or (os.getenv("EESSI_USER_INSTALL") ~= nil)) then
     LmodError("You cannot use EESSI_SITE_INSTALL in combination with any other EESSI_*_INSTALL environment variables")
   end
-  easybuild_installpath = string.gsub(os.getenv("EESSI_SOFTWARE_PATH"), 'versions', 'host_injections')
+  site_install = os.getenv("EESSI_SITE_INSTALL")
+  site_modulepath = nil
+  if (site_install ~= nil) then
+    -- Check the folder exists
+    if not isDir(site_install) then
+      LmodError("The location of EESSI_SITE_INSTALL (" .. site_install .. ") does not exist or is not a folder")
+    end
+    if (mode() == "load") then
+      LmodMessage("Configuring for use of EESSI_SITE_INSTALL under " .. site_install)
+    end
+    easybuild_installpath = string.gsub(os.getenv("EESSI_SOFTWARE_PATH"), os.getenv("EESSI_CVMFS_REPO"), site_install)
+    site_modulepath = pathJoin(easybuild_installpath, 'modules', 'all')
+  end
 else
   -- Deal with user and project installs
   project_install = os.getenv("EESSI_PROJECT_INSTALL")

--- a/easystacks/software.eessi.io/2023.06/rebuilds/20240520-eb-4.9.1-update-EESSI-extend-module.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20240520-eb-4.9.1-update-EESSI-extend-module.yml
@@ -1,0 +1,5 @@
+# 2024-05-20
+# Rebuild EESSI-extend/2023.06-easybuild
+# The current version does not handle EESSI_SITE_INSTALL correctly.
+easyconfigs:
+  - EESSI-extend-2023.06-easybuild.eb


### PR DESCRIPTION
The current module `EESSI-extend/2023.06-easybuild` does not handle the environment setting `EESSI_SITE_INSTALL` correctly. It just falls back to using the standard `CVMFS` installation path where `versions` is replaced with `host_injections`. This is probably due to an oversight when reviewing PR #371.

Note, when rebuilding this for NESSI, we ran into permission issues when EasyBuild tried to set the permissions of the software after it has been built. Will be interesting to see if we run into the same issue here.