### PR TITLE
install_cuda_host_injections: Don't fail if temp dir exists or parent is missing

### DIFF
--- a/scripts/gpu_support/nvidia/install_cuda_host_injections.sh
+++ b/scripts/gpu_support/nvidia/install_cuda_host_injections.sh
@@ -175,13 +175,13 @@ else
   # Check the exit code
   if [ $? -ne 0 ]; then
     eb_version=$(eb --version)
-    available_cuda_easyconfigs=$(eb --search ^CUDA-*.eb|grep CUDA)
+    available_cuda_easyconfigs=$(eb --search "^CUDA-.*.eb"|grep CUDA)
 
     error="The easyconfig ${cuda_easyconfig} was not found in EasyBuild version:\n"
     error="${error}  ${eb_version}\n"
     error="${error}You either need to give a different version of CUDA to install _or_ \n"
     error="${error}use a different version of EasyBuild for the installation.\n"
-    error="${error}\nThe versions of available with the current eb command are:\n"
+    error="${error}\nThe versions of CUDA available with the current eb command are:\n"
     error="${error}${available_cuda_easyconfigs}"
     fatal_error "${error}"
   fi

--- a/scripts/gpu_support/nvidia/install_cuda_host_injections.sh
+++ b/scripts/gpu_support/nvidia/install_cuda_host_injections.sh
@@ -123,7 +123,7 @@ else
     tmpdir=$(mktemp -d)
   else
     tmpdir="${CUDA_TEMP_DIR}"/temp
-    if ! mkdir "$tmpdir" ; then
+    if ! mkdir -p "$tmpdir" ; then
       fatal_error "Could not create directory ${tmpdir}"
     fi
   fi


### PR DESCRIPTION
Use `mkdir -p` such that  `--temp-dir /tmp/$USER/EESSI` works out of the box. It also avoids failures if the user got "ERROR: Could not create directory /tmp/root/EESSI/temp" and did `mkdir -p /tmp/root/EESSI/temp` manually.