### PR TITLE
[WIP] DEBUG only {2023.06,2023a} PyTorch-bundle v2.1.2

### DIFF
--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -249,6 +249,12 @@ if command_exists "nvidia-smi"; then
     ${EESSI_PREFIX}/scripts/gpu_support/nvidia/link_nvidia_host_libraries.sh
 fi
 
+# Install extra software that is needed (e.g., for providing a custom ctypes
+# library when needed)
+cd ${TOPDIR}/scripts/extra
+./install_extra_packages.sh --temp-dir /tmp/temp --easystack eessi-2023.06-extra-packages.yml
+cd ${TOPDIR}
+
 # use PR patch file to determine in which easystack files stuff was added
 changed_easystacks=$(cat ${pr_diff} | grep '^+++' | cut -f2 -d' ' | sed 's@^[a-z]/@@g' | grep '^easystacks/.*yml$' | egrep -v 'known-issues|missing') 
 if [ -z "${changed_easystacks}" ]; then

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -18,7 +18,11 @@ easyconfigs:
   - GATK-4.5.0.0-GCCcore-12.3.0-Java-17.eb
   - WhatsHap-2.2-foss-2023a.eb
   - BLAST+-2.14.1-gompi-2023a.eb:
-      options:     
+      options:
         from-pr: 20784
   - Valgrind-3.21.0-gompi-2023a.eb
   - OrthoFinder-2.5.5-foss-2023a.eb
+  - PyTorch-bundle-2.1.2-foss-2023a.eb:
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20382
+      options:
+        from-pr: 20382

--- a/scripts/extra/custom_ctypes-1.2.eb
+++ b/scripts/extra/custom_ctypes-1.2.eb
@@ -1,0 +1,29 @@
+##
+# This is a contribution from the NESSI project
+# Homepage: 	https://documentation.sigma2.no
+#
+# Authors::	Thomas Roeblitz <thomas.roblitz@uib.no>
+# License::	GPL-2.0-only
+#
+##
+
+easyblock = 'Tarball'
+
+name = 'custom_ctypes'
+version = '1.2'
+
+homepage = 'https://github.com/ComputeCanada/custom_ctypes'
+description = """custum_ctypes is a small Python package to fix the discovery of libraries with Python's ctypes module. It changes the behavior of find_library to return absolute paths to shared objects rather than just the names."""
+
+toolchain = SYSTEM
+
+source_urls = ['https://github.com/ComputeCanada/custom_ctypes/archive/refs/tags']
+sources = ['%(version)s.tar.gz']
+checksums = ['3b30ce633c6a329169f2b10ff24b8eaaeef3fa208a66cdacdb53c22f02a88d9b']
+
+sanity_check_paths = {
+    'files': ['README.md'],
+    'dirs': ['lib'],
+}
+
+moduleclass = 'lib'

--- a/scripts/extra/eessi-2023.06-extra-packages.yml
+++ b/scripts/extra/eessi-2023.06-extra-packages.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - custom_ctypes-1.2.eb

--- a/scripts/extra/install_extra_packages.sh
+++ b/scripts/extra/install_extra_packages.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# This script can be used to install extra packages under ${EESSI_SOFTWARE_PATH}
+
+# some logging
+echo ">>> Running ${BASH_SOURCE}"
+
+# Initialise our bash functions
+TOPDIR=$(dirname $(realpath ${BASH_SOURCE}))
+source "${TOPDIR}"/../utils.sh
+
+# Function to display help message
+show_help() {
+    echo "Usage: $0 [OPTIONS]"
+    echo "Options:"
+    echo "  --help                           Display this help message"
+    echo "  -e, --easystack EASYSTACKFILE    Easystack file which specifies easyconfigs to be installed."
+    echo "  -t, --temp-dir /path/to/tmpdir   Specify a location to use for temporary"
+    echo "                                   storage during the installation"
+}
+
+# Initialize variables
+TEMP_DIR=
+EASYSTACK_FILE=
+
+# Parse command-line options
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help)
+            show_help
+            exit 0
+            ;;
+        -e|--easystack)
+            if [ -n "$2" ]; then
+                EASYSTACK_FILE="$2"
+                shift 2
+            else
+                echo "Error: Argument required for $1"
+                show_help
+                exit 1
+            fi
+            ;;
+        -t|--temp-dir)
+            if [ -n "$2" ]; then
+                TEMP_DIR="$2"
+                shift 2
+            else
+                echo "Error: Argument required for $1"
+                show_help
+                exit 1
+            fi
+            ;;
+        *)
+            show_help
+            fatal_error "Error: Unknown option: $1"
+            ;;
+    esac
+done
+
+if [[ -z ${EASYSTACK_FILE} ]]; then
+    show_help
+    fatal_error "Error: need to specify easystack file"
+fi
+
+# Make sure NESSI is initialised
+check_eessi_initialised
+
+# As an installation location just use $EESSI_SOFTWARE_PATH
+export NESSI_CVMFS_INSTALL=${EESSI_SOFTWARE_PATH}
+
+# we need a directory we can use for temporary storage
+if [[ -z "${TEMP_DIR}" ]]; then
+    tmpdir=$(mktemp -d)
+else
+    mkdir -p ${TEMP_DIR}
+    tmpdir=$(mktemp -d --tmpdir=${TEMP_DIR} extra.XXX)
+    if [[ ! -d "$tmpdir" ]] ; then
+        fatal_error "Could not create directory ${tmpdir}"
+    fi
+fi
+echo "Created temporary directory '${tmpdir}'"
+export WORKING_DIR=${tmpdir}
+
+# load EasyBuild
+ml EasyBuild
+
+# load NESSI-extend/2023.06-easybuild
+ml NESSI-extend/2023.06-easybuild
+
+eb --show-config
+
+eb --easystack ${EASYSTACK_FILE} --robot
+
+# clean up tmpdir
+rm -rf "${tmpdir}"


### PR DESCRIPTION
The main purpose of this PR is to facilitate debugging various issues when building PyTorch-bundle _and_ demonstrating approaches that could solve the issues. It is expected that the fixes provided here are not final.

- includes a fix for `find_library` provided by `ctypes.util` which prevented importing `sndfile`
- includes a fix for `aarch64/generic` where importing `sentencepiece` lead to the error `libtcmalloc_minimal.so.4: cannot allocate memory in static TLS block`
- includes a fix for the extension `torchvision` where some library was not compiled with `jpeg` support, hence some tests failed

Initially we will disable all fixes, build for selected architectures and document the errors. We then enable fixes one-by-one and document the results (some error fixed, some new errors, ...).