### PR TITLE
{2023.06}[foss/2023a] OrthoFinder v2.5.5

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -20,3 +20,4 @@ easyconfigs:
   - BLAST+-2.14.1-gompi-2023a.eb:
       options:     
         from-pr: 20784
+  - OrthoFinder-2.5.5-foss-2023a.eb


### PR DESCRIPTION
6 required modules missing: :
```
cimfomfa/22.273-GCCcore-12.3.0.lua
DIAMOND/2.1.8-GCC-12.3.0.lua
FastME/2.1.6.3-GCC-12.3.0.lua
MCL/22.282-GCCcore-12.3.0.lua
MMseqs2/14-7e284-gompi-2023a.lua
OrthoFinder/2.5.5-foss-2023a.lua
```