### PR TITLE
{2023.06}[GCC/12.3.0] BCFtools v1.18

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - BCFtools-1.18-GCC-12.3.0.eb


### PR DESCRIPTION
```
2 out of 8 required modules missing:

* HTSlib/1.18-GCC-12.3.0 (HTSlib-1.18-GCC-12.3.0.eb)
* BCFtools/1.18-GCC-12.3.0 (BCFtools-1.18-GCC-12.3.0.eb)
```