### PR TITLE
{2023.06}[gompi/2023a] BLAST+ v2.14.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -17,3 +17,6 @@ easyconfigs:
         from-pr: 20595
   - GATK-4.5.0.0-GCCcore-12.3.0-Java-17.eb
   - WhatsHap-2.2-foss-2023a.eb
+  - BLAST+-2.14.1-gompi-2023a.eb:
+      options:     
+        from-pr: 20751

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -19,4 +19,4 @@ easyconfigs:
   - WhatsHap-2.2-foss-2023a.eb
   - BLAST+-2.14.1-gompi-2023a.eb:
       options:     
-        from-pr: 20751
+        from-pr: 20784


### PR DESCRIPTION
```
2 out of 39 required modules missing:

* cpio/2.15-GCCcore-12.3.0 (cpio-2.15-GCCcore-12.3.0.eb)
* BLAST+/2.14.1-gompi-2023a (BLAST+-2.14.1-gompi-2023a.eb)
```