### PR TITLE
move CUDA installations in CPU-only paths to dedicated easyconfigs

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a-CUDA.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a-CUDA.yml
@@ -1,0 +1,9 @@
+easyconfigs:
+  - CUDA-Samples-12.1-GCC-12.3.0-CUDA-12.1.1.eb:
+      # use easyconfig that only install subset of CUDA samples,
+      # to circumvent problem with nvcc linking to glibc of host OS,
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19189;
+      # and where additional samples are excluded because they fail to build on aarch64,
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19451;
+      options:
+        from-pr: 19451

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -35,14 +35,6 @@ easyconfigs:
   - Boost-1.82.0-GCC-12.3.0.eb
   - netCDF-4.9.2-gompi-2023a.eb
   - FFmpeg-6.0-GCCcore-12.3.0.eb
-  - CUDA-Samples-12.1-GCC-12.3.0-CUDA-12.1.1.eb:
-      # use easyconfig that only install subset of CUDA samples,
-      # to circumvent problem with nvcc linking to glibc of host OS,
-      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19189;
-      # and where additional samples are excluded because they fail to build on aarch64,
-      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19451;
-      options:
-        from-pr: 19451
   - ALL-0.9.2-foss-2023a.eb:
       options:
         from-pr: 19455

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a-CUDA.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a-CUDA.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - OSU-Micro-Benchmarks-7.2-gompi-2023a-CUDA-12.1.1.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -34,7 +34,6 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19996
         from-pr: 19996
   - dask-2023.9.2-foss-2023a.eb
-  - OSU-Micro-Benchmarks-7.2-gompi-2023a-CUDA-12.1.1.eb
   - JupyterNotebook-7.0.2-GCCcore-12.3.0.eb
   - ImageMagick-7.1.1-15-GCCcore-12.3.0.eb:
       options:


### PR DESCRIPTION
Nothing needs to be installed here, this is just pulling things apart so the `*CUDA*` installations aren't mixed with the CPU-only installations.

The `*CUDA*` easystack files being added here will eventually be removed, since the `CUDA-Samples/12.1-GCC-12.3.0-CUDA-12.1.1` and `OSU-Micro-Benchmarks/7.2-gompi-2023a-CUDA-12.1.1` installation we currently have in the CPU-only installation paths don't belong there, they should go under `accel/nvidia`, see also:
* #715
* #716