### PR TITLE
{2023.06}[GCCcore/12.2.0] gnuplot v5.4.6

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
@@ -3,4 +3,5 @@ easyconfigs:
   - BioPerl-1.7.8-GCCcore-12.2.0.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21136
-        from-commit: d8076ebaf8cb915762adebf88d385cc672b350dc 
+        from-commit: d8076ebaf8cb915762adebf88d385cc672b350dc
+  - gnuplot-5.4.6-GCCcore-12.2.0.eb 


### PR DESCRIPTION
```
Missing packages:
gnuplot/5.4.6-GCCcore-12.2.0
libcerf/2.3-GCCcore-12.2.0
libgd/2.3.3-GCCcore-12.2.0
Lua/5.4.4-GCCcore-12.2.0
Perl/5.36.0-GCCcore-12.2.0-minimal
```