### PR TITLE
Fix failing test step on AWS

### DIFF
--- a/bot/test.sh
+++ b/bot/test.sh
@@ -206,7 +206,7 @@ else
 fi
 # Bind mount /sys/fs/cgroup so that we can determine the amount of memory available in our cgroup for
 # Reframe configuration
-TEST_STEP_ARGS+=("--extra-bind-paths" "/sys/fs/cgroup:/hostsys/fs/cgroup:ro,/proc/self:/hostproc/self:ro"")
+TEST_STEP_ARGS+=("--extra-bind-paths" "/sys/fs/cgroup:/hostsys/fs/cgroup:ro,/proc/self:/hostproc/self:ro")
 
 # prepare arguments to test_suite.sh (specific to test step)
 declare -a TEST_SUITE_ARGS=()

--- a/bot/test.sh
+++ b/bot/test.sh
@@ -206,7 +206,7 @@ else
 fi
 # Bind mount /sys/fs/cgroup so that we can determine the amount of memory available in our cgroup for
 # Reframe configuration
-TEST_STEP_ARGS+=("--extra-bind-paths" "/sys/fs/cgroup:/hostsys/fs/cgroup:ro,/proc/self:/hostproc/self:ro")
+TEST_STEP_ARGS+=("--extra-bind-paths" "/sys/fs/cgroup:/hostsys/fs/cgroup:ro")
 
 # prepare arguments to test_suite.sh (specific to test step)
 declare -a TEST_SUITE_ARGS=()

--- a/bot/test.sh
+++ b/bot/test.sh
@@ -206,7 +206,7 @@ else
 fi
 # Bind mount /sys/fs/cgroup so that we can determine the amount of memory available in our cgroup for
 # Reframe configuration
-TEST_STEP_ARGS+=("--extra-bind-paths" "/sys/fs/cgroup:/hostsys/fs/cgroup:ro")
+TEST_STEP_ARGS+=("--extra-bind-paths" "/sys/fs/cgroup:/hostsys/fs/cgroup:ro,/proc/self:/hostproc/self:ro"")
 
 # prepare arguments to test_suite.sh (specific to test step)
 declare -a TEST_SUITE_ARGS=()

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -164,6 +164,11 @@ if [[ "${cpuinfo}" =~ (Core\(s\) per socket:[^0-9]*([0-9]+)) ]]; then
 else
     fatal_error "Failed to get the number of cores per socket for the current test hardware with lscpu."
 fi
+
+# The /sys inside the container is not the same as the /sys of the host
+# We want to extract the memory limit from the cgroup on the host (which is typically set by SLURM).
+# Thus, bot/test.sh bind-mounts the host's /sys/fs/cgroup into /hostsys/fs/cgroup
+# and that's the prefix we use to extract the memory limit from
 cgroup_v1_mem_limit="/hostsys/fs/cgroup/memory/$(</proc/self/cpuset)/memory.limit_in_bytes"
 cgroup_v2_mem_limit="/hostsys/fs/cgroup/$(</proc/self/cpuset)/memory.max"
 if [ -f "$cgroup_v1_mem_limit" ]; then

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -164,11 +164,11 @@ if [[ "${cpuinfo}" =~ (Core\(s\) per socket:[^0-9]*([0-9]+)) ]]; then
 else
     fatal_error "Failed to get the number of cores per socket for the current test hardware with lscpu."
 fi
-cgroup_v1_mem_limit="/sys/fs/cgroup/memory/$(</proc/self/cpuset)/memory.limit_in_bytes"
-cgroup_v2_mem_limit="/sys/fs/cgroup/$(</proc/self/cpuset)/memory.max"
+cgroup_v1_mem_limit="/hostsys/fs/cgroup/memory/$(</proc/self/cpuset)/memory.limit_in_bytes"
+cgroup_v2_mem_limit="/hostsys/fs/cgroup/$(</proc/self/cpuset)/memory.max"
 echo "cpuset_file: $(</proc/self/cpuset)"
-echo "ls -al /sys/fs/cgroup/memory/$(</proc/self/cpuset)"
-ls -al "/sys/fs/cgroup/memory/$(</proc/self/cpuset)"
+echo "ls -al /hostsys/fs/cgroup/memory/$(</proc/self/cpuset)"
+ls -al "/hostsys/fs/cgroup/memory/$(</proc/self/cpuset)"
 if [ -f "$cgroup_v1_mem_limit" ]; then
     echo "Getting memory limit from file $cgroup_v1_mem_limit"
     cgroup_mem_bytes=$(cat "$cgroup_v1_mem_limit")

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -164,8 +164,8 @@ if [[ "${cpuinfo}" =~ (Core\(s\) per socket:[^0-9]*([0-9]+)) ]]; then
 else
     fatal_error "Failed to get the number of cores per socket for the current test hardware with lscpu."
 fi
-cgroup_v1_mem_limit="/hostsys/fs/cgroup/memory/$(</hostproc/self/cpuset)/memory.limit_in_bytes"
-cgroup_v2_mem_limit="/hostsys/fs/cgroup/$(</hostproc/self/cpuset)/memory.max"
+cgroup_v1_mem_limit="/hostsys/fs/cgroup/memory/$(</proc/self/cpuset)/memory.limit_in_bytes"
+cgroup_v2_mem_limit="/hostsys/fs/cgroup/$(</proc/self/cpuset)/memory.max"
 echo "cpuset_file: $(</proc/self/cpuset)"
 echo "ls -al /hostsys/fs/cgroup/memory/$(</proc/self/cpuset)"
 ls -al "/hostsys/fs/cgroup/memory/$(</proc/self/cpuset)"

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -166,6 +166,9 @@ else
 fi
 cgroup_v1_mem_limit="/sys/fs/cgroup/memory/$(</proc/self/cpuset)/memory.limit_in_bytes"
 cgroup_v2_mem_limit="/sys/fs/cgroup/$(</proc/self/cpuset)/memory.max"
+echo "cpuset_file: $(</proc/self/cpuset)"
+echo "ls -al /sys/fs/cgroup/memory/$(</proc/self/cpuset)"
+ls -al "/sys/fs/cgroup/memory/$(</proc/self/cpuset)"
 if [ -f "$cgroup_v1_mem_limit" ]; then
     echo "Getting memory limit from file $cgroup_v1_mem_limit"
     cgroup_mem_bytes=$(cat "$cgroup_v1_mem_limit")

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -166,9 +166,6 @@ else
 fi
 cgroup_v1_mem_limit="/hostsys/fs/cgroup/memory/$(</proc/self/cpuset)/memory.limit_in_bytes"
 cgroup_v2_mem_limit="/hostsys/fs/cgroup/$(</proc/self/cpuset)/memory.max"
-echo "cpuset_file: $(</proc/self/cpuset)"
-echo "ls -al /hostsys/fs/cgroup/memory/$(</proc/self/cpuset)"
-ls -al "/hostsys/fs/cgroup/memory/$(</proc/self/cpuset)"
 if [ -f "$cgroup_v1_mem_limit" ]; then
     echo "Getting memory limit from file $cgroup_v1_mem_limit"
     cgroup_mem_bytes=$(cat "$cgroup_v1_mem_limit")

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -164,8 +164,8 @@ if [[ "${cpuinfo}" =~ (Core\(s\) per socket:[^0-9]*([0-9]+)) ]]; then
 else
     fatal_error "Failed to get the number of cores per socket for the current test hardware with lscpu."
 fi
-cgroup_v1_mem_limit="/hostsys/fs/cgroup/memory/$(</proc/self/cpuset)/memory.limit_in_bytes"
-cgroup_v2_mem_limit="/hostsys/fs/cgroup/$(</proc/self/cpuset)/memory.max"
+cgroup_v1_mem_limit="/hostsys/fs/cgroup/memory/$(</hostproc/self/cpuset)/memory.limit_in_bytes"
+cgroup_v2_mem_limit="/hostsys/fs/cgroup/$(</hostproc/self/cpuset)/memory.max"
 echo "cpuset_file: $(</proc/self/cpuset)"
 echo "ls -al /hostsys/fs/cgroup/memory/$(</proc/self/cpuset)"
 ls -al "/hostsys/fs/cgroup/memory/$(</proc/self/cpuset)"

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -167,8 +167,10 @@ fi
 cgroup_v1_mem_limit="/sys/fs/cgroup/memory/$(</proc/self/cpuset)/memory.limit_in_bytes"
 cgroup_v2_mem_limit="/sys/fs/cgroup/$(</proc/self/cpuset)/memory.max"
 if [ -f "$cgroup_v1_mem_limit" ]; then
+    echo "Getting memory limit from file $cgroup_v1_mem_limit"
     cgroup_mem_bytes=$(cat "$cgroup_v1_mem_limit")
-else
+elif [ -f "$cgroup_v2_mem_limit" ]; then
+    echo "Getting memory limit from file $cgroup_v2_mem_limit"
     cgroup_mem_bytes=$(cat "$cgroup_v2_mem_limit")
     if [ "$cgroup_mem_bytes" = 'max' ]; then
         # In cgroupsv2, the memory.max file may contain 'max', meaning the group can use the full system memory
@@ -179,6 +181,8 @@ else
         fi
         cgroup_mem_bytes=$(("$cgroup_mem_kilobytes"*1024))
     fi
+else
+    fatal_error "Both files ${cgroup_v1_mem_limit} and ${cgroup_v2_mem_limit} couldn't be found. Failed to get the memory limit from the current cgroup"
 fi
 if [[ $? -eq 0 ]]; then
     # Convert to MiB


### PR DESCRIPTION
Currently, the test step on AWS fails because we fail to get a memory limit from the cgroup. I'll add some more verbose output as a first step to debugging this.