### PR TITLE
add support for detecting Zen5 (AMD Turin)

### DIFF
--- a/init/arch_specs/eessi_arch_x86.spec
+++ b/init/arch_specs/eessi_arch_x86.spec
@@ -5,3 +5,4 @@
 "x86_64/amd/zen2"		"AuthenticAMD"	"avx2 fma"						# AMD Rome
 "x86_64/amd/zen3"		"AuthenticAMD"	"avx2 fma vaes"						# AMD Milan, Milan-X
 "x86_64/amd/zen4"		"AuthenticAMD"	"avx2 fma vaes avx512f avx512ifma"			# AMD Genoa, Genoa-X
+"x86_64/amd/zen5"		"AuthenticAMD"	"avx2 fma vaes avx512f avx512ifma avx512_vp2intersect avx_vnni"			# AMD Turin


### PR DESCRIPTION
see also https://github.com/archspec/archspec-json/pull/124

I made this a draft, because we should try and verify that this works first, but I don't know if/where there are AMD Turin-based systems available yet...