### PR TITLE
Take accelerator builds into account in CI that checks for missing installations

### DIFF
--- a/.github/workflows/test-software.eessi.io.yml
+++ b/.github/workflows/test-software.eessi.io.yml
@@ -10,17 +10,10 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 env:
   EESSI_ACCELERATOR_TARGETS: |
-    aarch64/generic:
-    aarch64/neoverse_n1:
-    aarch64/neoverse_v1:
-    x86_64/generic:
     x86_64/amd/zen2:
       - nvidia/cc80
     x86_64/amd/zen3:
       - nvidia/cc80
-    x86_64/amd/zen4:
-    x86_64/intel/haswell:
-    x86_64/intel/skylake_avx512:
 jobs:
   check_missing:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-software.eessi.io.yml
+++ b/.github/workflows/test-software.eessi.io.yml
@@ -73,7 +73,7 @@ jobs:
                   for accel in ${accelerators}; do
                       module use ${EESSI_SOFTWARE_PATH}/accel/${accel}/modules/all
                       echo "checking missing installations for accelerator ${accel} using modulepath: ${MODULEPATH}"
-                      for easystack_file in $(ls easystacks/software.eessi.io/${{matrix.EESSI_VERSION}}/accel/nvidia/eessi-${{matrix.EESSI_VERSION}}-eb-*.yml); do
+                      for easystack_file in $(ls easystacks/software.eessi.io/${{matrix.EESSI_VERSION}}/accel/$(dirname ${accel})/eessi-${{matrix.EESSI_VERSION}}-eb-*.yml); do
                           echo "check missing installations for ${easystack_file}..."
                           ./check_missing_installations.sh ${easystack_file}
                           ec=$?

--- a/.github/workflows/test-software.eessi.io.yml
+++ b/.github/workflows/test-software.eessi.io.yml
@@ -2,8 +2,7 @@
 name: Check for missing software installations in software.eessi.io
 on:
   push:
-#    branches: [ "*-software.eessi.io" ]
-    branches: "*"
+    branches: [ "*-software.eessi.io" ]
   pull_request:
   workflow_dispatch:
 permissions:

--- a/.github/workflows/test-software.eessi.io.yml
+++ b/.github/workflows/test-software.eessi.io.yml
@@ -2,11 +2,25 @@
 name: Check for missing software installations in software.eessi.io
 on:
   push:
-    branches: [ "*-software.eessi.io" ]
+#    branches: [ "*-software.eessi.io" ]
+    branches: "*"
   pull_request:
   workflow_dispatch:
 permissions:
   contents: read # to fetch code (actions/checkout)
+env:
+  EESSI_ACCELERATOR_TARGETS: |
+    aarch64/generic:
+    aarch64/neoverse_n1:
+    aarch64/neoverse_v1:
+    x86_64/generic:
+    x86_64/amd/zen2:
+      - nvidia/cc80
+    x86_64/amd/zen3:
+      - nvidia/cc80
+    x86_64/amd/zen4:
+    x86_64/intel/haswell:
+    x86_64/intel/skylake_avx512:
 jobs:
   check_missing:
     runs-on: ubuntu-latest
@@ -48,6 +62,8 @@ jobs:
               export EESSI_PREFIX=/cvmfs/software.eessi.io/versions/${{matrix.EESSI_VERSION}}
               export EESSI_OS_TYPE=linux
               env | grep ^EESSI | sort
+
+              # first check the CPU-only builds for this CPU target
               echo "just run check_missing_installations.sh (should use easystacks/software.eessi.io/${{matrix.EESSI_VERSION}}/eessi-${{matrix.EESSI_VERSION}}-*.yml)"
               for easystack_file in $(ls easystacks/software.eessi.io/${{matrix.EESSI_VERSION}}/eessi-${{matrix.EESSI_VERSION}}-eb-*.yml); do
                   echo "check missing installations for ${easystack_file}..."
@@ -55,6 +71,24 @@ jobs:
                   ec=$?
                   if [[ ${ec} -ne 0 ]]; then echo "missing installations found for ${easystack_file}!" >&2; exit ${ec}; fi
               done
+
+              # now check the accelerator builds for this CPU target
+              accelerators=$(echo "${EESSI_ACCELERATOR_TARGETS}" | yq ".${EESSI_SOFTWARE_SUBDIR_OVERRIDE}[]")
+              if [ -z ${accelerators} ]; then
+                  echo "no accelerator targets defined for ${EESSI_SOFTWARE_SUBDIR_OVERRIDE}"
+              else
+                  for accel in ${accelerators}; do
+                      module use ${EESSI_SOFTWARE_PATH}/accel/${accel}/modules/all
+                      echo "checking missing installations for accelerator ${accel} using modulepath: ${MODULEPATH}"
+                      for easystack_file in $(ls easystacks/software.eessi.io/${{matrix.EESSI_VERSION}}/accel/nvidia/eessi-${{matrix.EESSI_VERSION}}-eb-*.yml); do
+                          echo "check missing installations for ${easystack_file}..."
+                          ./check_missing_installations.sh ${easystack_file}
+                          ec=$?
+                          if [[ ${ec} -ne 0 ]]; then echo "missing installations found for ${easystack_file}!" >&2; exit ${ec}; fi
+                      done
+                      module unuse ${EESSI_SOFTWARE_PATH}/accel/${accel}/modules/all
+                  done
+              fi
 
         - name: Test check_missing_installations.sh with missing package (GCC/8.3.0)
           run: |


### PR DESCRIPTION
It doesn't really seem possible to add complex combinations into the workflow matrix, and maybe we don't want that anyway (for instance because the accelerator builds also need the CPU stack). So, I've now defined a CPU->accelerators mapping and use that to:
- first run the "check missing" script for the CPU-only stack
- look up the accelerator targets for this particular CPU target
- loop over all accelerator targets and do the following for each of them:
  - prepend the module dir of this accelerator target to $MODULEPATH
  - run the "check missing" script for every accelerator easystack file
  - remove the module dir from the $MODULEPATH again