### PR TITLE
{2023.06} use `$EESSI_ACCELERATOR_TARGET` in EESSI-extend module

### DIFF
--- a/EESSI-extend-2023.06-easybuild.eb
+++ b/EESSI-extend-2023.06-easybuild.eb
@@ -87,6 +87,16 @@ if (os.getenv("EESSI_CVMFS_INSTALL") ~= nil) then
   end
   eessi_cvmfs_install = true
   easybuild_installpath = os.getenv("EESSI_SOFTWARE_PATH")
+  eessi_accelerator_target = os.getenv("EESSI_ACCELERATOR_TARGET")
+  if (eessi_accelerator_target ~= nil) then
+    cuda_compute_capability = string.match(eessi_accelerator_target, "^nvidia/cc([0-9][0-9])$")
+    if (cuda_compute_capability ~= nil) then
+      easybuild_installpath = pathJoin(easybuild_installpath, 'accel', eessi_accelerator_target)
+      easybuild_cuda_compute_capabilities = cuda_compute_capability:sub(1, 1) ..  "." .. cuda_compute_capability:sub(2, 2)
+    else
+      LmodError("Incorrect value for $EESSI_ACCELERATOR_TARGET: " .. eessi_accelerator_target)
+    end
+  end
 elseif (os.getenv("EESSI_SITE_INSTALL") ~= nil) then
   -- Make sure no other EESSI install environment variables are set
   if ((os.getenv("EESSI_PROJECT_INSTALL") ~= nil) or (os.getenv("EESSI_USER_INSTALL") ~= nil)) then
@@ -145,6 +155,11 @@ setenv ("EASYBUILD_UMASK", "022")
 
 -- Allow this module to be loaded when running EasyBuild
 setenv ("EASYBUILD_ALLOW_LOADED_MODULES", "EasyBuild,EESSI-extend")
+
+-- Set environment variables if building for CUDA compute capabilities
+if (easybuild_cuda_compute_capabilities ~= nil) then
+  setenv ("EASYBUILD_CUDA_COMPUTE_CAPABILITIES", easybuild_cuda_compute_capabilities)
+end
 
 -- Set all related environment variables if we have project or user installations (including extending MODULEPATH)
 if (user_modulepath ~= nil) then

--- a/easystacks/software.eessi.io/2023.06/rebuilds/20241112-eb-4.9.4-EESSI-extend.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20241112-eb-4.9.4-EESSI-extend.yml
@@ -1,0 +1,6 @@
+# 2024.11.12
+# for installations under /cvmfs, if EESSI_ACCELERATOR_TARGET is set,
+# EESSI-extend should adjust EASYBUILD_INSTALLPATH and set
+# EASYBUILD_CUDA_COMPUTE_CAPABILITIES
+easyconfigs:
+  - EESSI-extend-2023.06-easybuild.eb


### PR DESCRIPTION
When building for `/cvmfs` we need to adjust the installation path and set CUDA compute capabilities taking the value of `$EESSI_ACCELERATOR_TARGET` into account.