### PR TITLE
{2023.06}[2023a] ESPResSo v4.2.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -4,3 +4,6 @@ easyconfigs:
   - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
       options:
         from-pr: 20379
+  - ESPResSo-4.2.2-foss-2023a.eb:
+      options:
+        from-pr: 20595


### PR DESCRIPTION
[ESPResSo v4.2.2](https://github.com/espressomd/espresso/releases/tag/4.2.2) has been released! 

For now this is a draft until #560 is accepted and https://github.com/easybuilders/easybuild-easyconfigs/pull/20595 is merged.