### PR TITLE
Make the `bot/bot-check.sh` script correctly pick up builds for accelerators

### DIFF
--- a/bot/check-build.sh
+++ b/bot/check-build.sh
@@ -457,7 +457,13 @@ if [[ ! -z ${TARBALL} ]]; then
     repo_version=$(cfg_get_value "repository" "repo_version")
     os_type=$(cfg_get_value "architecture" "os_type")
     software_subdir=$(cfg_get_value "architecture" "software_subdir")
+    accelerator=$(cfg_get_value "architecture" "accelerator")
     prefix="${repo_version}/software/${os_type}/${software_subdir}"
+
+    # if we build for an accelerator, the prefix is different
+    if [[ ! -z ${accelerator} ]]; then
+      prefix="${prefix}/accel/${accelerator}"
+    fi
 
     # extract directories/entries from tarball content
     modules_entries=$(grep "${prefix}/modules" ${tmpfile})


### PR DESCRIPTION
Fixes https://github.com/EESSI/eessi-bot-software-layer/issues/286 (more or less). The problem here was that the script was only checking for new installations in the CPU prefix, and it interpreted everything else (including stuff in the accelerator prefix) to be "other files". The latter would get printed in full, leading to a very large Github comment. This is now fixed by appending `accel/${accelerator}` to `${prefix}`  for accelerator builds. Note that this only works for non-mixed builds (i.e. either CPU-only builds or GPU-only builds), but I think we decided that we would not allow this, at least not for now, to prevent that things get mixed up.