### PR TITLE
{2023.06}[foss/2023a] waLBerla 6.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -5,3 +5,7 @@ easyconfigs:
         from-commit: 6cbfbd7d7a55dc7243f46d0beea510278f4718df
         # see https://github.com/easybuilders/easybuild-easyblocks/pull/3467
         include-easyblocks-from-commit: c3aebe1f133d064a228c5d6c282e898b83d74601
+  - waLBerla-6.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21600
+        from-commit: 9b12318bcff1749781d9eb71c23e21bc3a79ed01


### PR DESCRIPTION
This PR adds the same version of `waLBerla` as installed previously, but with the updated `foss2023a` toolchain.