### PR TITLE
{2023.06}[gfbf/2023a] ipympl v0.9.3

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -48,9 +48,13 @@ easyconfigs:
   - PyOpenGL-3.1.7-GCCcore-12.3.0.eb:
       options:
         from-pr: 20007
-  - ipympl-0.9.3-foss-2023a.eb:
-      options:
-        from-pr: 20126
+  # removed by https://github.com/easybuilders/easybuild-easyconfigs/pull/20586
+  # adding ipympl-0.9.3-gfbf-2023a.eb as a replacement in
+  # easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+  # comment the below out here or CI will fail
+  # - ipympl-0.9.3-foss-2023a.eb:
+  #    options:
+  #      from-pr: 20126
   - OpenJPEG-2.5.0-GCCcore-12.3.0.eb
   - OpenFOAM-10-foss-2023a.eb
   - Highway-1.0.4-GCCcore-12.3.0.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -4,3 +4,11 @@ easyconfigs:
   - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
       options:
         from-pr: 20379
+  # replacement for ipympl-0.9.3-foss-2023a.eb which has been built via
+  # easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml and was
+  # later removed in https://github.com/easybuilders/easybuild-easyconfigs/pull/20586
+  # below we use the replacement ec file which is provided by
+  # https://github.com/easybuilders/easybuild-easyconfigs/pull/18852
+  - ipympl-0.9.3-gfbf-2023a.eb:
+     options:
+       from-pr: 18852


### PR DESCRIPTION
Replacement for the version built with `foss/2023a` (`ipympl-0.9.3-foss-2023a.eb` was removed in ).

`ipympl/0.9.3-foss-2023a` should/may be deleted from the CVMFS repository manually.