### PR TITLE
{2023.06}[GCCcore/12.3.0-GCC/12.3.0-gompi/2023a] bio-packages

### DIFF
--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -26,7 +26,8 @@ if [ ! -d ${software_dir} ]; then
     exit 2
 fi
 
-overlay_upper_dir="${eessi_tmpdir}/overlay-upper"
+cvmfs_repo_name=${cvmfs_repo#/cvmfs/}
+overlay_upper_dir="${eessi_tmpdir}/${cvmfs_repo_name}/overlay-upper"
 
 software_dir_overlay="${overlay_upper_dir}/versions/${eessi_version}"
 if [ ! -d ${software_dir_overlay} ]; then

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -1,2 +1,17 @@
 easyconfigs:
   - BCFtools-1.18-GCC-12.3.0.eb
+  - BWA-0.7.18-GCCcore-12.3.0.eb
+  - CapnProto-1.0.1-GCCcore-12.3.0.eb
+  - DendroPy-4.6.1-GCCcore-12.3.0.eb
+  - DIAMOND-2.1.8-GCC-12.3.0.eb
+  - FastME-2.1.6.3-GCC-12.3.0.eb
+  - fastp-0.23.4-GCC-12.3.0.eb
+  - HMMER-3.4-gompi-2023a.eb
+  - IQ-TREE-2.3.5-gompi-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20955
+        from-commit: 185f88b9a03d65a7fb74edc7acb4221e87e90784      
+  - KronaTools-2.8.1-GCCcore-12.3.0.eb
+  - LSD2-2.4.1-GCCcore-12.3.0.eb
+  - MAFFT-7.520-GCC-12.3.0-with-extensions.eb
+  - ncbi-vdb-3.0.10-gompi-2023a.e

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -14,4 +14,4 @@ easyconfigs:
   - KronaTools-2.8.1-GCCcore-12.3.0.eb
   - LSD2-2.4.1-GCCcore-12.3.0.eb
   - MAFFT-7.520-GCC-12.3.0-with-extensions.eb
-  - ncbi-vdb-3.0.10-gompi-2023a.e
+  - ncbi-vdb-3.0.10-gompi-2023a.eb


### PR DESCRIPTION
```
missing packages :

BWA-0.7.17-GCCcore-12.3.0.
CapnProto-1.0.1-GCCcore-12.3.0
DendroPy-4.6.1-GCCcore-12.3.0
DIAMOND-2.1.8-GCC-12.3.0 
FastME-2.1.6.3-GCC-12.3.0
fastp-0.23.4-GCC-12.3.0
HMMER-3.4-gompi-2023a
IQ-TREE-2.3.5-gompi-2023a
KronaTools-2.8.1-GCCcore-12.3.0
LSD2-2.4.1-GCCcore-12.3.0
MAFFT-7.520-GCC-12.3.0-with-extensions
ncbi-vdb-3.0.10-gompi-2023a
```