### PR TITLE
Fix test step when only deploying scripts

### DIFF
--- a/bot/check-test.sh
+++ b/bot/check-test.sh
@@ -65,7 +65,7 @@ SUCCESS=-1
 # Grep for the success pattern, so we can report the amount of tests run
 if [[ ${SLURM_OUTPUT_FOUND} -eq 1 ]]; then
   GP_success='\[\s*PASSED\s*\].*Ran .* test case'
-  grep_reframe_success=$(grep -v "^>> searching for " ${job_dir}/${job_out} | grep -Pzo "${GP_success}")
+  grep_reframe_success=$(grep -v "^>> searching for " ${job_dir}/${job_out} | grep "${GP_success}")
   [[ $? -eq 0 ]] && SUCCESS=1 || SUCCESS=0
   # have to be careful to not add searched for pattern into slurm out file
   [[ ${VERBOSE} -ne 0 ]] && echo ">> searching for '"${GP_success}"'"

--- a/bot/check-test.sh
+++ b/bot/check-test.sh
@@ -23,6 +23,16 @@ else
     [[ ${VERBOSE} -ne 0 ]] && echo "   Slurm output file '"${job_out}"' NOT found"
 fi
 
+# First, account for the scenario where we skipped the ReFrame test suite
+SKIPPED=-1
+if [[ ${SLURM_OUTPUT_FOUND} -eq 1 ]]; then
+  GP_skipped='Skipping EESSI test site run'
+  grep_reframe_skipped=$(grep -v "^>> searching for " ${job_dir}/${job_out} | grep "${GP_skipped}")
+  [[ $? -eq 0 ]] && SKIPPED=1 || SKIPPED=0
+  # have to be careful to not add searched for pattern into slurm out file
+  [[ ${VERBOSE} -ne 0 ]] && echo ">> searching for '"${GP_skipped}"'"
+  [[ ${VERBOSE} -ne 0 ]] && echo "${grep_reframe_skipped}"
+fi
 
 # ReFrame prints e.g.
 #[----------] start processing checks
@@ -89,6 +99,10 @@ if [[ ${SLURM_OUTPUT_FOUND} -eq 0 ]]; then
 elif [[ ${SUCCESS} -eq 1 ]]; then
     summary=":grin: SUCCESS"
     reason=""
+    status="SUCCESS"
+elif [[ ${SKIPPED} -eq 1]]; then
+    summary="SKIPPED"
+    reason="The EESSI test suite was skipped. If this PR only deploys scripts, that's expected behavior."
     status="SUCCESS"
 # Should come before general errors: if FAILED==1, it indicates the test suite ran
 # otherwise the pattern wouldn't have been there

--- a/bot/check-test.sh
+++ b/bot/check-test.sh
@@ -23,17 +23,6 @@ else
     [[ ${VERBOSE} -ne 0 ]] && echo "   Slurm output file '"${job_out}"' NOT found"
 fi
 
-# First, account for the scenario where we skipped the ReFrame test suite
-SKIPPED=-1
-if [[ ${SLURM_OUTPUT_FOUND} -eq 1 ]]; then
-  GP_skipped='Skipping EESSI test site run'
-  grep_reframe_skipped=$(grep -v "^>> searching for " ${job_dir}/${job_out} | grep "${GP_skipped}")
-  [[ $? -eq 0 ]] && SKIPPED=1 || SKIPPED=0
-  # have to be careful to not add searched for pattern into slurm out file
-  [[ ${VERBOSE} -ne 0 ]] && echo ">> searching for '"${GP_skipped}"'"
-  [[ ${VERBOSE} -ne 0 ]] && echo "${grep_reframe_skipped}"
-fi
-
 # ReFrame prints e.g.
 #[----------] start processing checks
 #[ RUN      ] GROMACS_EESSI %benchmark_info=HECBioSim/Crambin %nb_impl=cpu %scale=2_nodes %module_name=GROMACS/2021.3-foss-2021a /d597cff4 @snellius:rome+default
@@ -99,10 +88,6 @@ if [[ ${SLURM_OUTPUT_FOUND} -eq 0 ]]; then
 elif [[ ${SUCCESS} -eq 1 ]]; then
     summary=":grin: SUCCESS"
     reason=""
-    status="SUCCESS"
-elif [[ ${SKIPPED} -eq 1]]; then
-    summary="SKIPPED"
-    reason="The EESSI test suite was skipped. If this PR only deploys scripts, that's expected behavior."
     status="SUCCESS"
 # Should come before general errors: if FAILED==1, it indicates the test suite ran
 # otherwise the pattern wouldn't have been there

--- a/bot/check-test.sh
+++ b/bot/check-test.sh
@@ -65,7 +65,7 @@ SUCCESS=-1
 # Grep for the success pattern, so we can report the amount of tests run
 if [[ ${SLURM_OUTPUT_FOUND} -eq 1 ]]; then
   GP_success='\[\s*PASSED\s*\].*Ran .* test case'
-  grep_reframe_success=$(grep -v "^>> searching for " ${job_dir}/${job_out} | grep "${GP_success}")
+  grep_reframe_success=$(grep -v "^>> searching for " ${job_dir}/${job_out} | grep -Pzo "${GP_success}")
   [[ $? -eq 0 ]] && SUCCESS=1 || SUCCESS=0
   # have to be careful to not add searched for pattern into slurm out file
   [[ ${VERBOSE} -ne 0 ]] && echo ">> searching for '"${GP_success}"'"
@@ -75,7 +75,10 @@ fi
 if [[ ! -z ${grep_reframe_failed} ]]; then
     grep_reframe_result=${grep_reframe_failed}
 else
-    grep_reframe_result=${grep_reframe_success}
+    # Grep the entire output of ReFrame, so that we can report it in the foldable section of the test report
+    GP_success_full='(?s)\[----------\] start processing checks.*?\[==========\] Finished on [a-zA-Z0-9 ]*'
+    grep_reframe_success_full=$(grep -v "^>> searching for " ${job_dir}/${job_out} | grep -Pzo "${GP_success}")
+    grep_reframe_result=${grep_reframe_success_full}
 fi
 
 echo "[TEST]" > ${job_test_result_file}

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -198,14 +198,19 @@ fi
 # Get the subset of test names based on the test mapping and tags (e.g. CI, 1_node)
 module_list="module_files.list.txt"
 mapping_config="tests/eessi_test_mapping/software_to_tests.yml"
-if [[ ! -f "$module_list" || ! -f "$mapping_config" ]]; then
-    fatal_error "No new module files were found. Skipping EESSI test site run."
+if [[ ! -f "$module_list" ]]; then
+    echo_green "File ${module_list} not found, so only running the default set of tests from ${mapping_config}"
+    # Run with --debug for easier debugging in case there are issues:
+    python3 tests/eessi_test_mapping/map_software_to_test.py --mapping-file "${mapping_config}" --debug --defaults-only
+    REFRAME_NAME_ARGS=$(python3 tests/eessi_test_mapping/map_software_to_test.py --mapping-file "${mapping_config}" --defaults-only)
+    test_selection_exit_code=$?
+else
+    # Run with --debug for easier debugging in case there are issues:
+    python3 tests/eessi_test_mapping/map_software_to_test.py --module-list "${module_list}" --mapping-file "${mapping_config}" --debug
+    REFRAME_NAME_ARGS=$(python3 tests/eessi_test_mapping/map_software_to_test.py --module-list "${module_list}" --mapping-file "${mapping_config}")
+    test_selection_exit_code=$?
 fi
-
-# Run with --debug for easier debugging in case there are issues:
-python3 tests/eessi_test_mapping/map_software_to_test.py --module-list "${module_list}" --mapping-file "${mapping_config}" --debug
-REFRAME_NAME_ARGS=$(python3 tests/eessi_test_mapping/map_software_to_test.py --module-list "${module_list}" --mapping-file "${mapping_config}")
-test_selection_exit_code=$?
+# Check exit status
 if [[ ${test_selection_exit_code} -eq 0 ]]; then
     echo_green "Succesfully extracted names of tests to run: ${REFRAME_NAME_ARGS}"
 else

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -198,6 +198,10 @@ fi
 # Get the subset of test names based on the test mapping and tags (e.g. CI, 1_node)
 module_list="module_files.list.txt"
 mapping_config="tests/eessi_test_mapping/software_to_tests.yml"
+if [[ ! -f "$module_list" || ! -f "$mapping_config" ]]; then
+    fatal_error "No new module files were found. Skipping EESSI test site run."
+fi
+
 # Run with --debug for easier debugging in case there are issues:
 python3 tests/eessi_test_mapping/map_software_to_test.py --module-list "${module_list}" --mapping-file "${mapping_config}" --debug
 REFRAME_NAME_ARGS=$(python3 tests/eessi_test_mapping/map_software_to_test.py --module-list "${module_list}" --mapping-file "${mapping_config}")

--- a/tests/eessi_test_mapping/map_software_to_test.py
+++ b/tests/eessi_test_mapping/map_software_to_test.py
@@ -33,29 +33,32 @@ def get_tests_for_software(software_name, mappings):
 
     return []
 
-def main(yaml_file, module_file, debug):
+def main(yaml_file, module_file, debug, defaults_only):
     """Main function to process software names and their tests."""
     mappings = load_mappings(yaml_file)
     if debug:
         print(f"Loaded mappings from '{yaml_file}'")
 
-    software_names = read_software_names(module_file)
-    if debug:
-        print(f"Read software names from '{module_file}'")
+    if not defaults_only:
+        software_names = read_software_names(module_file)
+        if debug:
+            print(f"Read software names from '{module_file}'")
 
     tests_to_run = []
     arg_string = ""
-    # For each module name, get the relevant set of tests
-    for software_name in software_names:
-        additional_tests = get_tests_for_software(software_name, mappings)
-        for test in additional_tests:
-            if test not in tests_to_run:
-                tests_to_run.append(test)
-        
-        if additional_tests and debug:
-            print(f"Software: {software_name} -> Tests: {additional_tests}")
-        elif debug:
-            print(f"Software: {software_name} -> No tests found")
+
+    if not defaults_only:
+        # For each module name, get the relevant set of tests
+        for software_name in software_names:
+            additional_tests = get_tests_for_software(software_name, mappings)
+            for test in additional_tests:
+                if test not in tests_to_run:
+                    tests_to_run.append(test)
+            
+            if additional_tests and debug:
+                print(f"Software: {software_name} -> Tests: {additional_tests}")
+            elif debug:
+                print(f"Software: {software_name} -> No tests found")
 
     # Always add the default set of tests, if default_tests is specified
     if 'default_tests' in mappings:
@@ -83,8 +86,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Map software names to their tests based on a YAML configuration.")
     parser.add_argument('--mapping-file', type=str, help='Path to the YAML file containing the test mappings.')
     parser.add_argument('--module-list', type=str, help='Path to the file containing the list of software names.')
-    parser.add_argument('--debug', action='store_true', help='Enable debug output.')
+    defaults_help = "Don't consider the module-list file, only return the default tests from the mapping file"
+    parser.add_argument('--defaults-only', action='store_true', default=False, help=defaults_help)
+    parser.add_argument('--debug', action='store_true', default=False, help='Enable debug output.')
     
     args = parser.parse_args()
     
-    main(args.mapping_file, args.module_list, args.debug)
+    main(args.mapping_file, args.module_list, args.debug, args.defaults_only)


### PR DESCRIPTION
Also, this _should_ print a more extensive ReFrame report, showing which tests where run (and which passed / failed)