### PR TITLE
enhance archdetect to support detection of NVIDIA GPUs + using that in EESSI init script

### DIFF
--- a/.github/workflows/tests_archdetect_nvidia_gpu.yml
+++ b/.github/workflows/tests_archdetect_nvidia_gpu.yml
@@ -52,14 +52,6 @@ jobs:
 
               echo "Test for '${{matrix.fake_nvidia_smi_script}}' PASSED: '$out'"
 
-              # by default the 'errexit' option is enabled (set -e),
-              # which causes trouble when 'eessi_archdetect.sh accelpath'
-              # fails to detect an accelerator and produces a non-zero exit code,
-              # so we have to unset it using 'set +e'
-              echo "set flags: $-"
-              set +e
-              echo "set flags after unsetting errexit option: $-"
-
               # run full EESSI init script, which pick up on the accelerator (if available)
               echo
               . init/bash 2>&1 | tee init.out
@@ -95,7 +87,7 @@ jobs:
               else
                   echo ">>> checking for 'accel/nvidia/cc80' in init output..."
                   grep "archdetect found supported accelerator for CPU target x86_64/amd/zen2: accel/nvidia/cc80" init.out || (echo "FAILED 2" && exit 1)
-                  grep "Prepending /cvmfs/software.eessi.io/versions/2023.06/software/linux x86_64/amd/zen2/accel/nvidia/cc80/modules/all to \$MODULEPATH" init.out || (echo "FAILED 3" && exit 1)
+                  grep "Prepending /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/accel/nvidia/cc80/modules/all to \$MODULEPATH" init.out || (echo "FAILED 3" && exit 1)
               fi
 
               echo ">>> checking last line of init output..."

--- a/.github/workflows/tests_archdetect_nvidia_gpu.yml
+++ b/.github/workflows/tests_archdetect_nvidia_gpu.yml
@@ -1,0 +1,132 @@
+# documentation: https://help.github.com/en/articles/workflow-syntax-for-github-actions
+name: Tests for accelerator detection (NVIDIA GPU)
+on:
+  push:
+  pull_request:
+permissions:
+  contents: read # to fetch code (actions/checkout)
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        fake_nvidia_smi_script:
+          - none # no nvidia-smi command
+          - no_devices # nvidia-smi command works, but no GPUs available
+          - 1xa100 # cc80, supported with (atleast) zen2 CPU
+          - 2xa100 # cc80, supported with (atleast) zen2 CPU
+          - 4xa100 # cc80, supported with (atleast) zen2 CPU
+          - cc01 # non-existing GPU
+      fail-fast: false
+    steps:
+    - name: checkout
+      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+    # we deliberately do not use the eessi/github-action-eessi action,
+    # because we want to control when the EESSI environment is initialized
+    - name: Mount EESSI CernVM-FS repository
+      uses: cvmfs-contrib/github-action-cvmfs@55899ca74cf78ab874bdf47f5a804e47c198743c # v4.0
+      with:
+          cvmfs_config_package: https://github.com/EESSI/filesystem-layer/releases/download/latest/cvmfs-config-eessi_latest_all.deb
+          cvmfs_http_proxy: DIRECT
+          cvmfs_repositories: software.eessi.io
+
+    - name: test accelerator detection
+      run: |
+          export EESSI_SOFTWARE_SUBDIR_OVERRIDE='x86_64/amd/zen2'
+
+          # put fake nvidia-smi command in place (unless we don't want to)
+          if [[ "${{matrix.fake_nvidia_smi_script}}" != "none" ]]; then
+              tmpdir=$(mktemp -d)
+              ln -s $PWD/tests/archdetect/nvidia-smi/${{matrix.fake_nvidia_smi_script}}.sh $tmpdir/nvidia-smi
+              export PATH=$tmpdir:$PATH
+          fi
+
+          # first run with debugging enabled, just to show the output
+          ./init/eessi_archdetect.sh -d accelpath || echo "non-zero exit code: $?"
+
+          # verify output (or exit code if non-zero)
+          out=$(./init/eessi_archdetect.sh accelpath || echo "non-zero exit code: $?")
+
+          if [[ $out == "$( cat ./tests/archdetect/nvidia-smi/${{matrix.fake_nvidia_smi_script}}.output )" ]]; then
+
+              echo "Test for '${{matrix.fake_nvidia_smi_script}}' PASSED: '$out'"
+
+              # by default the 'errexit' option is enabled (set -e),
+              # which causes trouble when 'eessi_archdetect.sh accelpath'
+              # fails to detect an accelerator and produces a non-zero exit code,
+              # so we have to unset it using 'set +e'
+              echo "set flags: $-"
+              set +e
+              echo "set flags after unsetting errexit option: $-"
+
+              # run full EESSI init script, which pick up on the accelerator (if available)
+              echo
+              . init/bash 2>&1 | tee init.out
+              echo "-----------------------------------------------------------------------------"
+
+              if [[ "${{matrix.fake_nvidia_smi_script}}" == "none" ]] || [[ "${{matrix.fake_nvidia_smi_script}}" == "no_devices" ]]; then
+
+                  pattern="archdetect could not detect any accelerators"
+                  echo ">>> checking for pattern '${pattern}' in init output..."
+                  grep "${pattern}" init.out || (echo "FAILED 1" || exit 1)
+
+                  pattern="archdetect found supported accelerator"
+                  echo ">>> checking for lack of pattern '${pattern}' in init output..."
+                  match=$(grep "${pattern}" init.out || true)
+                  test "x${match}" = "x" || (echo "unexpected match found for '${pattern}' in init output" && exit 1)
+
+                  pattern="Prepending /cvmfs/software.eessi.io/versions/2023.06/software/linux/.*/accel/.*/modules/all to \$MODULEPATH"
+                  echo ">>> checking for lack of pattern '${pattern}' in init output..."
+                  match=$(grep "${pattern}" init.out || true)
+                  test "x${match}" = "x" || (echo "unexpected match found for '${pattern}' in init output" && exit 1)
+
+              elif [[ "${{matrix.fake_nvidia_smi_script}}" == "cc01" ]]; then
+
+                  pattern="No matching path found in x86_64/amd/zen2 for accelerator detected by archdetect (accel/nvidia/cc01)"
+                  echo ">>> checking for pattern '${pattern}' in init output..."
+                  grep "${pattern}" init.out || (echo "FAILED 1" || exit 1)
+
+                  pattern="Prepending /cvmfs/software.eessi.io/versions/2023.06/software/linux/.*/accel/.*/modules/all to \$MODULEPATH"
+                  echo ">>> checking for lack of pattern '${pattern}' in init output..."
+                  match=$(grep "${pattern}" init.out || true)
+                  test "x${match}" = "x" || (echo "unexpected match found for '${pattern}' in init output" && exit 1)
+
+              else
+                  echo ">>> checking for 'accel/nvidia/cc80' in init output..."
+                  grep "archdetect found supported accelerator for CPU target x86_64/amd/zen2: accel/nvidia/cc80" init.out || (echo "FAILED 2" && exit 1)
+                  grep "Prepending /cvmfs/software.eessi.io/versions/2023.06/software/linux x86_64/amd/zen2/accel/nvidia/cc80/modules/all to \$MODULEPATH" init.out || (echo "FAILED 3" && exit 1)
+              fi
+
+              echo ">>> checking last line of init output..."
+              tail -1 init.out | grep "Environment set up to use EESSI (2023.06), have fun!" || (echo "FAILED, full init utput:" && cat init.out && exit 1)
+
+              echo "All checks on init output PASSED"
+          else
+              echo "Test for '${{matrix.fake_nvidia_smi_script}}' FAILED: '$out'" >&2
+              exit 1
+          fi
+
+    - name: test accelerator detection under $EESSI_ACCEL_SOFTWARE_SUBDIR_OVERRIDE + $EESSI_ACCELERATOR_TARGET_OVERRIDE
+      run: |
+          export EESSI_SOFTWARE_SUBDIR_OVERRIDE='x86_64/amd/zen2'
+          export EESSI_ACCEL_SOFTWARE_SUBDIR_OVERRIDE='x86_64/amd/zen3'
+          export EESSI_ACCELERATOR_TARGET_OVERRIDE='accel/nvidia/cc80'
+
+          # first run with debugging enabled, just to show the output
+          ./init/eessi_archdetect.sh -d accelpath || echo "non-zero exit code: $?"
+
+          # verify output (or exit code if non-zero)
+          out=$(./init/eessi_archdetect.sh accelpath || echo "non-zero exit code: $?")
+
+          echo
+          . init/bash 2>&1 | tee init.out
+          echo "-----------------------------------------------------------------------------"
+
+          echo ">>> checking for 'accel/nvidia/cc80' in init output..."
+          grep "archdetect found supported accelerator for CPU target x86_64/amd/zen3: accel/nvidia/cc80" init.out || (echo "FAILED 1" && exit 1)
+          grep "Using x86_64/amd/zen2 as software subdirectory" init.out || (echo "FAILED 2" && exit 1)
+          grep "Prepending /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/modules/all to \$MODULEPATH" init.out || (echo "FAILED 3" && exit 1)
+          grep "Prepending /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/accel/nvidia/cc80/modules/all to \$MODULEPATH" init.out || (echo "FAILED 4" && exit 1)
+
+          echo "All checks on init output PASSED"

--- a/init/bash
+++ b/init/bash
@@ -29,6 +29,11 @@ if [ $? -eq 0 ]; then
     show_msg "Prepending site path $EESSI_SITE_MODULEPATH to \$MODULEPATH..."
     module use $EESSI_SITE_MODULEPATH
 
+    if [ ! -z ${EESSI_MODULEPATH_ACCEL} ]; then
+        show_msg "Prepending $EESSI_MODULEPATH_ACCEL to \$MODULEPATH..."
+        module use $EESSI_MODULEPATH_ACCEL
+    fi
+
     #show_msg ""
     #show_msg "*** Known problems in the ${EESSI_VERSION} software stack ***"
     #show_msg ""

--- a/init/eessi_archdetect.sh
+++ b/init/eessi_archdetect.sh
@@ -153,7 +153,15 @@ cpupath(){
 accelpath() {
     # If EESSI_ACCELERATOR_TARGET_OVERRIDE is set, use it
     log "DEBUG" "accelpath: Override variable set as '$EESSI_ACCELERATOR_TARGET_OVERRIDE' "
-    [ $EESSI_ACCELERATOR_TARGET_OVERRIDE ] && echo ${EESSI_ACCELERATOR_TARGET_OVERRIDE} && exit
+    if [ ! -z $EESSI_ACCELERATOR_TARGET_OVERRIDE ]; then
+        if [[ "$EESSI_ACCELERATOR_TARGET_OVERRIDE" =~ ^accel/nvidia/cc[0-9][0-9]$ ]]; then
+            echo ${EESSI_ACCELERATOR_TARGET_OVERRIDE}
+            return 0
+        else
+            log "ERROR" "Value of \$EESSI_ACCELERATOR_TARGET_OVERRIDE should match 'accel/nvidia/cc[0-9[0-9]', but it does not: '$EESSI_ACCELERATOR_TARGET_OVERRIDE'"
+        fi
+        return 0
+    fi
 
     # check for NVIDIA GPUs via nvidia-smi command
     nvidia_smi=$(command -v nvidia-smi)

--- a/init/eessi_archdetect.sh
+++ b/init/eessi_archdetect.sh
@@ -178,7 +178,8 @@ accelpath() {
             echo $res
             rm -f $nvidia_smi_out
         else
-            log "ERROR" "accelpath: nvidia-smi command failed, see output in $nvidia_smi_out"
+            log "DEBUG" "accelpath: nvidia-smi command failed, see output in $nvidia_smi_out"
+            exit 3
         fi
     else
         log "DEBUG" "accelpath: nvidia-smi command not found"

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -38,15 +38,29 @@ if [ -d $EESSI_PREFIX ]; then
           break
         fi
       done
-      export EESSI_ACCEL_PATH=$(${EESSI_INIT_DIR_PATH}/eessi_archdetect.sh accelpath)
-      if [ -z ${EESSI_ACCEL_PATH} ]; then
-          show_msg "archdetect could not find any accelerators"
-      else
-          EESSI_GPU_SOFTWARE_SUBDIR=${$EESSI_GPU_SOFTWARE_SUBDIR_OVERRIDE:-${EESSI_SOFTWARE_SUBDIR}}
-          EESSI_GPU_SOFTWARE_PATH=${EESSI_PREFIX}/software/${EESSI_OS_TYPE}/${EESSI_GPU_SOFTWARE_SUBDIR}
-          if [ -d ${EESSI_GPU_SOFTWARE_PATH}/${EESSI_ACCEL_PATH} ]; then
-              show_msg "archdetect found accelerator: ${EESSI_ACCEL_PATH}"
+      # to be able to grab exit code of archdetect trying to detect accelerators,
+      # we can not run it via $(...), so we have to redirect the output to a temporary file
+      tmpout=$(mktemp)
+      ${EESSI_INIT_DIR_PATH}/eessi_archdetect.sh accelpath 2>&1 > $tmpout
+      ec=$?
+      if [[ $ec -eq 0 ]]; then
+          export EESSI_ACCEL_SUBDIR=$(tail -1 $tmpout && rm -f $tmpout)
+          if [ -z ${EESSI_ACCEL_SUBDIR} ]; then
+              error "accelerator detection with archdetect worked, but no result was returned?!"
+          else
+              # allow specifying different parent directory for accel/* subdirectory via $EESSI_ACCEL_SOFTWARE_SUBDIR_OVERRIDE
+              EESSI_ACCEL_SOFTWARE_SUBDIR=${EESSI_ACCEL_SOFTWARE_SUBDIR_OVERRIDE:-$EESSI_SOFTWARE_SUBDIR}
+              # path to where accel/* subdirectory is located
+              EESSI_ACCEL_SOFTWARE_PATH=${EESSI_PREFIX}/software/${EESSI_OS_TYPE}/${EESSI_ACCEL_SOFTWARE_SUBDIR}
+              if [ -d $EESSI_ACCEL_SOFTWARE_PATH/${EESSI_ACCEL_SUBDIR} ]; then
+                  show_msg "archdetect found supported accelerator for CPU target ${EESSI_ACCEL_SOFTWARE_SUBDIR}: ${EESSI_ACCEL_SUBDIR}"
+              else
+                  show_msg "No matching path found in ${EESSI_ACCEL_SOFTWARE_SUBDIR} for accelerator detected by archdetect (${EESSI_ACCEL_SUBDIR})"
+              fi
           fi
+      else
+          show_msg "archdetect could not detect any accelerators"
+          rm -f $tmpout
       fi
     elif [ "$EESSI_USE_ARCHSPEC" == "1" ]; then
       # note: eessi_software_subdir_for_host.py will pick up value from $EESSI_SOFTWARE_SUBDIR_OVERRIDE if it's defined!
@@ -116,7 +130,7 @@ if [ -d $EESSI_PREFIX ]; then
             false
           fi
 
-          EESSI_MODULEPATH_ACCEL=${EESSI_GPU_SOFTWARE_PATH}/${EESSI_ACCEL_PATH}/${EESSI_MODULE_SUBDIR}
+          EESSI_MODULEPATH_ACCEL=${EESSI_ACCEL_SOFTWARE_PATH}/${EESSI_ACCEL_SUBDIR}/${EESSI_MODULE_SUBDIR}
           if [ -d ${EESSI_MODULEPATH_ACCEL} ]; then
              export EESSI_MODULEPATH_ACCEL=${EESSI_MODULEPATH_ACCEL}
               show_msg "Using ${EESSI_MODULEPATH_ACCEL} as additional directory (for accelerators) to be added to MODULEPATH."

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -130,9 +130,8 @@ if [ -d $EESSI_PREFIX ]; then
             false
           fi
 
-          EESSI_MODULEPATH_ACCEL=${EESSI_ACCEL_SOFTWARE_PATH}/${EESSI_ACCEL_SUBDIR}/${EESSI_MODULE_SUBDIR}
-          if [ -d ${EESSI_MODULEPATH_ACCEL} ]; then
-             export EESSI_MODULEPATH_ACCEL=${EESSI_MODULEPATH_ACCEL}
+          if [ -d ${EESSI_ACCEL_SOFTWARE_PATH}/${EESSI_ACCEL_SUBDIR}/${EESSI_MODULE_SUBDIR} ]; then
+              export EESSI_MODULEPATH_ACCEL=${EESSI_ACCEL_SOFTWARE_PATH}/${EESSI_ACCEL_SUBDIR}/${EESSI_MODULE_SUBDIR}
               show_msg "Using ${EESSI_MODULEPATH_ACCEL} as additional directory (for accelerators) to be added to MODULEPATH."
           fi
 

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -38,6 +38,14 @@ if [ -d $EESSI_PREFIX ]; then
           break
         fi
       done
+      export EESSI_ACCEL_PATH=$(${EESSI_INIT_DIR_PATH}/eessi_archdetect.sh accelpath)
+      if [ -z ${EESSI_ACCEL_PATH} ]; then
+          show_msg "archdetect could not find any accelerators"
+      else
+          if [ -d ${EESSI_PREFIX}/software/${EESSI_OS_TYPE}/${EESSI_SOFTWARE_SUBDIR}/${EESSI_ACCEL_PATH} ]; then
+              show_msg "archdetect found accelerator: ${EESSI_ACCEL_PATH}"
+          fi
+      fi
     elif [ "$EESSI_USE_ARCHSPEC" == "1" ]; then
       # note: eessi_software_subdir_for_host.py will pick up value from $EESSI_SOFTWARE_SUBDIR_OVERRIDE if it's defined!
       export EESSI_EPREFIX_PYTHON=$EESSI_EPREFIX/usr/bin/python3
@@ -104,6 +112,12 @@ if [ -d $EESSI_PREFIX ]; then
           else
             error "EESSI module path at $EESSI_MODULEPATH not found!"
             false
+          fi
+
+          EESSI_MODULEPATH_ACCEL=${EESSI_SOFTWARE_PATH}/${EESSI_ACCEL_PATH}/${EESSI_MODULE_SUBDIR}
+          if [ -d ${EESSI_MODULEPATH_ACCEL} ]; then
+             export EESSI_MODULEPATH_ACCEL=${EESSI_MODULEPATH_ACCEL}
+              show_msg "Using ${EESSI_MODULEPATH_ACCEL} as additional directory (for accelerators) to be added to MODULEPATH."
           fi
 
           # Fix wrong path for RHEL >=8 libcurl 

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -42,7 +42,9 @@ if [ -d $EESSI_PREFIX ]; then
       if [ -z ${EESSI_ACCEL_PATH} ]; then
           show_msg "archdetect could not find any accelerators"
       else
-          if [ -d ${EESSI_PREFIX}/software/${EESSI_OS_TYPE}/${EESSI_SOFTWARE_SUBDIR}/${EESSI_ACCEL_PATH} ]; then
+          EESSI_GPU_SOFTWARE_SUBDIR=${$EESSI_GPU_SOFTWARE_SUBDIR_OVERRIDE:-${EESSI_SOFTWARE_SUBDIR}}
+          EESSI_GPU_SOFTWARE_PATH=${EESSI_PREFIX}/software/${EESSI_OS_TYPE}/${EESSI_GPU_SOFTWARE_SUBDIR}
+          if [ -d ${EESSI_GPU_SOFTWARE_PATH}/${EESSI_ACCEL_PATH} ]; then
               show_msg "archdetect found accelerator: ${EESSI_ACCEL_PATH}"
           fi
       fi
@@ -114,7 +116,7 @@ if [ -d $EESSI_PREFIX ]; then
             false
           fi
 
-          EESSI_MODULEPATH_ACCEL=${EESSI_SOFTWARE_PATH}/${EESSI_ACCEL_PATH}/${EESSI_MODULE_SUBDIR}
+          EESSI_MODULEPATH_ACCEL=${EESSI_GPU_SOFTWARE_PATH}/${EESSI_ACCEL_PATH}/${EESSI_MODULE_SUBDIR}
           if [ -d ${EESSI_MODULEPATH_ACCEL} ]; then
              export EESSI_MODULEPATH_ACCEL=${EESSI_MODULEPATH_ACCEL}
               show_msg "Using ${EESSI_MODULEPATH_ACCEL} as additional directory (for accelerators) to be added to MODULEPATH."

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -38,12 +38,27 @@ if [ -d $EESSI_PREFIX ]; then
           break
         fi
       done
+
+      # we need to make sure that errexit shell option (set -e) is not enabled,
+      # since archdetect will produce non-zero exit code if no accelerator was found
+      if [[ "$-" =~ e ]]; then
+        errexit_shell_option_set='yes'
+        set +e
+      else
+        errexit_shell_option_set='no'
+      fi
+
       # to be able to grab exit code of archdetect trying to detect accelerators,
       # we can not run it via $(...), so we have to redirect the output to a temporary file
       tmpout=$(mktemp)
       ${EESSI_INIT_DIR_PATH}/eessi_archdetect.sh accelpath 2>&1 > $tmpout
-      ec=$?
-      if [[ $ec -eq 0 ]]; then
+      accelpath_exit_code=$?
+
+      if [[ "$errexit_shell_option_set" == "yes" ]]; then
+        set -e
+      fi
+
+      if [[ $accelpath_exit_code -eq 0 ]]; then
           export EESSI_ACCEL_SUBDIR=$(tail -1 $tmpout && rm -f $tmpout)
           if [ -z ${EESSI_ACCEL_SUBDIR} ]; then
               error "accelerator detection with archdetect worked, but no result was returned?!"

--- a/tests/archdetect/nvidia-smi/1xa100.output
+++ b/tests/archdetect/nvidia-smi/1xa100.output
@@ -1,0 +1,1 @@
+accel/nvidia/cc80

--- a/tests/archdetect/nvidia-smi/1xa100.sh
+++ b/tests/archdetect/nvidia-smi/1xa100.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# output from NVIDIA A100 system,
+# produced by: nvidia-smi --query-gpu=gpu_name,count,driver_version,compute_cap --format=csv,noheader
+echo "NVIDIA A100-SXM4-80GB, 1, 545.23.08, 8.0"
+exit 0

--- a/tests/archdetect/nvidia-smi/2xa100.output
+++ b/tests/archdetect/nvidia-smi/2xa100.output
@@ -1,0 +1,1 @@
+accel/nvidia/cc80

--- a/tests/archdetect/nvidia-smi/2xa100.sh
+++ b/tests/archdetect/nvidia-smi/2xa100.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# output from NVIDIA A100 system,
+# produced by: nvidia-smi --query-gpu=gpu_name,count,driver_version,compute_cap --format=csv,noheader
+echo "NVIDIA A100-SXM4-80GB, 2, 545.23.08, 8.0"
+echo "NVIDIA A100-SXM4-80GB, 2, 545.23.08, 8.0"
+exit 0

--- a/tests/archdetect/nvidia-smi/4xa100.output
+++ b/tests/archdetect/nvidia-smi/4xa100.output
@@ -1,0 +1,1 @@
+accel/nvidia/cc80

--- a/tests/archdetect/nvidia-smi/4xa100.sh
+++ b/tests/archdetect/nvidia-smi/4xa100.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# output from NVIDIA A100 system,
+# produced by: nvidia-smi --query-gpu=gpu_name,count,driver_version,compute_cap --format=csv,noheader
+echo "NVIDIA A100-SXM4-80GB, 4, 545.23.08, 8.0"
+echo "NVIDIA A100-SXM4-80GB, 4, 545.23.08, 8.0"
+echo "NVIDIA A100-SXM4-80GB, 4, 545.23.08, 8.0"
+echo "NVIDIA A100-SXM4-80GB, 4, 545.23.08, 8.0"
+exit 0

--- a/tests/archdetect/nvidia-smi/cc01.output
+++ b/tests/archdetect/nvidia-smi/cc01.output
@@ -1,0 +1,1 @@
+accel/nvidia/cc01

--- a/tests/archdetect/nvidia-smi/cc01.sh
+++ b/tests/archdetect/nvidia-smi/cc01.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# output from non-existing NVIDIA GPU system,
+# to test handling of unknown GPU model
+# (supposedly) produced by: nvidia-smi --query-gpu=gpu_name,count,driver_version,compute_cap --format=csv,noheader
+echo "NVIDIA does-not-exist, 1, 000.00.00, 0.1"
+exit 0

--- a/tests/archdetect/nvidia-smi/no_devices.output
+++ b/tests/archdetect/nvidia-smi/no_devices.output
@@ -1,0 +1,1 @@
+non-zero exit code: 3

--- a/tests/archdetect/nvidia-smi/no_devices.sh
+++ b/tests/archdetect/nvidia-smi/no_devices.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "No devices were found"
+exit 6

--- a/tests/archdetect/nvidia-smi/none.output
+++ b/tests/archdetect/nvidia-smi/none.output
@@ -1,0 +1,1 @@
+non-zero exit code: 2


### PR DESCRIPTION
Example output:
```
$ . init/bash
Found EESSI repo @ /cvmfs/software.eessi.io/versions/2023.06!
archdetect says x86_64/amd/zen3
archdetect found accelerator: accel/nvidia/cc80
Using x86_64/amd/zen3 as software subdirectory.
Found Lmod configuration file at /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/.lmod/lmodrc.lua
Found Lmod SitePackage.lua file at /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/.lmod/SitePackage.lua
Using /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/modules/all as the directory to be added to MODULEPATH.
Using /cvmfs/software.eessi.io/host_injections/2023.06/software/linux/x86_64/amd/zen3/modules/all as the site extension directory to be added to MODULEPATH.
Using /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/accel/nvidia/cc80/modules/all as additional directory (for accelerators) to be added to MODULEPATH.
Found libcurl CAs file at RHEL location, setting CURL_CA_BUNDLE
Initializing Lmod...
Prepending /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/modules/all to $MODULEPATH...
Prepending site path /cvmfs/software.eessi.io/host_injections/2023.06/software/linux/x86_64/amd/zen3/modules/all to $MODULEPATH...
Prepending /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/accel/nvidia/cc80/modules/all to $MODULEPATH...
Environment set up to use EESSI (2023.06), have fun!

{EESSI 2023.06} $ echo $MODULEPATH
/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/accel/nvidia/cc80/modules/all:/cvmfs/software.eessi.io/host_injections/2023.06/software/linux/x86_64/amd/zen3/modules/all:/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/modules/all

{EESSI 2023.06} $ ls -ld $(echo $MODULEPATH | cut -f1 -d:)
drwxr-xr-x 10 cvmfs cvmfs 4096 Sep 25 13:21 /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/accel/nvidia/cc80/modules/all

{EESSI 2023.06} $ module avail LAMMPS

---------- /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/accel/nvidia/cc80/modules/all ----------
   LAMMPS/2Aug2023_update2-foss-2023a-kokkos-CUDA-12.1.1 (g)

---------- /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3/modules/all ----------
   LAMMPS/2Aug2023_update2-foss-2023a-kokkos    LAMMPS/29Aug2024-foss-2023b-kokkos (D)
```