### PR TITLE
set `$LMOD_SHORT_TIME` to prevent Lmod from creating a user cache

### DIFF
--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -116,7 +116,11 @@ if [ -d $EESSI_PREFIX ]; then
         else
           error "Lmod SitePackage.lua file not found at $lmod_sitepackage_file"
         fi
-       
+
+        # set time until user cache is created to 1 day (86400 seconds),
+        # to prevent that Lmod ever creates one (since it will quickly go stale)
+        export LMOD_SHORT_TIME=86400
+
         if [ ! -z $EESSI_BASIC_ENV ]; then
           show_msg "Only setting up basic environment, so we're done"
         elif [ -d $EESSI_SOFTWARE_PATH ]; then


### PR DESCRIPTION
On some systems, Lmod may configured to create a user cache (in `~/.cache/lmod`) after a very short amount of time, for example on Vega:

```
$ ml --config 2>&1 | grep -i LMOD_.*_TIME
User cache valid time(sec) (LMOD_ANCIENT_TIME)                86400
Write cache after (sec) (LMOD_SHORT_TIME)                     2
```

So if a `module` command takes longer than 2 seconds, which can happen if CernVM-FS has to pull in an updated Lmod cache first from the EESSI repository, then a user cache will be auto-generated, which (by default) will be considered valid for 24h.

We should prevent that this happens, since it can easily lead to confusion when a module file is available under `/cvmfs/software.eessi.io`, but it's not visible via `module avail` (and if Lmod is configured with `LMOD_CACHED_LOADS` enabled, you won't be able to load it either, despite it being there).

Draft PR, since this script is not the only place we should set `$LMOD_SHORT_TIME` if we want to take control of this...