### PR TITLE
{2023.06,a64fx}[foss/2023a] R v4.3.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -18,3 +18,4 @@ easyconfigs:
         include-easyblocks-from-commit: c8256a36e7062bc09f5ce30552a9de9827054c9e
         # https://github.com/easybuilders/easybuild-easyconfigs/pull/20841
         from-commit: f0e91e6e430ebf902f7788ebb47f0203dee60649
+  - R-4.3.2-gfbf-2023a.eb


### PR DESCRIPTION
Step up towards #680, which is stuck due to a tricky problem with a dependency of `R-bundle-CRAN`...