### PR TITLE
{2023.06}[foss/2022b] SEPP v4.5.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -4,3 +4,4 @@ easyconfigs:
         from-pr: 20379
   - ParaView-5.11.1-foss-2022b.eb
   - ASE-3.22.1-gfbf-2022b.eb
+  - SEPP-4.5.1-foss-2022b.eb


### PR DESCRIPTION
```
2 out of 43 required modules missing:

* DendroPy/4.5.2-GCCcore-12.2.0 (DendroPy-4.5.2-GCCcore-12.2.0.eb)
* SEPP/4.5.1-foss-2022b (SEPP-4.5.1-foss-2022b.eb)
```