### PR TITLE
Remove `/cvmfs/` in path to overlay upper directory in tarball script

### DIFF
--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -26,7 +26,8 @@ if [ ! -d ${software_dir} ]; then
     exit 2
 fi
 
-overlay_upper_dir="${eessi_tmpdir}/${cvmfs_repo}/overlay-upper"
+cvmfs_repo_name=${cvmfs_repo#/cvmfs/}
+overlay_upper_dir="${eessi_tmpdir}/${cvmfs_repo_name}/overlay-upper"
 
 software_dir_overlay="${overlay_upper_dir}/versions/${eessi_version}"
 if [ ! -d ${software_dir_overlay} ]; then


### PR DESCRIPTION
Follow-up to #635 , which didn't fully fix the issue. The `cvmfs_repo` variable not only contained the repo name, but also had a leading `/cvmfs`. This has to be removed when setting the path to the overlay upper directory, which looks like `/tmp/<repo name>/overlay-upper`.