### PR TITLE
Allow initialisation scripts to be used with bash < 4.2

### DIFF
--- a/init/bash
+++ b/init/bash
@@ -1,7 +1,7 @@
 function show_msg {
   # only echo msg if EESSI_SILENT is unset
   msg=$1
-  if [[ ! -v EESSI_SILENT ]]; then
+  if [[ -z ${EESSI_SILENT+x} ]]; then
     echo "$msg"
   fi
 }

--- a/init/eessi_defaults
+++ b/init/eessi_defaults
@@ -12,7 +12,7 @@
 if [[ $(uname -m) == "riscv64" ]]; then
     export EESSI_CVMFS_REPO="${EESSI_CVMFS_REPO_OVERRIDE:=/cvmfs/riscv.eessi.io}"
     export EESSI_VERSION="${EESSI_VERSION_OVERRIDE:=20240402}"
-    if [[ ! -v EESSI_SILENT ]]; then
+    if [[ -z ${EESSI_SILENT+x} ]]; then
         echo "RISC-V architecture detected, but there is no RISC-V support yet in the production repository."
         echo "Automatically switching to version ${EESSI_VERSION} of the RISC-V development repository ${EESSI_CVMFS_REPO}."
         echo "For more details about this repository, see https://www.eessi.io/docs/repositories/riscv.eessi.io/."

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -10,7 +10,7 @@ function error() {
 function show_msg {
   # only echo msg if EESSI_SILENT is unset
   msg=$1
-  if [[ ! -v EESSI_SILENT ]]; then
+  if [[ -z ${EESSI_SILENT+x} ]]; then
     echo "$msg"
   fi
 }


### PR DESCRIPTION
If using a CentOS6 bash you get
```
-bash: /cvmfs/software.eessi.io/versions/2023.06/init/bash: line 4: conditional binary operator expected
-bash: /cvmfs/software.eessi.io/versions/2023.06/init/bash: line 4: syntax error near `EESSI_SILENT'
-bash: /cvmfs/software.eessi.io/versions/2023.06/init/bash: line 4: `  if [[ ! -v EESSI_SILENT ]]; then'
```
`-v` was introduced in Bash 4.2, but it's not hard for us to improve our backwards compatibility