### PR TITLE
{2023.06}[GCC/12.3.0] Redland v1.0.17

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -67,3 +67,7 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21310
         from-commit: 799d9101df2cf81aabe252f00cc82a7246363f53
+  - Redland-1.0.17-GCC-12.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21227
+        from-commit: 4c5e3455dec31e68e8383c7fd86d1f80c434676d


### PR DESCRIPTION
```
18 out of 52 required modules missing:

* libgpg-error/1.48-GCCcore-12.3.0 (libgpg-error-1.48-GCCcore-12.3.0.eb)
* libgcrypt/1.10.3-GCCcore-12.3.0 (libgcrypt-1.10.3-GCCcore-12.3.0.eb)
* unixODBC/2.3.12-GCCcore-12.3.0 (unixODBC-2.3.12-GCCcore-12.3.0.eb)
* libaio/0.3.113-GCCcore-12.3.0 (libaio-0.3.113-GCCcore-12.3.0.eb)
* LZO/2.10-GCCcore-12.3.0 (LZO-2.10-GCCcore-12.3.0.eb)
* Raptor/2.0.16-GCCcore-12.3.0 (Raptor-2.0.16-GCCcore-12.3.0.eb)
* jemalloc/5.3.0-GCCcore-12.3.0 (jemalloc-5.3.0-GCCcore-12.3.0.eb)
* Pygments/2.18.0-GCCcore-12.3.0 (Pygments-2.18.0-GCCcore-12.3.0.eb)
* mallard-ducktype/1.0.2-GCCcore-12.3.0 (mallard-ducktype-1.0.2-GCCcore-12.3.0.eb)
* Judy/1.0.5-GCCcore-12.3.0 (Judy-1.0.5-GCCcore-12.3.0.eb)
* libxml2-python/2.11.4-GCCcore-12.3.0 (libxml2-python-2.11.4-GCCcore-12.3.0.eb)
* ITSTool/2.0.7-GCCcore-12.3.0 (ITSTool-2.0.7-GCCcore-12.3.0.eb)
* yelp-xsl/42.1-GCCcore-12.3.0 (yelp-xsl-42.1-GCCcore-12.3.0.eb)
* yelp-tools/42.1-GCCcore-12.3.0 (yelp-tools-42.1-GCCcore-12.3.0.eb)
* gtk-doc/1.34.0-GCCcore-12.3.0 (gtk-doc-1.34.0-GCCcore-12.3.0.eb)
* Rasqal/0.9.33-GCCcore-12.3.0 (Rasqal-0.9.33-GCCcore-12.3.0.eb)
* MariaDB/11.6.0-GCC-12.3.0 (MariaDB-11.6.0-GCC-12.3.0.eb)
* Redland/1.0.17-GCC-12.3.0 (Redland-1.0.17-GCC-12.3.0.eb)

```