### PR TITLE
{2023.06}[GCCcore/12.3.0] orjson v3.9.15

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -41,3 +41,7 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21136
         from-commit: d8076ebaf8cb915762adebf88d385cc672b350dc
   - grpcio-1.57.0-GCCcore-12.3.0.eb
+  - orjson-3.9.15-GCCcore-12.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20880
+        from-commit: bc6e08f89759b8b70166de5bfcb5056b9db8ec90


### PR DESCRIPTION
```
3 out of 18 required modules missing:

* Rust/1.75.0-GCCcore-12.3.0 
* maturin/1.4.0-GCCcore-12.3.0-Rust-1.75.0
* orjson/3.9.15-GCCcore-12.3.0
```