### PR TITLE
{2023.06}[foss/2023a] wradlib v2.0.3

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -45,3 +45,7 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20880
         from-commit: bc6e08f89759b8b70166de5bfcb5056b9db8ec90
+  - wradlib-2.0.3-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21094
+        from-commit: 9807cf9f13a9e969b447f136e9e8ad9e5c4548a2

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -48,4 +48,4 @@ easyconfigs:
   - wradlib-2.0.3-foss-2023a.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21094
-        from-commit: 9807cf9f13a9e969b447f136e9e8ad9e5c4548a2
+        from-commit: 3a2e0b8e6ee45277d01fb7e2eb93027a28c9461a


### PR DESCRIPTION
```
5 out of 137 required modules missing:

* psycopg2/2.9.9-GCCcore-12.3.0 (psycopg2-2.9.9-GCCcore-12.3.0.eb)
* SQLAlchemy/2.0.25-GCCcore-12.3.0 (SQLAlchemy-2.0.25-GCCcore-12.3.0.eb)
* h5netcdf/1.2.0-foss-2023a (h5netcdf-1.2.0-foss-2023a.eb)
* geopandas/0.14.2-foss-2023a (geopandas-0.14.2-foss-2023a.eb)
* wradlib/2.0.3-foss-2023a (wradlib-2.0.3-foss-2023a.eb)
```