### PR TITLE
prevent GObject-Introspection from setting EB-filtered environment variables

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20240719-eb-4.9.2-GObject-Introspection-filter-envvars.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20240719-eb-4.9.2-GObject-Introspection-filter-envvars.yml
@@ -1,0 +1,12 @@
+# 2024.07.19
+# GObject-Introspection sets $LD_LIBRARY_PATH (to many different paths, including $EPREFIX/lib)
+# when calling gcc, and this causes a lot of issues for, especially, scripts using /bin/bash.
+#
+# This rebuild ensures (by using a new EasyBuild hook) that GObject-Introspection will not set
+# environment variables that are configured to be filtered by EasyBuild.
+# 
+# See https://github.com/EESSI/software-layer/issues/196
+easyconfigs:
+  - GObject-Introspection-1.74.0-GCCcore-12.2.0.eb
+  - GObject-Introspection-1.76.1-GCCcore-12.3.0.eb
+  - GObject-Introspection-1.78.1-GCCcore-13.2.0.eb

--- a/easystacks/software.eessi.io/2023.06/rebuilds/20240719-eb-4.9.2-GObject-Introspection-filter-envvars.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20240719-eb-4.9.2-GObject-Introspection-filter-envvars.yml
@@ -10,3 +10,5 @@ easyconfigs:
   - GObject-Introspection-1.74.0-GCCcore-12.2.0.eb
   - GObject-Introspection-1.76.1-GCCcore-12.3.0.eb
   - GObject-Introspection-1.78.1-GCCcore-13.2.0.eb
+  - at-spi2-core-2.46.0-GCCcore-12.2.0.eb
+  - at-spi2-core-2.49.91-GCCcore-12.3.0.eb

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -486,21 +486,6 @@ def pre_configure_hook_wrf_aarch64(self, *args, **kwargs):
         raise EasyBuildError("WRF-specific hook triggered for non-WRF easyconfig?!")
 
 
-def pre_configure_hook_atspi2core_filter_ld_library_path(self, *args, **kwargs):
-    """
-    pre-configure hook for at-spi2-core:
-    - instruct GObject-Introspection's g-ir-scanner tool to not set $LD_LIBRARY_PATH
-      when EasyBuild is configured to filter it, see:
-      https://github.com/EESSI/software-layer/issues/196
-    """
-    if self.name == 'at-spi2-core':
-        if build_option('filter_env_vars') and 'LD_LIBRARY_PATH' in build_option('filter_env_vars'):
-            sed_cmd = 'sed -i "s/gir_extra_args = \[/gir_extra_args = \[\\n  \'--lib-dirs-envvar=FILTER_LD_LIBRARY_PATH\',/g" %(start_dir)s/atspi/meson.build && '
-            self.cfg.update('preconfigopts', sed_cmd)
-    else:
-        raise EasyBuildError("at-spi2-core-specific hook triggered for non-at-spi2-core easyconfig?!")
-
-
 def pre_test_hook(self,*args, **kwargs):
     """Main pre-test hook: trigger custom functions based on software name."""
     if self.name in PRE_TEST_HOOKS:
@@ -760,7 +745,6 @@ POST_PREPARE_HOOKS = {
 }
 
 PRE_CONFIGURE_HOOKS = {
-    'at-spi2-core': pre_configure_hook_atspi2core_filter_ld_library_path,
     'BLIS': pre_configure_hook_BLIS_a64fx,
     'GObject-Introspection': pre_configure_hook_gobject_introspection,
     'Extrae': pre_configure_hook_extrae,


### PR DESCRIPTION
This should properly fix #196. Instead of fixing it in all the packages that use GObject-Introspection to compile stuff, it changes GObject-Introspection itself and makes sure that it doesn't set $LD_LIBRARY_PATH (or any other variable) when EB is configured to filter it. 

I initially checked in the hook if EB was configured to filter $LD_LIBRARY_PATH and then used one of the following sed commands:
```
# always sets runtime_path_envvar = []
sed -i "s/runtime_path_envvar = .* \(if not.*\)/runtime_path_envvar = [] \1/g"
```
and
```
# only remove $LD_LIBRARY_PATH from the list
sed -i "s/\(runtime_path_envvar = .*\)\('LD_LIBRARY_PATH', \)\(.*\)/\1\3/g"
```

But in the end I went for another solution (which I found a bit cleaner, though the sed command is a bit longer/more complex), which is always applied by the hook, but changes the original line:
```
`runtime_path_envvar = ['LD_LIBRARY_PATH', 'DYLD_FALLBACK_LIBRARY_PATH'] if not lib_dirs_envvar else [lib_dirs_envvar]`
```
to
```
            runtime_path_envvar = ['LD_LIBRARY_PATH', 'DYLD_FALLBACK_LIBRARY_PATH'] if not lib_dirs_envvar else [lib_dirs_envvar]
            runtime_path_envvar =  [x for x in runtime_path_envvar if not x in os.environ.get('EASYBUILD_FILTER_ENV_VARS', '').split(',')]
```

I.e. it will remove items from that list if they're also in $EASYBUILD_FILTER_ENV_VARS. Note that this may not always work outside of EESSI, e.g. someone could pass this list via a CLI argument instead of an environment variable. But for EESSI it should always work as we do use an environment variable. 

I've tested this interactively and both GObject-Introspection itself installed without issues, but also the affected packages Pango, at-spi2-core, and GTK worked fine. I'll trigger some (re)builds here to verify this.