### PR TITLE
{2023.06}[foss/2023a] librosa 0.10.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -27,3 +27,4 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20951
         from-commit: a92667fe32396bbd4106243658625f7ff2adcd68
   - amdahl-0.3.1-gompi-2023a.eb
+  - librosa-0.10.1-foss-2023a.eb


### PR DESCRIPTION
This is to show we can reproduce the failure in seen in https://github.com/EESSI/software-layer/pull/585#issuecomment-2127129308