### PR TITLE
{2023.06}[foss/2023b] R-bundle-CRAN v2024.06

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023b.yml
@@ -19,3 +19,4 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21200
         from-commit: 765ba900daf5953e306c4dad896febe52fdd6c00
+  - R-bundle-CRAN-2024.06-foss-2023b.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023b.yml
@@ -19,4 +19,7 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21200
         from-commit: 765ba900daf5953e306c4dad896febe52fdd6c00
-  - R-bundle-CRAN-2024.06-foss-2023b.eb
+  - R-bundle-CRAN-2024.06-foss-2023b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21183
+        from-commit: 2280e31879494ecf5764b12fc7b580d7dac849de


### PR DESCRIPTION
Hit an issue with `R/4.3.2-gfbf-2023a` when trying to install an R package via
```R
library(devtools)
install_github("Gibbsdavidl/CatterPlots", lib = "/dev/shm")
```
That function uses some curl/5.1.0 included with the R installation. The issue should be solved when using curl/5.2.0. However, instead of rebuilding `R/4.3.2-gfbf-2023a` with a patched or upgraded curl, we rather opt to install a newer R that includes a newer curl.