### PR TITLE
{2023.06}[foss/2023a] WhatsHap v2.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -16,3 +16,4 @@ easyconfigs:
       options:
         from-pr: 20595
   - GATK-4.5.0.0-GCCcore-12.3.0-Java-17.eb
+  - WhatsHap-2.2-foss-2023a.eb


### PR DESCRIPTION
Lic --> MIT
```
6 out of 64 required modules missing:

* pyfaidx/0.8.1.1-GCCcore-12.3.0 (pyfaidx-0.8.1.1-GCCcore-12.3.0.eb)
* ISA-L/2.30.0-GCCcore-12.3.0 (ISA-L-2.30.0-GCCcore-12.3.0.eb)
* python-isal/1.1.0-GCCcore-12.3.0 (python-isal-1.1.0-GCCcore-12.3.0.eb)
* Pysam/0.22.0-GCC-12.3.0 (Pysam-0.22.0-GCC-12.3.0.eb)
* Biopython/1.83-foss-2023a (Biopython-1.83-foss-2023a.eb)
* WhatsHap/2.2-foss-2023a (WhatsHap-2.2-foss-2023a.eb)
```