### PR TITLE
{2023.06}[foss/2022b] ParaView v5.11.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -2,3 +2,4 @@ easyconfigs:
   - R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb:
       options:
         from-pr: 20379
+  - ParaView-5.11.1-foss-2022b.eb


### PR DESCRIPTION
```
7 out of 99 required modules missing:

* ffnvcodec/11.1.5.2 (ffnvcodec-11.1.5.2.eb)
* x264/20230226-GCCcore-12.2.0 (x264-20230226-GCCcore-12.2.0.eb)
* Yasm/1.3.0-GCCcore-12.2.0 (Yasm-1.3.0-GCCcore-12.2.0.eb)
* x265/3.5-GCCcore-12.2.0 (x265-3.5-GCCcore-12.2.0.eb)
* SDL2/2.26.3-GCCcore-12.2.0 (SDL2-2.26.3-GCCcore-12.2.0.eb)
* FFmpeg/5.1.2-GCCcore-12.2.0 (FFmpeg-5.1.2-GCCcore-12.2.0.eb)
* ParaView/5.11.1-foss-2022b (ParaView-5.11.1-foss-2022b.eb)
```