### PR TITLE
{2023.06}[foss/2023a]  waLBerla 6.1 w/ CUDA

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -5,3 +5,7 @@ easyconfigs:
         from-commit: 6cbfbd7d7a55dc7243f46d0beea510278f4718df
         # see https://github.com/easybuilders/easybuild-easyblocks/pull/3467
         include-easyblocks-from-commit: c3aebe1f133d064a228c5d6c282e898b83d74601
+  - waLBerla-6.1-foss-2023a-CUDA-12.1.1.eb:
+      options: 
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21601
+        from-commit: b2295ce4b662851c3b387f945e4b5ac80cb00d42


### PR DESCRIPTION
This PR adds the same version of `waLBerla` as installed previously, but with the updated `foss2023a` toolchain with `CUDA` support.