### PR TITLE
{zen4} prevent GObject-Introspection from setting EB-filtered environment variables

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20240719-eb-4.9.2-GObject-Introspection-filter-envvars-zen4.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20240719-eb-4.9.2-GObject-Introspection-filter-envvars-zen4.yml
@@ -1,0 +1,11 @@
+# 2024.07.19
+# GObject-Introspection sets $LD_LIBRARY_PATH (to many different paths, including $EPREFIX/lib)
+# when calling gcc, and this causes a lot of issues for, especially, scripts using /bin/bash.
+#
+# This rebuild ensures (by using a new EasyBuild hook) that GObject-Introspection will not set
+# environment variables that are configured to be filtered by EasyBuild.
+# 
+# See https://github.com/EESSI/software-layer/issues/196
+easyconfigs:
+  - GObject-Introspection-1.76.1-GCCcore-12.3.0.eb
+  - GObject-Introspection-1.78.1-GCCcore-13.2.0.eb


### PR DESCRIPTION
Requires #646, and this will do the rebuilds for zen4. For zen4 we didn't have any at-spi2-core versions yet, and no GObject-Introspection for GCC 12.2.0 either.