### PR TITLE
Fix typo in `create_lmodsitepackage.py`

### DIFF
--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -28,7 +28,7 @@ local function from_eessi_prefix(t)
     -- If EESSI_PREFIX wasn't defined, we cannot check if this module was from the EESSI environment
     -- In that case, we assume it isn't, otherwise EESSI_PREFIX would (probably) have been set
     if eessi_prefix == nil then
-        return False
+        return false
     else
         -- NOTE: exact paths for site so may need to be updated later.
         -- See https://github.com/EESSI/software-layer/pull/371


### PR DESCRIPTION
Current typo results in the following problem (found by @TopRichard )
```bash
[ritop7377@login-2.BETZY ~]$ ml

Currently Loaded Modules:
  1) StdEnv (S)   2) EESSI/2023.06

  Where:
   S:  Module is Sticky, requires --force to unload or purge

 

[ritop@login ~]$ module purge
/usr/bin/lua: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/.lmod/SitePackage.lua:21: variable 'False' is not declared
stack traceback:
        [C]: in function 'error'
        /cluster/installations/lmod/lmod/libexec/../tools/strict.lua:36: in function </cluster/installations/lmod/lmod/libexec/../tools/strict.lua:34>
        /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/.lmod/SitePackage.lua:21: in function 'from_eessi_prefix'
        /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/.lmod/SitePackage.lua:189: in function </cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/.lmod/SitePackage.lua:185>
        (tail call): ?
        /cluster/installations/lmod/lmod/libexec/Master.lua:381: in function 'load'
        /cluster/installations/lmod/lmod/libexec/MasterControl.lua:1009: in function 'load'
        /cluster/installations/lmod/lmod/libexec/Master.lua:773: in function 'reload_sticky'
        /cluster/installations/lmod/lmod/libexec/MasterControl.lua:1120: in function 'unload_usr'
        /cluster/installations/lmod/lmod/libexec/cmdfuncs.lua:496: in function 'Purge'
        /cluster/installations/lmod/lmod/libexec/cmdfuncs.lua:473: in function 'cmd'
        /cluster/installations/lmod/lmod/libexec/lmod:512: in function 'main'
        /cluster/installations/lmod/lmod/libexec/lmod:570: in main chunk
        [C]: ?
```