### PR TITLE
{2023.06}[foss/2023a] Critic2 v1.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -45,3 +45,7 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20880
         from-commit: bc6e08f89759b8b70166de5bfcb5056b9db8ec90
+  - Critic2-1.2-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20833
+        from-commit: 78426c2383fc7e4b9b9e77d7a77f336e1bee3843

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -59,7 +59,7 @@ easyconfigs:
         include-easyblocks-from-commit: bb86f05d4917b29e022023f152efdf0ca5c14ded
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20964
         from-commit: 7d539a9e599d8bc5ac2bda6ee9587ef62351ee03
- - Critic2-1.2-foss-2023a.eb:
+  - Critic2-1.2-foss-2023a.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20833
         from-commit: 78426c2383fc7e4b9b9e77d7a77f336e1bee3843


### PR DESCRIPTION
```
missing packages:

Critic2/1.2-foss-2023a
libcint/5.4.0-gfbf-2023a
```