### PR TITLE
{2023.06}[gfbf/2022b] ASE v3.22.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -3,3 +3,4 @@ easyconfigs:
       options:
         from-pr: 20379
   - ParaView-5.11.1-foss-2022b.eb
+  - ASE-3.22.1-gfbf-2022b.eb


### PR DESCRIPTION
```
3 out of 61 required modules missing:

* Flask/2.2.3-GCCcore-12.2.0 (Flask-2.2.3-GCCcore-12.2.0.eb)
* spglib-python/2.0.2-gfbf-2022b (spglib-python-2.0.2-gfbf-2022b.eb)
* ASE/3.22.1-gfbf-2022b (ASE-3.22.1-gfbf-2022b.eb)

```