### PR TITLE
{2023.06}[foss/2022b] math-packages

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
@@ -27,4 +27,8 @@ easyconfigs:
   - lpsolve-5.5.2.11-GCC-12.2.0.eb
   - fastp-0.23.4-GCC-12.2.0.eb
   - KronaTools-2.8.1-GCCcore-12.2.0.eb
-  - MultiQC-1.14-foss-2022b.eb 
+  - MultiQC-1.14-foss-2022b.eb
+  - CGAL-5.5.2-GCCcore-12.2.0.eb
+  - KaHIP-3.14-gompi-2022b.eb
+  - MPC-1.3.1-GCCcore-12.2.0.eb
+  - MUMPS-5.6.1-foss-2022b-metis.eb


### PR DESCRIPTION
```
missing packages:

CGAL/5.5.2-GCCcore-12.2.0
KaHIP/3.14-gompi-2022b
METIS/5.1.0-GCCcore-12.2.0
MPC/1.3.1-GCCcore-12.2.0
MUMPS/5.6.1-foss-2022b-metis
SCOTCH/7.0.3-gompi-2022b

```