### PR TITLE
Workaround to fix broken curl installation

### DIFF
--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -15,6 +15,20 @@ function show_msg {
   fi
 }
 
+function check_rhel_ca {
+
+  os=$(grep -oP '(?<=^ID_LIKE=).+' /etc/os-release | tr -d '"')
+
+  version_id=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"')
+  version_major=${version_id%\.*}
+
+  if [[ $os =~ "rhel" ]] && [ $version_major -gt 7 ]
+  then
+        export CURL_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
+  fi
+}
+
+
 # set up minimal environment: $EESSI_PREFIX, $EESSI_VERSION, $EESSI_OS_TYPE, $EESSI_CPU_FAMILY, $EPREFIX
 source $EESSI_INIT_DIR_PATH/minimal_eessi_env
 
@@ -106,6 +120,8 @@ if [ -d $EESSI_PREFIX ]; then
             false
           fi
 
+        # Fix wrong path for RHEL >=8 libcurl 
+	check_rhel_ca
 
         else
           error "EESSI software layer at $EESSI_SOFTWARE_PATH not found!"

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -15,20 +15,6 @@ function show_msg {
   fi
 }
 
-function check_rhel_ca {
-
-  os=$(grep -oP '(?<=^ID_LIKE=).+' /etc/os-release | tr -d '"')
-
-  version_id=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"')
-  version_major=${version_id%\.*}
-
-  if [[ $os =~ "rhel" ]] && [ $version_major -gt 7 ]
-  then
-        export CURL_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
-  fi
-}
-
-
 # set up minimal environment: $EESSI_PREFIX, $EESSI_VERSION, $EESSI_OS_TYPE, $EESSI_CPU_FAMILY, $EPREFIX
 source $EESSI_INIT_DIR_PATH/minimal_eessi_env
 
@@ -121,7 +107,11 @@ if [ -d $EESSI_PREFIX ]; then
           fi
 
         # Fix wrong path for RHEL >=8 libcurl 
-	check_rhel_ca
+	rhel_libcurl_file="/etc/pki/tls/certs/ca-bundle.crt"
+        if [ -f $rhel_libcurl_file ]; then
+          show_msg "Found libcurl CAs file at RHEL location, setting CURL_CA_BUNDLE"
+          export CURL_CA_BUNDLE=$rhel_libcurl_file
+        fi
 
         else
           error "EESSI software layer at $EESSI_SOFTWARE_PATH not found!"

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -106,15 +106,15 @@ if [ -d $EESSI_PREFIX ]; then
             false
           fi
 
-        # Fix wrong path for RHEL >=8 libcurl 
-	# This is required here because we ship curl in our compat layer. If we only provided
-	# curl as a module file we could instead do this via a `modluafooter` in an EasyBuild
-	# hook (or via an Lmod hook)
-	rhel_libcurl_file="/etc/pki/tls/certs/ca-bundle.crt"
-        if [ -f $rhel_libcurl_file ]; then
-          show_msg "Found libcurl CAs file at RHEL location, setting CURL_CA_BUNDLE"
-          export CURL_CA_BUNDLE=$rhel_libcurl_file
-        fi
+          # Fix wrong path for RHEL >=8 libcurl 
+	  # This is required here because we ship curl in our compat layer. If we only provided
+	  # curl as a module file we could instead do this via a `modluafooter` in an EasyBuild
+	  # hook (or via an Lmod hook)
+	  rhel_libcurl_file="/etc/pki/tls/certs/ca-bundle.crt"
+          if [ -f $rhel_libcurl_file ]; then
+            show_msg "Found libcurl CAs file at RHEL location, setting CURL_CA_BUNDLE"
+            export CURL_CA_BUNDLE=$rhel_libcurl_file
+          fi
 
         else
           error "EESSI software layer at $EESSI_SOFTWARE_PATH not found!"

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -107,6 +107,9 @@ if [ -d $EESSI_PREFIX ]; then
           fi
 
         # Fix wrong path for RHEL >=8 libcurl 
+	# This is required here because we ship curl in our compat layer. If we only provided
+	# curl as a module file we could instead do this via a `modluafooter` in an EasyBuild
+	# hook (or via an Lmod hook)
 	rhel_libcurl_file="/etc/pki/tls/certs/ca-bundle.crt"
         if [ -f $rhel_libcurl_file ]; then
           show_msg "Found libcurl CAs file at RHEL location, setting CURL_CA_BUNDLE"


### PR DESCRIPTION
As reported in the EESSI support portal issue [#25](https://gitlab.com/eessi/support/-/issues/25), curl fails in RHEL 8 and above systems as CA files location differs. Works for all rhel based systems as I could reproduce the issue also in them.

```
$ cat /etc/os-release 
NAME="Rocky Linux"
VERSION="9.3 (Blue Onyx)"
ID="rocky"
ID_LIKE="rhel centos fedora"

$ source software-layer/init/bash 
Found EESSI repo @ /cvmfs/software.eessi.io/versions/2023.06!
archdetect says x86_64/intel/skylake_avx512
Using x86_64/intel/skylake_avx512 as software subdirectory.
[...]
Environment set up to use EESSI (2023.06), have fun!

{EESSI 2023.06} $ ml CMake
{EESSI 2023.06} $ curl https://www.example.com
<!doctype html>
<html>
<head>
    <title>Example Domain</title>
[...]
```

I am not a fan of hardcording in the init script but investigating the issue I haven't found a more suitable way to solve it for our use case. Maybe another solution would be to add a modlua footer exporting this variable in the affected modules? 