### PR TITLE
{2023.06,2023a,zen4} Highway v1.0.4 with fix for failing test

### DIFF
--- a/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -15,4 +15,4 @@ easyconfigs:
   - Highway-1.0.4-GCCcore-12.3.0.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20942
-        from-pr: 20942
+        from-commit: 524da37b903585cea5a9eeb4156d1c8d57636bd8

--- a/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -2,7 +2,8 @@ easyconfigs:
   - ESPResSo-4.2.2-foss-2023a.eb
   - TensorFlow-2.13.0-foss-2023a.eb
   - R-4.3.2-gfbf-2023a.eb
-  - Highway-1.0.4-GCCcore-12.3.0.eb:
-      options:
-        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20942
-        from-pr: 20942
+  - Highway-1.0.4-GCCcore-12.3.0.eb
+  #- Highway-1.0.4-GCCcore-12.3.0.eb:
+  #    options:
+  #      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20942
+  #      from-pr: 20942

--- a/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -11,7 +11,6 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20958
         from-commit: dbadb2074464d816740ee0e95595c2cb31b6338f
-  #- Highway-1.0.4-GCCcore-12.3.0.eb
   - Highway-1.0.4-GCCcore-12.3.0.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20942

--- a/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -2,3 +2,7 @@ easyconfigs:
   - ESPResSo-4.2.2-foss-2023a.eb
   - TensorFlow-2.13.0-foss-2023a.eb
   - R-4.3.2-gfbf-2023a.eb
+  - Highway-1.0.4-GCCcore-12.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20942
+        from-pr: 20942


### PR DESCRIPTION
This is mainly for testing if a patch provided in https://github.com/easybuilders/easybuild-easyconfigs/pull/20942 fixes a failing test. See https://github.com/EESSI/software-layer/pull/613