### PR TITLE
{2023.06}[GCCcore/13.2.0] IPython v8.17.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - IPython-8.17.2-GCCcore-13.2.0.eb


### PR DESCRIPTION
```
7 out of 35 required modules missing:

* libsodium/1.0.19-GCCcore-13.2.0 (libsodium-1.0.19-GCCcore-13.2.0.eb)
* libxslt/1.1.38-GCCcore-13.2.0 (libxslt-1.1.38-GCCcore-13.2.0.eb)
* lxml/4.9.3-GCCcore-13.2.0 (lxml-4.9.3-GCCcore-13.2.0.eb)
* OpenPGM/5.2.122-GCCcore-13.2.0 (OpenPGM-5.2.122-GCCcore-13.2.0.eb)
* jedi/0.19.1-GCCcore-13.2.0 (jedi-0.19.1-GCCcore-13.2.0.eb)
* ZeroMQ/4.3.5-GCCcore-13.2.0 (ZeroMQ-4.3.5-GCCcore-13.2.0.eb)
* IPython/8.17.2-GCCcore-13.2.0 (IPython-8.17.2-GCCcore-13.2.0.eb)
```