### PR TITLE
{2023.06}[gompi/2023a] amdahl 0.3.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -26,3 +26,4 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20951
         from-commit: a92667fe32396bbd4106243658625f7ff2adcd68
+  - amdahl-0.3.1-gompi-2023a.eb


### PR DESCRIPTION
```
1 out of 25 required modules missing:

* amdahl/0.3.1-gompi-2023a (amdahl-0.3.1-gompi-2023a.eb)
```