### PR TITLE
DEBUG {2023.06}[foss/2023a] TensorFlow v2.15.1 w/ CUDA 12.1.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/accel/nvidia/eessi-2023.06-eb-4.9.4-2023a-CUDA.yml
+++ b/easystacks/software.eessi.io/2023.06/accel/nvidia/eessi-2023.06-eb-4.9.4-2023a-CUDA.yml
@@ -1,3 +1,9 @@
 easyconfigs:
   - CUDA-12.1.1.eb
   - cuDNN-8.9.2.26-CUDA-12.1.1.eb
+  - TensorFlow-2.15.1-foss-2023a-CUDA-12.1.1.eb:
+      options:
+        # need to use updated tensorflow easyblock to work around ImportError not
+        # finding libnccl.so.2
+        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3497
+        include-easyblock-from-commit: 68d89b954b9a67ac157e8030f2ad670ff9374964


### PR DESCRIPTION
PR to debug issues building TensorFlow v2.15.1 with CUDA v12.1.1

1. Uses an updated `tensorflow.py` easyblock that solves an `ImportError` issue with `libnccl.so.2`. See https://github.com/easybuilders/easybuild-easyblocks/pull/3497