### PR TITLE
{2023.06,zen4} add missing installations with foss/2023b

### DIFF
--- a/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.2-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.2-2023b.yml
@@ -1,2 +1,18 @@
 easyconfigs:
   - GROMACS-2024.1-foss-2023b.eb
+  - netCDF-4.9.2-gompi-2023b.eb
+  - matplotlib-3.8.2-gfbf-2023b.eb
+  - DP3-6.0-foss-2023b.eb
+  - WSClean-3.4-foss-2023b.eb
+  - CDO-2.2.2-gompi-2023b.eb
+  - python-casacore-3.5.2-foss-2023b.eb
+  - libspatialindex-1.9.3-GCCcore-13.2.0.eb
+  - LittleCMS-2.15-GCCcore-13.2.0.eb
+  - giflib-5.2.1-GCCcore-13.2.0.eb
+  - OpenJPEG-2.5.0-GCCcore-13.2.0.eb
+  - libwebp-1.3.2-GCCcore-13.2.0.eb
+  - Wayland-1.22.0-GCCcore-13.2.0.eb
+  - Qt5-5.15.13-GCCcore-13.2.0.eb
+  - OSU-Micro-Benchmarks-7.2-gompi-2023b.eb
+  - NLTK-3.8.1-foss-2023b.eb
+  - Valgrind-3.23.0-gompi-2023b.eb


### PR DESCRIPTION
This should add all software we currently have installed for the other CPU targets to `x86_64/amd/zen4`.

This includes a couple of "expensive" builds like X11 and Qt5, so we may need to split this up in smaller chunks, we'll see...

```
86 out of 146 required modules missing:
```

<details>

```
* giflib/5.2.1-GCCcore-13.2.0 (giflib-5.2.1-GCCcore-13.2.0.eb)
* libpng/1.6.40-GCCcore-13.2.0 (libpng-1.6.40-GCCcore-13.2.0.eb)
* Bison/3.8.2-GCCcore-13.2.0 (Bison-3.8.2-GCCcore-13.2.0.eb)
* NASM/2.16.01-GCCcore-13.2.0 (NASM-2.16.01-GCCcore-13.2.0.eb)
* libiconv/1.17-GCCcore-13.2.0 (libiconv-1.17-GCCcore-13.2.0.eb)
* Szip/2.1.1-GCCcore-13.2.0 (Szip-2.1.1-GCCcore-13.2.0.eb)
* ecBuild/3.8.0 (ecBuild-3.8.0.eb)
* jbigkit/2.1-GCCcore-13.2.0 (jbigkit-2.1-GCCcore-13.2.0.eb)
* PCRE/8.45-GCCcore-13.2.0 (PCRE-8.45-GCCcore-13.2.0.eb)
* cppy/1.2.1-GCCcore-13.2.0 (cppy-1.2.1-GCCcore-13.2.0.eb)
* CFITSIO/4.3.1-GCCcore-13.2.0 (CFITSIO-4.3.1-GCCcore-13.2.0.eb)
* re2c/3.1-GCCcore-13.2.0 (re2c-3.1-GCCcore-13.2.0.eb)
* tqdm/4.66.2-GCCcore-13.2.0 (tqdm-4.66.2-GCCcore-13.2.0.eb)
* libjpeg-turbo/3.0.1-GCCcore-13.2.0 (libjpeg-turbo-3.0.1-GCCcore-13.2.0.eb)
* Doxygen/1.9.8-GCCcore-13.2.0 (Doxygen-1.9.8-GCCcore-13.2.0.eb)
* libspatialindex/1.9.3-GCCcore-13.2.0 (libspatialindex-1.9.3-GCCcore-13.2.0.eb)
* LittleCMS/2.15-GCCcore-13.2.0 (LittleCMS-2.15-GCCcore-13.2.0.eb)
* GSL/2.7-GCC-13.2.0 (GSL-2.7-GCC-13.2.0.eb)
* double-conversion/3.3.0-GCCcore-13.2.0 (double-conversion-3.3.0-GCCcore-13.2.0.eb)
* ICU/74.1-GCCcore-13.2.0 (ICU-74.1-GCCcore-13.2.0.eb)
* JasPer/4.0.0-GCCcore-13.2.0 (JasPer-4.0.0-GCCcore-13.2.0.eb)
* libdeflate/1.19-GCCcore-13.2.0 (libdeflate-1.19-GCCcore-13.2.0.eb)
* libidn2/2.3.2-GCCcore-13.2.0 (libidn2-2.3.2-GCCcore-13.2.0.eb)
* Brotli/1.1.0-GCCcore-13.2.0 (Brotli-1.1.0-GCCcore-13.2.0.eb)
* gzip/1.13-GCCcore-13.2.0 (gzip-1.13-GCCcore-13.2.0.eb)
* Wayland/1.22.0-GCCcore-13.2.0 (Wayland-1.22.0-GCCcore-13.2.0.eb)
* wget/1.21.4-GCCcore-13.2.0 (wget-1.21.4-GCCcore-13.2.0.eb)
* freetype/2.13.2-GCCcore-13.2.0 (freetype-2.13.2-GCCcore-13.2.0.eb)
* libaec/1.0.6-GCCcore-13.2.0 (libaec-1.0.6-GCCcore-13.2.0.eb)
* lz4/1.9.4-GCCcore-13.2.0 (lz4-1.9.4-GCCcore-13.2.0.eb)
* zstd/1.5.5-GCCcore-13.2.0 (zstd-1.5.5-GCCcore-13.2.0.eb)
* Boost/1.83.0-GCC-13.2.0 (Boost-1.83.0-GCC-13.2.0.eb)
* Boost.Python/1.83.0-GCC-13.2.0 (Boost.Python-1.83.0-GCC-13.2.0.eb)
* LibTIFF/4.6.0-GCCcore-13.2.0 (LibTIFF-4.6.0-GCCcore-13.2.0.eb)
* OpenJPEG/2.5.0-GCCcore-13.2.0 (OpenJPEG-2.5.0-GCCcore-13.2.0.eb)
* libwebp/1.3.2-GCCcore-13.2.0 (libwebp-1.3.2-GCCcore-13.2.0.eb)
* Pillow/10.2.0-GCCcore-13.2.0 (Pillow-10.2.0-GCCcore-13.2.0.eb)
* Qhull/2020.2-GCCcore-13.2.0 (Qhull-2020.2-GCCcore-13.2.0.eb)
* UDUNITS/2.2.28-GCCcore-13.2.0 (UDUNITS-2.2.28-GCCcore-13.2.0.eb)
* PCRE2/10.42-GCCcore-13.2.0 (PCRE2-10.42-GCCcore-13.2.0.eb)
* googletest/1.14.0-GCCcore-13.2.0 (googletest-1.14.0-GCCcore-13.2.0.eb)
* GLib/2.78.1-GCCcore-13.2.0 (GLib-2.78.1-GCCcore-13.2.0.eb)
* nlohmann_json/3.11.3-GCCcore-13.2.0 (nlohmann_json-3.11.3-GCCcore-13.2.0.eb)
* Lua/5.4.6-GCCcore-13.2.0 (Lua-5.4.6-GCCcore-13.2.0.eb)
* fontconfig/2.14.2-GCCcore-13.2.0 (fontconfig-2.14.2-GCCcore-13.2.0.eb)
* PROJ/9.3.1-GCCcore-13.2.0 (PROJ-9.3.1-GCCcore-13.2.0.eb)
* X11/20231019-GCCcore-13.2.0 (X11-20231019-GCCcore-13.2.0.eb)
* Tk/8.6.13-GCCcore-13.2.0 (Tk-8.6.13-GCCcore-13.2.0.eb)
* PGPLOT/5.2.2-GCCcore-13.2.0 (PGPLOT-5.2.2-GCCcore-13.2.0.eb)
* Tkinter/3.11.5-GCCcore-13.2.0 (Tkinter-3.11.5-GCCcore-13.2.0.eb)
* WCSLIB/7.11-GCC-13.2.0 (WCSLIB-7.11-GCC-13.2.0.eb)
* graphite2/1.3.14-GCCcore-13.2.0 (graphite2-1.3.14-GCCcore-13.2.0.eb)
* HDF5/1.14.3-gompi-2023b (HDF5-1.14.3-gompi-2023b.eb)
* netCDF/4.9.2-gompi-2023b (netCDF-4.9.2-gompi-2023b.eb)
* OSU-Micro-Benchmarks/7.2-gompi-2023b (OSU-Micro-Benchmarks-7.2-gompi-2023b.eb)
* Valgrind/3.23.0-gompi-2023b (Valgrind-3.23.0-gompi-2023b.eb)
* ecCodes/2.31.0-gompi-2023b (ecCodes-2.31.0-gompi-2023b.eb)
* IDG/1.2.0-foss-2023b (IDG-1.2.0-foss-2023b.eb)
* arpack-ng/3.9.0-foss-2023b (arpack-ng-3.9.0-foss-2023b.eb)
* CDO/2.2.2-gompi-2023b (CDO-2.2.2-gompi-2023b.eb)
* Armadillo/12.8.0-foss-2023b (Armadillo-12.8.0-foss-2023b.eb)
* pixman/0.42.2-GCCcore-13.2.0 (pixman-0.42.2-GCCcore-13.2.0.eb)
* cairo/1.18.0-GCCcore-13.2.0 (cairo-1.18.0-GCCcore-13.2.0.eb)
* GObject-Introspection/1.78.1-GCCcore-13.2.0 (GObject-Introspection-1.78.1-GCCcore-13.2.0.eb)
* HarfBuzz/8.2.2-GCCcore-13.2.0 (HarfBuzz-8.2.2-GCCcore-13.2.0.eb)
* scikit-learn/1.4.0-gfbf-2023b (scikit-learn-1.4.0-gfbf-2023b.eb)
* matplotlib/3.8.2-gfbf-2023b (matplotlib-3.8.2-gfbf-2023b.eb)
* NLTK/3.8.1-foss-2023b (NLTK-3.8.1-foss-2023b.eb)
* casacore/3.5.0-foss-2023b (casacore-3.5.0-foss-2023b.eb)
* EveryBeam/0.5.2-foss-2023b (EveryBeam-0.5.2-foss-2023b.eb)
* AOFlagger/3.4.0-foss-2023b (AOFlagger-3.4.0-foss-2023b.eb)
* DP3/6.0-foss-2023b (DP3-6.0-foss-2023b.eb)
* WSClean/3.4-foss-2023b (WSClean-3.4-foss-2023b.eb)
* python-casacore/3.5.2-foss-2023b (python-casacore-3.5.2-foss-2023b.eb)
* snappy/1.1.10-GCCcore-13.2.0 (snappy-1.1.10-GCCcore-13.2.0.eb)
* NSPR/4.35-GCCcore-13.2.0 (NSPR-4.35-GCCcore-13.2.0.eb)
* Mako/1.2.4-GCCcore-13.2.0 (Mako-1.2.4-GCCcore-13.2.0.eb)
* NSS/3.94-GCCcore-13.2.0 (NSS-3.94-GCCcore-13.2.0.eb)
* nodejs/20.9.0-GCCcore-13.2.0 (nodejs-20.9.0-GCCcore-13.2.0.eb)
* libdrm/2.4.117-GCCcore-13.2.0 (libdrm-2.4.117-GCCcore-13.2.0.eb)
* libglvnd/1.7.0-GCCcore-13.2.0 (libglvnd-1.7.0-GCCcore-13.2.0.eb)
* libunwind/1.6.2-GCCcore-13.2.0 (libunwind-1.6.2-GCCcore-13.2.0.eb)
* LLVM/16.0.6-GCCcore-13.2.0 (LLVM-16.0.6-GCCcore-13.2.0.eb)
* Mesa/23.1.9-GCCcore-13.2.0 (Mesa-23.1.9-GCCcore-13.2.0.eb)
* libGLU/9.0.3-GCCcore-13.2.0 (libGLU-9.0.3-GCCcore-13.2.0.eb)
* Qt5/5.15.13-GCCcore-13.2.0 (Qt5-5.15.13-GCCcore-13.2.0.eb)
```