### PR TITLE
{2023.06}[gompi/2022b] BLAST+ V2.14.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - BLAST+-2.14.0-gompi-2022b.eb:
+      options:
+        from-commit: 1775912a1d36101d560e1355967732b07e82cd24

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
@@ -1,4 +1,2 @@
 easyconfigs:
-  - BLAST+-2.14.0-gompi-2022b.eb:
-      options:
-        from-commit: 1775912a1d36101d560e1355967732b07e82cd24
+  - BLAST+-2.14.0-gompi-2022b.eb


### PR DESCRIPTION
```
missing packages:

BLAST+/2.14.0-gompi-2022b
cpio/2.15-GCCcore-12.2.0
LMDB/0.9.29-GCCcore-12.2.0
```