### PR TITLE
{2023.06}[2023a,zen4] LAMMPS 2Aug2023 for zen4

### DIFF
--- a/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.3-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.3-2023a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - LAMMPS-2Aug2023_update2-foss-2023a-kokkos.eb

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -26,6 +26,8 @@ CPU_TARGET_NEOVERSE_V1 = 'aarch64/neoverse_v1'
 CPU_TARGET_AARCH64_GENERIC = 'aarch64/generic'
 CPU_TARGET_A64FX = 'aarch64/a64fx'
 
+CPU_TARGET_ZEN4 = 'x86_64/amd/zen4'
+
 EESSI_RPATH_OVERRIDE_ATTR = 'orig_rpath_override_dirs'
 
 SYSTEM = EASYCONFIG_CONSTANTS['SYSTEM'][0]
@@ -514,6 +516,23 @@ def pre_configure_hook_wrf_aarch64(self, *args, **kwargs):
         raise EasyBuildError("WRF-specific hook triggered for non-WRF easyconfig?!")
 
 
+def pre_configure_hook_LAMMPS_zen4(self, *args, **kwargs):
+    """
+    pre-configure hook for LAMMPS:
+    - set kokkos_arch on x86_64/amd/zen4
+    """
+
+    cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
+    if self.name == 'LAMMPS':
+        if self.version == '2Aug2023':
+            if get_cpu_architecture() == X86_64:
+                if cpu_target == CPU_TARGET_ZEN4:
+                    # There is no support for ZEN4 in LAMMPS yet so falling back to ZEN3
+                    self.cfg['kokkos'] = 'ZEN3'
+    else:
+        raise EasyBuildError("LAMMPS-specific hook triggered for non-LAMMPS easyconfig?!")
+
+
 def pre_test_hook(self,*args, **kwargs):
     """Main pre-test hook: trigger custom functions based on software name."""
     if self.name in PRE_TEST_HOOKS:
@@ -783,6 +802,7 @@ PRE_CONFIGURE_HOOKS = {
     'MetaBAT': pre_configure_hook_metabat_filtered_zlib_dep,
     'OpenBLAS': pre_configure_hook_openblas_optarch_generic,
     'WRF': pre_configure_hook_wrf_aarch64,
+    'LAMMPS': pre_configure_hook_LAMMPS_zen4,
 }
 
 PRE_TEST_HOOKS = {

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -524,7 +524,7 @@ def pre_configure_hook_LAMMPS_zen4(self, *args, **kwargs):
 
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
     if self.name == 'LAMMPS':
-        if self.version == '2Aug2023':
+        if self.version == '2Aug2023_update2':
             if get_cpu_architecture() == X86_64:
                 if cpu_target == CPU_TARGET_ZEN4:
                     # There is no support for ZEN4 in LAMMPS yet so falling back to ZEN3

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -528,7 +528,7 @@ def pre_configure_hook_LAMMPS_zen4(self, *args, **kwargs):
             if get_cpu_architecture() == X86_64:
                 if cpu_target == CPU_TARGET_ZEN4:
                     # There is no support for ZEN4 in LAMMPS yet so falling back to ZEN3
-                    self.cfg['kokkos'] = 'ZEN3'
+                    self.cfg['kokkos_arch'] = 'ZEN3'
     else:
         raise EasyBuildError("LAMMPS-specific hook triggered for non-LAMMPS easyconfig?!")
 


### PR DESCRIPTION
Building LAMMPS 2Aug2023 requires https://github.com/easybuilders/easybuild-easyblocks/pull/3336/files which is part of EasyBuild 4.9.3