### PR TITLE
Automatically redirect RISC-V users to `riscv.eessi.io` in init script + initial RISC-V support for archdetect

### DIFF
--- a/init/arch_specs/eessi_arch_riscv.spec
+++ b/init/arch_specs/eessi_arch_riscv.spec
@@ -1,0 +1,1 @@
+# Software path in EESSI 	| Vendor ID 	| List of defining CPU features

--- a/init/eessi_archdetect.sh
+++ b/init/eessi_archdetect.sh
@@ -85,6 +85,7 @@ cpupath(){
         "x86_64") local spec_file="eessi_arch_x86.spec";;
         "aarch64") local spec_file="eessi_arch_arm.spec";;
         "ppc64le") local spec_file="eessi_arch_ppc.spec";;
+        "riscv64") local spec_file="eessi_arch_riscv.spec";;
         *) log "ERROR" "cpupath: Unsupported CPU architecture $machine_type"
     esac
     # spec files are located in a subfolder with this script

--- a/init/eessi_defaults
+++ b/init/eessi_defaults
@@ -8,8 +8,20 @@
 # license: GPLv2
 #
 
-export EESSI_CVMFS_REPO="${EESSI_CVMFS_REPO_OVERRIDE:=/cvmfs/software.eessi.io}"
-export EESSI_VERSION="${EESSI_VERSION_OVERRIDE:=2023.06}"
+# use different defaults for RISC-V, as we want to redirect to the riscv.eessi.io repo
+if [[ $(uname -m) == "riscv64" ]]; then
+    export EESSI_CVMFS_REPO="${EESSI_CVMFS_REPO_OVERRIDE:=/cvmfs/riscv.eessi.io}"
+    export EESSI_VERSION="${EESSI_VERSION_OVERRIDE:=20240402}"
+    if [[ ! -v EESSI_SILENT ]]; then
+        echo "RISC-V architecture detected, but there is no RISC-V support yet in the production repository."
+        echo "Automatically switching to version ${EESSI_VERSION} of the RISC-V development repository ${EESSI_CVMFS_REPO}."
+        echo "For more details about this repository, see https://www.eessi.io/docs/repositories/riscv.eessi.io/."
+        echo ""
+    fi
+else
+    export EESSI_CVMFS_REPO="${EESSI_CVMFS_REPO_OVERRIDE:=/cvmfs/software.eessi.io}"
+    export EESSI_VERSION="${EESSI_VERSION_OVERRIDE:=2023.06}"
+fi
 # use archdetect by default, unless otherwise specified
 export EESSI_USE_ARCHDETECT="${EESSI_USE_ARCHDETECT:=1}"
 export EESSI_USE_ARCHSPEC="${EESSI_USE_ARCHSPEC:=0}"

--- a/init/minimal_eessi_env
+++ b/init/minimal_eessi_env
@@ -16,7 +16,7 @@ else
     export EESSI_OS_TYPE='macos'
 fi
 
-# aarch64 (Arm 64-bit), ppc64le (POWER 64-bit), x86_64 (x86 64-bit)
+# aarch64 (Arm 64-bit), riscv64 (RISC-V 64-bit), x86_64 (x86 64-bit)
 export EESSI_CPU_FAMILY=$(uname -m)
 
 # set $EPREFIX since that is basically a standard in Gentoo Prefix

--- a/install_scripts.sh
+++ b/install_scripts.sh
@@ -92,7 +92,7 @@ copy_files_by_list ${TOPDIR}/init ${INSTALL_PREFIX}/init "${init_files[@]}"
 
 # Copy for the init/arch_specs directory
 arch_specs_files=(
-   eessi_arch_arm.spec eessi_arch_ppc.spec eessi_arch_x86.spec
+   eessi_arch_arm.spec eessi_arch_ppc.spec eessi_arch_riscv.spec eessi_arch_x86.spec
 )
 copy_files_by_list ${TOPDIR}/init/arch_specs ${INSTALL_PREFIX}/init/arch_specs "${arch_specs_files[@]}"
 


### PR DESCRIPTION
Tested on my Visionfive 2:
```
$ source /nvme/git/software-layer/init/bash 
RISC-V architecture detected, but there is no RISC-V support yet in the production repository.
Automatically switching to version 20240402 of the RISC-V development repository /cvmfs/riscv.eessi.io.
For more details about this repository, see https://www.eessi.io/docs/repositories/riscv.eessi.io/.

Found EESSI repo @ /cvmfs/riscv.eessi.io/versions/20240402!
archdetect says riscv64/generic
Using riscv64/generic as software subdirectory.
Found Lmod configuration file at /cvmfs/riscv.eessi.io/versions/20240402/software/linux/riscv64/generic/.lmod/lmodrc.lua
Found Lmod SitePackage.lua file at /cvmfs/riscv.eessi.io/versions/20240402/software/linux/riscv64/generic/.lmod/SitePackage.lua
Using /cvmfs/riscv.eessi.io/versions/20240402/software/linux/riscv64/generic/modules/all as the directory to be added to MODULEPATH.
Using /cvmfs/riscv.eessi.io/host_injections/20240402/software/linux/riscv64/generic/modules/all as the site extension directory to be added to MODULEPATH.
Initializing Lmod...
Prepending /cvmfs/riscv.eessi.io/versions/20240402/software/linux/riscv64/generic/modules/all to $MODULEPATH...
Prepending site path /cvmfs/riscv.eessi.io/host_injections/20240402/software/linux/riscv64/generic/modules/all to $MODULEPATH...
Environment set up to use EESSI (20240402), have fun!
```

And this is what archdetect reports:
```
$ /nvme/git/software-layer/init/eessi_archdetect.sh -d cpupath
2024-05-21 14:11:50 [DEBUG] cpupath: Override variable set as '' 
2024-05-21 14:11:50 [DEBUG] cpupath: Host CPU architecture identified as 'riscv64'
2024-05-21 14:11:50 [DEBUG] cpupath: CPU vendor of host system: ''
2024-05-21 14:11:50 [DEBUG] cpupath: CPU flags of host system: ''
2024-05-21 14:11:50 [INFO] cpupath: best match for host CPU: riscv64/generic
riscv64/generic

# the override still works:
$ env EESSI_SOFTWARE_SUBDIR_OVERRIDE=riscv64/visionfive2 /nvme/git/software-layer/init/eessi_archdetect.sh -d cpupath
2024-05-21 14:12:16 [DEBUG] cpupath: Override variable set as 'riscv64/visionfive2' 
riscv64/visionfive2
```
