### PR TITLE
{2023.06}[foss/2023a] LRBinner v0.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -63,3 +63,7 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20833
         from-commit: 78426c2383fc7e4b9b9e77d7a77f336e1bee3843
+  - LRBinner-0.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21310
+        from-commit: 799d9101df2cf81aabe252f00cc82a7246363f53


### PR DESCRIPTION
```
missing packages:

FragGeneScan/1.31-GCCcore-12.3.0
HDBSCAN/0.8.38.post1-foss-2023a
LRBinner/0.1-foss-2023a
Seaborn/0.13.2-gfbf-2023a
tqdm/4.66.1-GCCcore-12.3.0
```
```
zen4 missing packages:

Biopython/1.83-foss-2023a
FragGeneScan/1.31-GCCcore-12.3.0
HDBSCAN/0.8.38.post1-foss-2023a
LRBinner/0.1-foss-2023a
MPC/1.3.1-GCCcore-12.3.0
PyTorch/2.1.2-foss-2023a
Seaborn/0.13.2-gfbf-2023a
Z3/4.12.2-GCCcore-12.3.0
expecttest/0.1.5-GCCcore-12.3.0
gmpy2/2.1.5-GCC-12.3.0
pytest-flakefinder/1.1.0-GCCcore-12.3.0
pytest-rerunfailures/12.0-GCCcore-12.3.0
pytest-shard/0.1.2-GCCcore-12.3.0
sympy/1.12-gfbf-2023a
tqdm/4.66.1-GCCcore-12.3.0

```
