### PR TITLE
{2023.06}[foss/2023b] NLTK v3.8.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023b.yml
@@ -2,3 +2,4 @@ easyconfigs:
   - GROMACS-2024.1-foss-2023b.eb:
       options:
         from-pr: 20439
+  - NLTK-3.8.1-foss-2023b.eb


### PR DESCRIPTION
```
3 out of 85 required modules missing:

* tqdm/4.66.2-GCCcore-13.2.0 (tqdm-4.66.2-GCCcore-13.2.0.eb)
* scikit-learn/1.4.0-gfbf-2023b (scikit-learn-1.4.0-gfbf-2023b.eb)
* NLTK/3.8.1-foss-2023b (NLTK-3.8.1-foss-2023b.eb)
```