### PR TITLE
Add Lmod wrapper for eessi_archdetect.sh

### DIFF
--- a/init/lmod_eessi_archdetect_wrapper.sh
+++ b/init/lmod_eessi_archdetect_wrapper.sh
@@ -1,0 +1,1 @@
+export EESSI_ARCHDETECT_OPTIONS=$($(dirname $(readlink -f $BASH_SOURCE))/eessi_archdetect.sh -a cpupath)


### PR DESCRIPTION
This allows you to run
```
/cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/usr/share/Lmod/libexec/sh_to_modulefile ./lmod_eessi_archdetect_wrapper.sh
```
and set an environment variable that can be leveraged in a module file