### PR TITLE
Use `readlink -f` instead of `realpath` (CentOS6)

### DIFF
--- a/init/eessi_archdetect.sh
+++ b/init/eessi_archdetect.sh
@@ -89,7 +89,7 @@ cpupath(){
         *) log "ERROR" "cpupath: Unsupported CPU architecture $machine_type"
     esac
     # spec files are located in a subfolder with this script
-    local base_dir=$(dirname $(realpath $0))
+    local base_dir=$(dirname $(readlink -f $0))
     update_arch_specs "$base_dir/arch_specs/${spec_file}"
   
     # Identify the host CPU vendor

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -1,6 +1,6 @@
 # this script is *sourced*, not executed, so can't rely on $0 to determine path to self
 # $BASH_SOURCE points to correct path, see also http://mywiki.wooledge.org/BashFAQ/028
-EESSI_INIT_DIR_PATH=$(dirname $(realpath $BASH_SOURCE))
+EESSI_INIT_DIR_PATH=$(dirname $(readlink -f $BASH_SOURCE))
 
 function error() {
     echo -e "\e[31mERROR: $1\e[0m" >&2

--- a/init/minimal_eessi_env
+++ b/init/minimal_eessi_env
@@ -2,7 +2,7 @@
 #
 # this script is *sourced*, not executed, so can't rely on $0 to determine path to self
 # $BASH_SOURCE points to correct path, see also http://mywiki.wooledge.org/BashFAQ/028
-EESSI_INIT_DIR_PATH=$(dirname $(realpath $BASH_SOURCE))
+EESSI_INIT_DIR_PATH=$(dirname $(readlink -f $BASH_SOURCE))
 
 # set up defaults: EESSI_CVMFS_REPO, EESSI_VERSION
 #   script takes *_OVERRIDEs into account


### PR DESCRIPTION
Final blocker for compatibility on CentOS6
```
[root@centos6 /]# if ! command -v realpath &> /dev/null; then
>     realpath() { readlink -f "$1"; }
>     export -f realpath
> fi
[root@centos6 /]# source /cvmfs/software.eessi.io/versions/2023.06/init/bash 
Found EESSI repo @ /cvmfs/software.eessi.io/versions/2023.06!
archdetect says x86_64/generic
Using x86_64/generic as software subdirectory.
Found Lmod configuration file at /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/generic/.lmod/lmodrc.lua
Found Lmod SitePackage.lua file at /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/generic/.lmod/SitePackage.lua
Using /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/generic/modules/all as the directory to be added to MODULEPATH.
Using /cvmfs/software.eessi.io/host_injections/2023.06/software/linux/x86_64/generic/modules/all as the site extension directory to be added to MODULEPATH.
Found libcurl CAs file at RHEL location, setting CURL_CA_BUNDLE
Initializing Lmod...
Prepending /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/generic/modules/all to $MODULEPATH...
Prepending site path /cvmfs/software.eessi.io/host_injections/2023.06/software/linux/x86_64/generic/modules/all to $MODULEPATH...
Environment set up to use EESSI (2023.06), have fun!
{EESSI 2023.06} [root@centos6 /]# module load GROMACS
{EESSI 2023.06} [root@centos6 /]# gmx --version
                 :-) GROMACS - gmx, 2024.1-EasyBuild_4.9.1 (-:

Executable:   /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/generic/software/GROMACS/2024.1-foss-2023b/bin/gmx
Data prefix:  /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/generic/software/GROMACS/2024.1-foss-2023b
Working dir:  /
Command line:
  gmx --version

GROMACS version:     2024.1-EasyBuild_4.9.1
Precision:           mixed
Memory model:        64 bit
MPI library:         thread_mpi
OpenMP support:      enabled (GMX_OPENMP_MAX_THREADS = 128)
GPU support:         disabled
SIMD instructions:   SSE2
CPU FFT library:     fftw-3.3.10-sse2
GPU FFT library:     none
Multi-GPU FFT:       none
RDTSCP usage:        enabled
TNG support:         enabled
Hwloc support:       disabled
Tracing support:     disabled
C compiler:          /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/generic/software/OpenMPI/4.1.6-GCC-13.2.0/bin/mpicc GNU 13.2.0
C compiler flags:    -fexcess-precision=fast -funroll-all-loops -msse2 -Wno-missing-field-initializers -O3 -DNDEBUG
C++ compiler:        /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/generic/software/OpenMPI/4.1.6-GCC-13.2.0/bin/mpicxx GNU 13.2.0
C++ compiler flags:  -fexcess-precision=fast -funroll-all-loops -msse2 -Wno-missing-field-initializers -Wno-cast-function-type-strict SHELL:-fopenmp -O3 -DNDEBUG
BLAS library:        External - user-supplied
LAPACK library:      External - user-supplied
```