### PR TITLE
Use ReFrame's CPU autodetect in test step

### DIFF
--- a/reframe_config_bot.py.tmpl
+++ b/reframe_config_bot.py.tmpl
@@ -57,8 +57,7 @@ site_configuration = {
         {
             'purge_environment': True,
             'resolve_module_conflicts': False,  # avoid loading the module before submitting the job
-            # disable automatic detection of CPU architecture (since we're using local scheduler)
-            'remote_detect': False,
+            'remote_detect': True,
         }
     ],
     'logging': common_logging_config(),

--- a/reframe_config_bot.py.tmpl
+++ b/reframe_config_bot.py.tmpl
@@ -15,19 +15,20 @@ site_configuration = {
             'modules_system': 'lmod',
             'partitions': [
                 {
-                    'name': 'default',
+                    'name': '__JOBID__',
                     'scheduler': 'local',
                     'launcher': 'mpirun',
                     'environs': ['default'],
                     'features': [
                         FEATURES[CPU]
                     ] + list(SCALES.keys()),
-                    'processor': {
-                        'num_cpus': __NUM_CPUS__,
-                        'num_sockets': __NUM_SOCKETS__,
-                        'num_cpus_per_core': __NUM_CPUS_PER_CORE__,
-                        'num_cpus_per_socket': __NUM_CPUS_PER_SOCKET__,
-                    },
+                    # 'processor': {
+                    #     'num_cpus': __NUM_CPUS__,
+                    #     'num_sockets': __NUM_SOCKETS__,
+                    #     'num_cpus_per_core': __NUM_CPUS_PER_CORE__,
+                    #     'num_cpus_per_socket': __NUM_CPUS_PER_SOCKET__,
+                    #     'num_cores_per_numa_node': __NUM_CORES_PER_NUMA_NODE__,
+                    # },
                     'resources': [
                         {
                             'name': 'memory',

--- a/reframe_config_bot.py.tmpl
+++ b/reframe_config_bot.py.tmpl
@@ -15,7 +15,7 @@ site_configuration = {
             'modules_system': 'lmod',
             'partitions': [
                 {
-                    'name': '__JOBID__',
+                    'name': '__RFM_PARTITION__',
                     'scheduler': 'local',
                     'launcher': 'mpirun',
                     'environs': ['default'],

--- a/reframe_config_bot.py.tmpl
+++ b/reframe_config_bot.py.tmpl
@@ -22,13 +22,6 @@ site_configuration = {
                     'features': [
                         FEATURES[CPU]
                     ] + list(SCALES.keys()),
-                    # 'processor': {
-                    #     'num_cpus': __NUM_CPUS__,
-                    #     'num_sockets': __NUM_SOCKETS__,
-                    #     'num_cpus_per_core': __NUM_CPUS_PER_CORE__,
-                    #     'num_cpus_per_socket': __NUM_CPUS_PER_SOCKET__,
-                    #     'num_cores_per_numa_node': __NUM_CORES_PER_NUMA_NODE__,
-                    # },
                     'resources': [
                         {
                             'name': 'memory',

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -173,7 +173,6 @@ else
 fi
 echo "Detected available memory: ${cgroup_mem_mib} MiB"
 
-# echo "Replacing detected system information in template ReFrame config file..."
 cp ${RFM_CONFIG_FILE_TEMPLATE} ${RFM_CONFIG_FILES}
 echo "Replacing memory limit in the ReFrame config file with the detected CGROUP memory limit: ${cgroup_mem_mib} MiB"
 sed -i "s/__MEM_PER_NODE__/${cgroup_mem_mib}/g" $RFM_CONFIG_FILES

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -201,13 +201,17 @@ else
 fi
 echo "Detected available memory: ${cgroup_mem_mib} MiB"
 
-echo "Replacing detected system information in template ReFrame config file..."
+# echo "Replacing detected system information in template ReFrame config file..."
+# cp ${RFM_CONFIG_FILE_TEMPLATE} ${RFM_CONFIG_FILES}
+# sed -i "s/__NUM_CPUS__/${cpu_count}/g" $RFM_CONFIG_FILES
+# sed -i "s/__NUM_SOCKETS__/${socket_count}/g" $RFM_CONFIG_FILES
+# sed -i "s/__NUM_CPUS_PER_CORE__/${threads_per_core}/g" $RFM_CONFIG_FILES
+# sed -i "s/__NUM_CPUS_PER_SOCKET__/${cores_per_socket}/g" $RFM_CONFIG_FILES
+# sed -i "s/__MEM_PER_NODE__/${cgroup_mem_mib}/g" $RFM_CONFIG_FILES
+echo "Replacing partition name in the template ReFrame config file, to trigger CPU autodetection for this job"
 cp ${RFM_CONFIG_FILE_TEMPLATE} ${RFM_CONFIG_FILES}
-sed -i "s/__NUM_CPUS__/${cpu_count}/g" $RFM_CONFIG_FILES
-sed -i "s/__NUM_SOCKETS__/${socket_count}/g" $RFM_CONFIG_FILES
-sed -i "s/__NUM_CPUS_PER_CORE__/${threads_per_core}/g" $RFM_CONFIG_FILES
-sed -i "s/__NUM_CPUS_PER_SOCKET__/${cores_per_socket}/g" $RFM_CONFIG_FILES
-sed -i "s/__MEM_PER_NODE__/${cgroup_mem_mib}/g" $RFM_CONFIG_FILES
+sed -i "s/__JOBID__/${SLURM_JOB_ID}/g" $RFM_CONFIG_FILES
+
 # Make debugging easier by printing the final config file:
 echo "Final config file (after replacements):"
 cat "${RFM_CONFIG_FILES}"

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -210,7 +210,7 @@ cp ${RFM_CONFIG_FILE_TEMPLATE} ${RFM_CONFIG_FILES}
 sed -i "s/__MEM_PER_NODE__/${cgroup_mem_mib}/g" $RFM_CONFIG_FILES
 echo "Replacing partition name in the template ReFrame config file, to trigger CPU autodetection for this job"
 # cp ${RFM_CONFIG_FILE_TEMPLATE} ${RFM_CONFIG_FILES}
-RFM_PARTITION="$SLURM_JOB_ID"
+RFM_PARTITION="job-$SLURM_JOB_ID"
 sed -i "s/__RFM_PARTITION__/${RFM_PARTITION}/g" $RFM_CONFIG_FILES
 
 # Make debugging easier by printing the final config file:

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -203,14 +203,10 @@ echo "Detected available memory: ${cgroup_mem_mib} MiB"
 
 # echo "Replacing detected system information in template ReFrame config file..."
 cp ${RFM_CONFIG_FILE_TEMPLATE} ${RFM_CONFIG_FILES}
-# sed -i "s/__NUM_CPUS__/${cpu_count}/g" $RFM_CONFIG_FILES
-# sed -i "s/__NUM_SOCKETS__/${socket_count}/g" $RFM_CONFIG_FILES
-# sed -i "s/__NUM_CPUS_PER_CORE__/${threads_per_core}/g" $RFM_CONFIG_FILES
-# sed -i "s/__NUM_CPUS_PER_SOCKET__/${cores_per_socket}/g" $RFM_CONFIG_FILES
+echo "Replacing memory limit in the ReFrame config file with the detected CGROUP memory limit: ${cgroup_mem_mib} MiB"
 sed -i "s/__MEM_PER_NODE__/${cgroup_mem_mib}/g" $RFM_CONFIG_FILES
-echo "Replacing partition name in the template ReFrame config file, to trigger CPU autodetection for this job"
-# cp ${RFM_CONFIG_FILE_TEMPLATE} ${RFM_CONFIG_FILES}
 RFM_PARTITION="${SLURM_JOB_PARTITION}"
+echo "Replacing partition name in the template ReFrame config file: ${RFM_PARTITION}"
 sed -i "s/__RFM_PARTITION__/${RFM_PARTITION}/g" $RFM_CONFIG_FILES
 
 # Make debugging easier by printing the final config file:

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -252,7 +252,8 @@ echo ">> Cleaning up ${TMPDIR}..."
 rm -r ${TMPDIR}
 
 RFM_SYSTEM=$(python3 -c "import ${RFM_CONFIG_FILES}; site_configuration['systems'][0]['name']")
-RFM_TOPOLOGY_FILE="${HOME}/.reframe/topology/${RFM_SYSTEM}-${RFM_PARTITION}/processor.json"
+RFM_TOPOLOGY_DIR="${HOME}/.reframe/topology/${RFM_SYSTEM}-${RFM_PARTITION}"
 echo ">> Cleaning up ReFrame CPU topology file"
+rm -rf ${RFM_TOPOLOGY_DIR}
 
 exit ${reframe_exit_code}

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -202,14 +202,14 @@ fi
 echo "Detected available memory: ${cgroup_mem_mib} MiB"
 
 # echo "Replacing detected system information in template ReFrame config file..."
-# cp ${RFM_CONFIG_FILE_TEMPLATE} ${RFM_CONFIG_FILES}
+cp ${RFM_CONFIG_FILE_TEMPLATE} ${RFM_CONFIG_FILES}
 # sed -i "s/__NUM_CPUS__/${cpu_count}/g" $RFM_CONFIG_FILES
 # sed -i "s/__NUM_SOCKETS__/${socket_count}/g" $RFM_CONFIG_FILES
 # sed -i "s/__NUM_CPUS_PER_CORE__/${threads_per_core}/g" $RFM_CONFIG_FILES
 # sed -i "s/__NUM_CPUS_PER_SOCKET__/${cores_per_socket}/g" $RFM_CONFIG_FILES
-# sed -i "s/__MEM_PER_NODE__/${cgroup_mem_mib}/g" $RFM_CONFIG_FILES
+sed -i "s/__MEM_PER_NODE__/${cgroup_mem_mib}/g" $RFM_CONFIG_FILES
 echo "Replacing partition name in the template ReFrame config file, to trigger CPU autodetection for this job"
-cp ${RFM_CONFIG_FILE_TEMPLATE} ${RFM_CONFIG_FILES}
+# cp ${RFM_CONFIG_FILE_TEMPLATE} ${RFM_CONFIG_FILES}
 RFM_PARTITION="$SLURM_JOB_ID"
 sed -i "s/__RFM_PARTITION__/${RFM_PARTITION}/g" $RFM_CONFIG_FILES
 

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -210,7 +210,7 @@ cp ${RFM_CONFIG_FILE_TEMPLATE} ${RFM_CONFIG_FILES}
 sed -i "s/__MEM_PER_NODE__/${cgroup_mem_mib}/g" $RFM_CONFIG_FILES
 echo "Replacing partition name in the template ReFrame config file, to trigger CPU autodetection for this job"
 # cp ${RFM_CONFIG_FILE_TEMPLATE} ${RFM_CONFIG_FILES}
-RFM_PARTITION="job-$SLURM_JOB_ID"
+RFM_PARTITION="${SLURM_JOB_PARTITION}"
 sed -i "s/__RFM_PARTITION__/${RFM_PARTITION}/g" $RFM_CONFIG_FILES
 
 # Make debugging easier by printing the final config file:
@@ -250,10 +250,5 @@ fi
 
 echo ">> Cleaning up ${TMPDIR}..."
 rm -r ${TMPDIR}
-
-RFM_SYSTEM=$(python3 -c "import ${RFM_CONFIG_FILES}; site_configuration['systems'][0]['name']")
-RFM_TOPOLOGY_DIR="${HOME}/.reframe/topology/${RFM_SYSTEM}-${RFM_PARTITION}"
-echo ">> Cleaning up ReFrame CPU topology file"
-rm -rf ${RFM_TOPOLOGY_DIR}
 
 exit ${reframe_exit_code}

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -141,34 +141,6 @@ export RFM_PREFIX=$PWD/reframe_runs
 echo "Configured reframe with the following environment variables:"
 env | grep "RFM_"
 
-# Inject correct CPU/memory properties into the ReFrame config file
-echo "Collecting system-specific input for the ReFrame configuration file"
-cpuinfo=$(lscpu)
-if [[ "${cpuinfo}" =~ CPU\(s\):[^0-9]*([0-9]+) ]]; then
-    cpu_count=${BASH_REMATCH[1]}
-    echo "Detected CPU count: ${cpu_count}"
-else
-    fatal_error "Failed to get the number of CPUs for the current test hardware with lscpu."
-fi
-if [[ "${cpuinfo}" =~ Socket\(s\):[^0-9]*([0-9]+) ]]; then
-    socket_count=${BASH_REMATCH[1]}
-    echo "Detected socket count: ${socket_count}"
-else
-    fatal_error "Failed to get the number of sockets for the current test hardware with lscpu."
-fi
-if [[ "${cpuinfo}" =~ (Thread\(s\) per core:[^0-9]*([0-9]+)) ]]; then
-    threads_per_core=${BASH_REMATCH[2]}
-    echo "Detected threads per core: ${threads_per_core}"
-else
-    fatal_error "Failed to get the number of threads per core for the current test hardware with lscpu."
-fi
-if [[ "${cpuinfo}" =~ (Core\(s\) per socket:[^0-9]*([0-9]+)) ]]; then
-    cores_per_socket=${BASH_REMATCH[2]}
-    echo "Detected cores per socket: ${cores_per_socket}"
-else
-    fatal_error "Failed to get the number of cores per socket for the current test hardware with lscpu."
-fi
-
 # The /sys inside the container is not the same as the /sys of the host
 # We want to extract the memory limit from the cgroup on the host (which is typically set by SLURM).
 # Thus, bot/test.sh bind-mounts the host's /sys/fs/cgroup into /hostsys/fs/cgroup

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -210,7 +210,8 @@ echo "Detected available memory: ${cgroup_mem_mib} MiB"
 # sed -i "s/__MEM_PER_NODE__/${cgroup_mem_mib}/g" $RFM_CONFIG_FILES
 echo "Replacing partition name in the template ReFrame config file, to trigger CPU autodetection for this job"
 cp ${RFM_CONFIG_FILE_TEMPLATE} ${RFM_CONFIG_FILES}
-sed -i "s/__JOBID__/${SLURM_JOB_ID}/g" $RFM_CONFIG_FILES
+RFM_PARTITION="$SLURM_JOB_ID"
+sed -i "s/__RFM_PARTITION__/${RFM_PARTITION}/g" $RFM_CONFIG_FILES
 
 # Make debugging easier by printing the final config file:
 echo "Final config file (after replacements):"
@@ -249,5 +250,9 @@ fi
 
 echo ">> Cleaning up ${TMPDIR}..."
 rm -r ${TMPDIR}
+
+RFM_SYSTEM=$(python3 -c "import ${RFM_CONFIG_FILES}; site_configuration['systems'][0]['name']")
+RFM_TOPOLOGY_FILE="${HOME}/.reframe/topology/${RFM_SYSTEM}-${RFM_PARTITION}/processor.json"
+echo ">> Cleaning up ReFrame CPU topology file"
 
 exit ${reframe_exit_code}


### PR DESCRIPTION
I've figured out the way we can use the CPU autodetection of ReFrame _with_ the local spawner. We just inject the partition name for the _current_ SLURM partition in which we are running into the ReFrame configuration file. This ensures that we get _one_ topology file per SLURM partition that is autodetected. Note that the autodetection only needs to happen once for each architecture, and then it's there "forever" in the `.reframe` in the homedir of the bot.

It's good to use the autodetection, as it guarantees all the CPU info we potentially rely on in the EESSI test suite is present. This is preferable over hard-coding it, and actually recommended according to our own documentation :D

To explain a bit: prior to this PR, we would create the ReFrame config file from a template. The template would contain placeholders like `__NUM_CPUS__`, `__NUM_SOCKETS__`, `__NUM_CPUS_PER_CORE` and `__NUM_CPUS_PER_SOCKET__`. In the `test_suite.sh` we would detect this information from the output of `lscpu`. The reason we did it this way is that we _thought_ we couldn't rely on CPU autodetection by ReFrame: ReFrame stores this in `$HOME/.reframe/topology/<system_name>-<partition_name>/processor.json`. Since the partition name here would always be the same (`default`) since we use the local spawner, it would autodetect once, and never again. That's problematic, since _actually_ our tests run on different partitions (the different types of build nodes: `zen2`, `zen3`, `zen4`, `haswell`, etc), with different node configurations.

The downside of this approach is that automatically detecting processor config ensures that we have a _predictable_ set of processor keywords defined in the ReFrame config file. E.g. in https://github.com/EESSI/software-layer/pull/585 it turned out that we were missing `num_cores_per_numa_node`. This is the reason our documentation [recommends using CPU autodetection](https://www.eessi.io/docs/test-suite/ReFrame-configuration-file/#cpu-auto-detection). When I hit that issue, I realized: we _can_ actually use CPU autodetection if, instead of the processor information, we simply detect which SLURM partition we are running on - and use that in a template replacement. This means that when running on e.g. the `x86-64-amd-zen2-node` partition, `__RFM_PARTITION__` get's replaced by `x86-64-amd-zen2-node`. ReFrame's CPU autodetect will then do CPU autodetection, and put the topology file in `$HOME/.reframe/topology/BotBuildTests-x86-64-amd-zen2-node/topology.json`. Then, when it runs a next time on e.g. `x86-64-intel-haswell-node`, it will _again_ do CPU autodetection, and store it in `$HOME/.reframe/topology/BotBuildTests-x86-64-intel-haswell-node/topology.json`.

That's perfect: that's exactly how it would work with a non-local spawner. It also means CPU info only needs to be detected once. Next time the bot runs (on _that_ partition), the info is already there and the CPU autodetection step can (and will) be skipped by ReFrame.