### PR TITLE
use latest Ubuntu in CI workflows

### DIFF
--- a/.github/workflows/test-software.eessi.io.yml
+++ b/.github/workflows/test-software.eessi.io.yml
@@ -5,7 +5,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
   check_missing:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_eessi_container_script.yml
+++ b/.github/workflows/test_eessi_container_script.yml
@@ -5,7 +5,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
   eessi_container_script:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_licenses.yml
+++ b/.github/workflows/test_licenses.yml
@@ -5,7 +5,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
         - name: Check out software-layer repository
           uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8, 3.9, '3.10']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python: [3.7, 3.8, 3.9, '3.10']
       fail-fast: false
     steps:
     - name: checkout

--- a/.github/workflows/tests_archdetect.yml
+++ b/.github/workflows/tests_archdetect.yml
@@ -5,7 +5,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         proc_cpuinfo:

--- a/.github/workflows/tests_init.yml
+++ b/.github/workflows/tests_init.yml
@@ -5,7 +5,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8, 3.9, '3.10']

--- a/.github/workflows/tests_init.yml
+++ b/.github/workflows/tests_init.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python: [3.7, 3.8, 3.9, '3.10']
       fail-fast: false
     steps:
     - name: checkout

--- a/.github/workflows/tests_readme.yml
+++ b/.github/workflows/tests_readme.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
         - name: Check out software-layer repository
           uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/tests_scripts.yml
+++ b/.github/workflows/tests_scripts.yml
@@ -28,7 +28,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
fix for:
```
Running cvmfs_config setup
  sudo: cvmfs_config: command not found
  !!! github-action-cvmfs FAILED !!!
  cvmfs_config setup exited with 1
```

which occurs because apt repository can't be found anymore (since 21 June):
```
   Err:2 http://security.ubuntu.com/ubuntu focal-updates/main amd64 gdb amd64 9.2-0ubuntu1~20.04.1
    404  Not Found [IP: 40.81.13.82 80]
  Err:3 http://security.ubuntu.com/ubuntu focal-updates/main amd64 gdbserver amd64 9.2-0ubuntu1~20.04.1
    404  Not Found [IP: 40.81.13.82 80]
  E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gdb/gdb_9.2-0ubuntu1~20.04.1_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
  E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gdb/gdbserver_9.2-0ubuntu1~20.04.1_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
  E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```