### PR TITLE
{2023.06}[2023b] Cython 3.0.10

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023b.yml
@@ -7,3 +7,4 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyblocks/pull/3496
         include-easyblocks-from-commit: 60633b0acfd41a0732992d9e16800dae71a056eb
+  - Cython-3.0.10-GCCcore-13.2.0.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023b.yml
@@ -1,2 +1,6 @@
 easyconfigs:
+  - SIONlib-1.7.7-GCCcore-13.2.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21748
+        from-commit: 253198299616e4069327797374e579077aa8dfa5
   - Score-P-8.4-gompi-2023b.eb


### PR DESCRIPTION
This should fix the currently broken CI (see #805), which is complaining about a missing Cython:
```
1 out of 42 required modules missing:

* Cython/3.0.10-GCCcore-13.2.0 (Cython-3.0.10-GCCcore-13.2.0.eb)
```