### PR TITLE
Use `LmodMessage` instead of `LmodWarning` on loading ESPResSo v4.2.1 

### DIFF
--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -193,7 +193,7 @@ end
 -- Combine both functions into a single one, as we can only register one function as load hook in lmod
 -- Also: make it non-local, so it can be imported and extended by other lmodrc files if needed
 function eessi_load_hook(t)
-    eessi_espresso_deprecated_warning(t)
+    eessi_espresso_deprecated_message(t)
     -- Only apply CUDA hooks if the loaded module is in the EESSI prefix
     -- This avoids getting an Lmod Error when trying to load a CUDA module from a local software stack
     if from_eessi_prefix(t) then

--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -175,16 +175,18 @@ local function eessi_cuda_enabled_load_hook(t)
     end
 end
 
-local function eessi_espresso_deprecated_warning(t)
+local function eessi_espresso_deprecated_message(t)
     local frameStk  = require("FrameStk"):singleton()
     local mt        = frameStk:mt()
     local simpleName = string.match(t.modFullName, "(.-)/")
     local version = string.match(t.modFullName, "%d.%d.%d")
     if simpleName == 'ESPResSo' and version == '4.2.1' then
+    -- Print a message on loading ESPreSso v <= 4.2.1 recommending using v 4.2.2 and above.
+    -- A message and not a warning as the exit code would break CI runs otherwise.
         local advice = 'Prefer versions  >= 4.2.2 which include important bugfixes.\\n'
         advice = advice .. 'For details see https://github.com/espressomd/espresso/releases/tag/4.2.2\\n'
         advice = advice .. 'Use version 4.2.1 at your own risk!\\n'
-        LmodWarning("\\nESPResSo v4.2.1 has known issues and has been deprecated. ", advice)
+        LmodMessage("\\nESPResSo v4.2.1 has known issues and has been deprecated. ", advice)
     end
 end
 


### PR DESCRIPTION
After deploying #560, loading ESPResSo 4.2.1 returns a 1 as exit code due to the use of `LmodWarning`. This in turn causes CI runs to fail for users and developers who are loading version 4.2.1 as part of their pipelines.

As far as I can see, there is no way to change the exit code and keep `LmodWarning`, which I would prefer to do so this PR changes the call to `LmodWarning` to `LmodMessage` to address this problem.

I'll keep this as a draft just until I test the message still gets printed when the module is loaded.

Thank you @jngrad for reporting this!

Reproducing the issue:

```Environment set up to use EESSI (2023.06), have fun!
{EESSI 2023.06} [pedro@login1 ~]$ ml ESPResSo/4.2.1
Lmod Warning:
ESPResSo v4.2.1 has known issues and has been deprecated. Prefer versions >= 4.2.2 which include important bugfixes.
For details see https://github.com/espressomd/espresso/releases/tag/4.2.2
Use version 4.2.1 at your own risk!

While processing the following module(s):
    Module fullname            Module Filename
    ---------------            ---------------
    ESPResSo/4.2.1-foss-2023a  /cvmfs/software.eessi.io/versions/2023.06/software/linux/aarch64/neoverse_n1/modules/all/ESPResSo/4.2.1-foss-2023a.lua

{EESSI 2023.06} [pedro@login1 ~]$ echo $?
1
```