### PR TITLE
{2023.06}[foss/2023a] grpcio v1.57.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -30,3 +30,4 @@ easyconfigs:
   - librosa-0.10.1-foss-2023a.eb
   - xarray-2023.9.0-gfbf-2023a.eb
   - SciTools-Iris-3.9.0-foss-2023a.eb
+  - grpcio-1.57.0-GCCcore-12.3.0.eb

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -220,6 +220,19 @@ def parse_hook_fontconfig_add_fonts(ec, eprefix):
         raise EasyBuildError("fontconfig-specific hook triggered for non-fontconfig easyconfig?!")
 
 
+def parse_hook_grpcio_zlib(ec, ecprefix):
+    """Adjust preinstallopts to use ZLIB from compat layer."""
+    if ec.name == 'grpcio' and ec.version in ['1.57.0']:
+        exts_list = ec['exts_list']
+        original_preinstallopts = (exts_list[0][2])['preinstallopts']
+        original_option = "GRPC_PYTHON_BUILD_SYSTEM_ZLIB=True"
+        new_option = "GRPC_PYTHON_BUILD_SYSTEM_ZLIB=False"
+        (exts_list[0][2])['preinstallopts'] = original_preinstallopts.replace(original_option, new_option, 1)
+        print_msg("Modified the easyconfig to use compat ZLIB with GRPC_PYTHON_BUILD_SYSTEM_ZLIB=False")
+    else:
+        raise EasyBuildError("grpcio-specific hook triggered for a non-grpcio easyconfig?!")
+
+
 def parse_hook_openblas_relax_lapack_tests_num_errors(ec, eprefix):
     """Relax number of failing numerical LAPACK tests for aarch64/neoverse_v1 CPU target for OpenBLAS < 0.3.23"""
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -756,6 +756,7 @@ PARSE_HOOKS = {
     'casacore': parse_hook_casacore_disable_vectorize,
     'CGAL': parse_hook_cgal_toolchainopts_precise,
     'fontconfig': parse_hook_fontconfig_add_fonts,
+    'grpcio': parse_hook_grpcio_zlib,
     'LAMMPS': parse_hook_lammps_remove_deps_for_CI_aarch64,
     'CP2K': parse_hook_CP2K_remove_deps_for_aarch64,
     'OpenBLAS': parse_hook_openblas_relax_lapack_tests_num_errors,


### PR DESCRIPTION
grpcio/1.57.0 is a missing dependency for builds in #603 / #585

It may require some tweaks to `preinstallopts` which we don't use initially (to confirm that those are needed).