### PR TITLE
{2023.06}[foss/2022b] data-lang

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2022b.yml
@@ -41,3 +41,6 @@ easyconfigs:
   - libaio-0.3.113-GCCcore-12.2.0.eb
   - Z3-4.12.2-GCCcore-12.2.0.eb
   - tbb-2021.10.0-GCCcore-12.2.0.eb
+  - dask-2023.7.1-foss-2022b.eb
+  - netcdf4-python-1.6.3-foss-2022b.eb
+  - Ruby-3.2.2-GCCcore-12.2.0.eb


### PR DESCRIPTION
missing packages :
```
bokeh/3.2.1-foss-2022b
dask/2023.7.1-foss-2022b
meson-python/0.11.0-GCCcore-12.2.0
netcdf4-python/1.6.3-foss-2022b
Ruby/3.2.2-GCCcore-12.2.0
setuptools/64.0.3-GCCcore-12.2.0
```