### PR TITLE
{2023.06}[GCCcore/12.2.0][GCCcore/12.3.0] BioPerl v1.7.8

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
@@ -2,5 +2,5 @@ easyconfigs:
   - BLAST+-2.14.0-gompi-2022b.eb
   - BioPerl-1.7.8-GCCcore-12.2.0.eb:
       options:
-        # see https://github.com/easybuilders/easybuild-framework/issues/4602 
-        include-easyblocks-from-commit: 89ea2e4737d792055de828e18f38bccee26b76cf 
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21136
+        from-commit: d8076ebaf8cb915762adebf88d385cc672b350dc 

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - BLAST+-2.14.0-gompi-2022b.eb
+  - BioPerl-1.7.8-GCCcore-12.2.0.eb 

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
@@ -1,3 +1,6 @@
 easyconfigs:
   - BLAST+-2.14.0-gompi-2022b.eb
-  - BioPerl-1.7.8-GCCcore-12.2.0.eb 
+  - BioPerl-1.7.8-GCCcore-12.2.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-framework/issues/4602 
+        include-easyblocks-from-commit: 89ea2e4737d792055de828e18f38bccee26b76cf 

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -38,5 +38,5 @@ easyconfigs:
         from-commit: f0e91e6e430ebf902f7788ebb47f0203dee60649
   - BioPerl-1.7.8-GCCcore-12.3.0.eb:
       options:
-        # see https://github.com/easybuilders/easybuild-framework/issues/4602 
-        include-easyblocks-from-commit: 89ea2e4737d792055de828e18f38bccee26b76cf
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21136
+        from-commit: d8076ebaf8cb915762adebf88d385cc672b350dc

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -30,3 +30,4 @@ easyconfigs:
   - librosa-0.10.1-foss-2023a.eb
   - xarray-2023.9.0-gfbf-2023a.eb
   - SciTools-Iris-3.9.0-foss-2023a.eb
+  - BioPerl-1.7.8-GCCcore-12.3.0.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -30,4 +30,7 @@ easyconfigs:
   - librosa-0.10.1-foss-2023a.eb
   - xarray-2023.9.0-gfbf-2023a.eb
   - SciTools-Iris-3.9.0-foss-2023a.eb
-  - BioPerl-1.7.8-GCCcore-12.3.0.eb
+  - BioPerl-1.7.8-GCCcore-12.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-framework/issues/4602 
+        include-easyblocks-from-commit: 89ea2e4737d792055de828e18f38bccee26b76cf

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -647,6 +647,16 @@ def post_sanitycheck_hook(self, *args, **kwargs):
         POST_SANITYCHECK_HOOKS[self.name](self, *args, **kwargs)
 
 
+def post_sanitycheck_bioperl(self, *args, **kwargs):
+    """
+    Allow the copy of easyblock perlmodule.py to /tmp/eb... after sanity check by changing directory permissions 
+    """
+    if self.name == 'BioPerl':
+        print_msg("Adding user write permission for EasyBuild directories under /tmp/eb*...")
+        bioperlcmd = "chmod u+w -R /tmp/eb*"
+        run_cmd(bioperlcmd)
+
+
 def post_sanitycheck_cuda(self, *args, **kwargs):
     """
     Remove files from CUDA installation that we are not allowed to ship,
@@ -791,5 +801,6 @@ POST_SINGLE_EXTENSION_HOOKS = {
 }
 
 POST_SANITYCHECK_HOOKS = {
+    'BioPerl': post_sanitycheck_bioperl,
     'CUDA': post_sanitycheck_cuda,
 }

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -647,16 +647,6 @@ def post_sanitycheck_hook(self, *args, **kwargs):
         POST_SANITYCHECK_HOOKS[self.name](self, *args, **kwargs)
 
 
-def post_sanitycheck_bioperl(self, *args, **kwargs):
-    """
-    Allow the copy of easyblock perlmodule.py to /tmp/eb... after sanity check by changing directory permissions 
-    """
-    if self.name == 'BioPerl':
-        print_msg("Adding user write permission for EasyBuild directories under /tmp/eb*...")
-        bioperlcmd = "chmod u+w -R /tmp/eb*"
-        run_cmd(bioperlcmd)
-
-
 def post_sanitycheck_cuda(self, *args, **kwargs):
     """
     Remove files from CUDA installation that we are not allowed to ship,
@@ -801,6 +791,5 @@ POST_SINGLE_EXTENSION_HOOKS = {
 }
 
 POST_SANITYCHECK_HOOKS = {
-    'BioPerl': post_sanitycheck_bioperl,
     'CUDA': post_sanitycheck_cuda,
 }


### PR DESCRIPTION
BioPerl build process tries to copy `perlmodule.py` once again after sanity check which results in  :

```
Failed to copy file /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/EasyBuild/4.9.2/lib/python3.11/site-packages/easybuild/easyblocks/generic/perlmodule.py to .../reprod_20240802080341_2187/e
asyblocks/perlmodule.py: [Errno 13] Permission') (at easybuild/main.py:178 in build_and_install_software)

```

BioPerl hook adds user write permission after sanity check to allow copying the easyblock file.


Missing packages:

```
BioPerl/1.7.8-GCCcore-12.2.0
BioPerl/1.7.8-GCCcore-12.3.0
DB/18.1.40-GCCcore-12.3.0
DB_File/1.859-GCCcore-12.3.0
groff/1.22.4-GCCcore-12.3.0
Perl-bundle-CPAN/5.36.1-GCCcore-12.3.0
XML-LibXML/2.0208-GCCcore-12.2.0
XML-LibXML/2.0209-GCCcore-12.3.0
```