### PR TITLE
use upper directory of former 'rw' session in 'ro' mode

### DIFF
--- a/eessi_container.sh
+++ b/eessi_container.sh
@@ -746,6 +746,10 @@ do
             # to be able to see the contents of the read-write session we have to mount
             # the fuse-overlayfs (in read-only mode) on top of the CernVM-FS repository
 
+            echo "While processing '${cvmfs_repo_name}' to be mounted 'read-only' we detected an overlay-upper"
+            echo "  directory (${EESSI_TMPDIR}/${cvmfs_repo_name}/overlay-upper) likely from a previous"
+            echo "  session. Will use it as left-most directory in 'lowerdir' argument for fuse-overlayfs."
+
             # make the target CernVM-FS repository available under /cvmfs_ro
             export EESSI_READONLY="container:cvmfs2 ${cvmfs_repo_name} /cvmfs_ro/${cvmfs_repo_name}"
 
@@ -766,6 +770,8 @@ do
             export EESSI_FUSE_MOUNTS
         else
             # basic "ro" access that doesn't require any fuseoverlay-fs
+            echo "Mounting '${cvmfs_repo_name}' 'read-only' without fuse-overlayfs."
+
             export EESSI_READONLY="container:cvmfs2 ${cvmfs_repo_name} /cvmfs/${cvmfs_repo_name}"
 
             EESSI_FUSE_MOUNTS+=("--fusemount" "${EESSI_READONLY}")


### PR DESCRIPTION
This PR is essentially redoing #550. Original description below. It is also doing a little code polishing replacing <kbd>TAB</kbd> with spaces.
___
Use case for this is that we want to test software additions to a CernVM-FS repository. Typically we would first run `eessi_container.sh` with `--access rw` to make the repository writable with an overlayfs. The changes are stored in some `overlay-upper` directory (under some `/tmp` dir or in a tarball of that `/tmp` directory). When we want to test the additions later we can run `eessi_container.sh` with `--resume TMPDIR_OR_TMPTARBALL`. However, until now this only worked when using `--access rw` which would make the repository again writable, which is likely not what is wanted in a test (because in actual use `/cvmfs/*` mounts are read-only). In fact, the `test-suite.sh` run after a build job has finished, uses `--access ro` (read-only), but this access mode did not recognise changes in an `overlay-upper` directory.

This PR merges an existing `overlay-upper` (given via `--resume ...`) on top of a CernVM-FS repository. Because it only uses the `lowerdir` option of `fuse-overlayfs` the merged directory is mounted read-only.
___

Because the mounting of directories under `/cvmfs` is done late in the `eessi_container.sh` script, this should also work with the changes introduced in #618, e.g., one should be able to run something like
```bash
eessi_container.sh --repository software.eessi.io,access=ro --repository dev.eessi.io,access=rw --storage=/tmp
```
which reports about a temporary location used such as `/tmp/eessi.abc123defg` and then
```bash
eessi_container.sh --repository software.eessi.io,access=ro --repository dev.eessi.io,access=ro --resume /tmp/eessi.abc123defg
```