### PR TITLE
{2023.06}[foss/2023a] GATK v4.5.0.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -15,3 +15,4 @@ easyconfigs:
   - ESPResSo-4.2.2-foss-2023a.eb:
       options:
         from-pr: 20595
+  - GATK-4.5.0.0-GCCcore-12.3.0-Java-17.eb


### PR DESCRIPTION
Popular bioinformatics package.

SPDX license identifier: `Apache-2.0`

```
3 out of 12 required modules missing:

* Java/17.0.6 (Java-17.0.6.eb)
* Java/17 (Java-17.eb)
* GATK/4.5.0.0-GCCcore-12.3.0-Java-17 (GATK-4.5.0.0-GCCcore-12.3.0-Java-17.eb)
```
