### PR TITLE
Fix path to overlay upper directory in create_tarball.sh

### DIFF
--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -26,7 +26,7 @@ if [ ! -d ${software_dir} ]; then
     exit 2
 fi
 
-overlay_upper_dir="${eessi_tmpdir}/overlay-upper"
+overlay_upper_dir="${eessi_tmpdir}/${cvmfs_repo}/overlay-upper"
 
 software_dir_overlay="${overlay_upper_dir}/versions/${eessi_version}"
 if [ ! -d ${software_dir_overlay} ]; then


### PR DESCRIPTION
#618 introduced a new structure where each repo has its own overlay-upper dir, see https://github.com/EESSI/software-layer/blob/2023.06-software.eessi.io/eessi_container.sh#L410 and https://github.com/EESSI/software-layer/blob/2023.06-software.eessi.io/eessi_container.sh#L744. This was not changed in the tarball script yet, leading to errors in https://github.com/EESSI/software-layer/pull/634:
```
Software directory overlay /tmp/overlay-upper/versions/2023.06 does not exist?!
```