### PR TITLE
{2023.06}[foss/2022b] h5py v3.8.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
@@ -4,4 +4,5 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21136
         from-commit: d8076ebaf8cb915762adebf88d385cc672b350dc
-  - gnuplot-5.4.6-GCCcore-12.2.0.eb 
+  - gnuplot-5.4.6-GCCcore-12.2.0.eb
+  - h5py-3.8.0-foss-2022b.eb


### PR DESCRIPTION
```
Missing packages:
h5py/3.8.0-foss-2022b
mpi4py/3.1.4-gompi-2022b
pkgconfig/1.5.5-GCCcore-12.2.0-python
```