### PR TITLE
rebuild OpenFOAM-10-foss-2023a.eb and OpenFOAM-11-foss-2023a.eb without `-ftree-vectorize`

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20240706-eb-4.9.2-OpenFOAM-no-ftree-vectorize.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20240706-eb-4.9.2-OpenFOAM-no-ftree-vectorize.yml
@@ -1,0 +1,12 @@
+# 2024.07.06
+# OpenFOAM 10 and 11 built with GCC 11.3.0 or 12.3.0 and -ftree-vectorize yields incorrect results,
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/20927
+easyconfigs:
+  - OpenFOAM-10-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20958
+        from-commit: dbadb2074464d816740ee0e95595c2cb31b6338f
+  - OpenFOAM-11-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20958
+        from-commit: dbadb2074464d816740ee0e95595c2cb31b6338f


### PR DESCRIPTION
see also https://github.com/easybuilders/easybuild-easyconfigs/issues/20927