### PR TITLE
{2023.06,2023a+2023b,zen4} Rebuild Python + add librosa 0.10.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20240801-eb-4.9.2-Python-ctypes-zen4.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20240801-eb-4.9.2-Python-ctypes-zen4.yml
@@ -1,0 +1,17 @@
+# 2024.08.01
+# Python ctypes relies on LD_LIBRARY_PATH and doesn't respect rpath linking. There is a workaround
+# for the EasyBuild context in https://github.com/easybuilders/easybuild-easyblocks/pull/3352.
+#
+# This rebuild ensures this fix is available for all Python versions shipped for
+# zen4 with EESSI.
+# 
+# See https://gitlab.com/eessi/support/-/issues/77
+easyconfigs:
+  - Python-3.11.3-GCCcore-12.3.0:
+      options:
+        # See https://github.com/easybuilders/easybuild-easyblocks/pull/3352
+        include-easyblocks-from-commit: 1ee17c0f7726c69e97442f53c65c5f041d65c94f
+  - Python-3.11.5-GCCcore-13.2.0:
+      options:
+        # See https://github.com/easybuilders/easybuild-easyblocks/pull/3352
+        include-easyblocks-from-commit: 1ee17c0f7726c69e97442f53c65c5f041d65c94f

--- a/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -15,3 +15,4 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20942
         from-commit: 524da37b903585cea5a9eeb4156d1c8d57636bd8
+  - librosa-0.10.1-foss-2023a.eb


### PR DESCRIPTION
Companion PR for #655 to apply changes also on `zen4`.