### PR TITLE
{2023.06} adds a script that loads `EESSI-extend` and installs it if it is not available yet

### DIFF
--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -273,7 +273,14 @@ unset EESSI_PROJECT_INSTALL
 unset EESSI_SITE_INSTALL
 export EESSI_CVMFS_INSTALL=1
 module unload EESSI-extend
-module load EESSI-extend/${EESSI_VERSION}-easybuild
+
+# The EESSI-extend module is being loaded (or installed if it doesn't exist yet).
+# The script requires the EESSI_VERSION given as argument, a couple of
+# environment variables set (TMPDIR, EB and EASYBUILD_INSTALLPATH) and the
+# function check_exit_code defined.
+# NOTE, the script exits if those variables/functions are undefined.
+export EASYBUILD_INSTALLPATH=${EESSI_PREFIX}/software/${EESSI_OS_TYPE}/${EESSI_SOFTWARE_SUBDIR_OVERRIDE}
+source load_eessi_extend_module.sh ${EESSI_VERSION}
 
 if [ ! -z "${shared_fs_path}" ]; then
     shared_eb_sourcepath=${shared_fs_path}/easybuild/sources

--- a/load_eessi_extend_module.sh
+++ b/load_eessi_extend_module.sh
@@ -1,0 +1,106 @@
+# Script to load the environment module for EESSI-extend.
+# If that module is not available yet, a specific version will be installed using the latest EasyBuild.
+#
+# This script must be sourced, since it makes changes in the current environment, like loading an EESSI-extend module.
+#
+# Assumptions (if one is not satisfied the script prints a message and exits)
+# - EESSI version is given as first argument
+# - TMPDIR is set
+# - EB is set
+# - EASYBUILD_INSTALLPATH needs to be set
+# - function check_exit_code is defined
+#   cfg/utils.sh in EESSI/software-layer repository defines this function, hence
+#   cfg/utils.sh shall be sourced before this script is run
+#
+# This script is part of the EESSI software layer, see
+# https://github.com/EESSI/software-layer.git
+#
+# author: Kenneth Hoste (@boegel, HPC-UGent)
+# author: Alan O'Cais (@ocaisa, CECAM)
+# author: Thomas Roeblitz (@trz42, University of Bergen)
+#
+# license: GPLv2
+#
+#
+set -o pipefail
+
+# this script is *sourced*, not executed, so can't rely on $0 to determine path to self or script name
+# $BASH_SOURCE points to correct path or script name, see also http://mywiki.wooledge.org/BashFAQ/028
+if [ $# -ne 1 ]; then
+    echo "Usage: source ${BASH_SOURCE} <EESSI-extend version>" >&2
+    exit 1
+fi
+
+EESSI_EXTEND_VERSION="${1}-easybuild"
+
+# make sure that environment variables that we expect to be set are indeed set
+if [ -z "${TMPDIR}" ]; then
+    echo "\$TMPDIR is not set; exiting" >&2
+    exit 2
+fi
+
+# ${EB} is used to specify which 'eb' command should be used;
+# can potentially be more than just 'eb', for example when using 'eb --optarch=GENERIC'
+if [ -z "${EB}" ]; then
+    echo "\$EB is not set; exiting" >&2
+    exit 2
+fi
+
+# ${EASYBUILD_INSTALLPATH} points to the installation path and needs to be set
+if [ -z "${EASYBUILD_INSTALLPATH}" ]; then
+    echo "\$EASYBUILD_INSTALLPATH is not set; exiting" >&2
+    exit 2
+fi
+
+# make sure that utility functions are defined (cfr. scripts/utils.sh script in EESSI/software-layer repo)
+type check_exit_code
+if [ $? -ne 0 ]; then
+    echo "check_exit_code function is not defined; exiting" >&2
+    exit 3
+fi
+
+echo ">> Checking for EESSI-extend module..."
+
+ml_av_eessi_extend_out=${TMPDIR}/ml_av_eessi_extend.out
+module avail 2>&1 | grep -i EESSI-extend/${EESSI_EXTEND_VERSION} &> ${ml_av_eessi_extend_out}
+
+if [[ $? -eq 0 ]]; then
+    echo_green ">> Module for EESSI-extend/${EESSI_EXTEND_VERSION} found!"
+else
+    echo_yellow ">> No module yet for EESSI-extend/${EESSI_EXTEND_VERSION}, installing it..."
+
+    EB_TMPDIR=${TMPDIR}/ebtmp
+    echo ">> Using temporary installation of EasyBuild (in ${EB_TMPDIR})..."
+    pip_install_out=${TMPDIR}/pip_install.out
+    pip3 install --prefix ${EB_TMPDIR} easybuild &> ${pip_install_out}
+
+    # keep track of original $PATH and $PYTHONPATH values, so we can restore them
+    ORIG_PATH=${PATH}
+    ORIG_PYTHONPATH=${PYTHONPATH}
+
+    echo ">> Final installation in ${EASYBUILD_INSTALLPATH}..."
+    export PATH=${EB_TMPDIR}/bin:${PATH}
+    export PYTHONPATH=$(ls -d ${EB_TMPDIR}/lib/python*/site-packages):${PYTHONPATH}
+    eb_install_out=${TMPDIR}/eb_install.out
+    ok_msg="EESSI-extend/${EESSI_EXTEND_VERSION} installed, let's go!"
+    fail_msg="Installing EESSI-extend/${EESSI_EXTEND_VERSION} failed, that's not good... (output: ${eb_install_out})"
+    ${EB} "EESSI-extend-${EESSI_EXTEND_VERSION}.eb" 2>&1 | tee ${eb_install_out}
+    check_exit_code $? "${ok_msg}" "${fail_msg}"
+
+    # restore origin $PATH and $PYTHONPATH values, and clean up environment variables that are no longer needed
+    export PATH=${ORIG_PATH}
+    export PYTHONPATH=${ORIG_PYTHONPATH}
+    unset EB_TMPDIR ORIG_PATH ORIG_PYTHONPATH
+
+    module --ignore-cache avail EESSI-extend/${EESSI_EXTEND_VERSION} &> ${ml_av_eessi_extend_out}
+    if [[ $? -eq 0 ]]; then
+        echo_green ">> EESSI-extend/${EESSI_EXTEND_VERSION} module installed!"
+    else
+        fatal_error "EESSI-extend/${EESSI_EXTEND_VERSION} module failed to install?! (output of 'pip install' in ${pip_install_out}, output of 'eb' in ${eb_install_out}, output of 'module avail EESSI-extend' in ${ml_av_eessi_extend_out})"
+    fi
+fi
+
+echo ">> Loading EESSI-extend/${EESSI_EXTEND_VERSION} module..."
+module --ignore-cache load EESSI-extend/${EESSI_EXTEND_VERSION}
+
+unset EESSI_EXTEND_VERSION

--- a/load_eessi_extend_module.sh
+++ b/load_eessi_extend_module.sh
@@ -8,9 +8,9 @@
 # - TMPDIR is set
 # - EB is set
 # - EASYBUILD_INSTALLPATH needs to be set
-# - function check_exit_code is defined
-#   cfg/utils.sh in EESSI/software-layer repository defines this function, hence
-#   cfg/utils.sh shall be sourced before this script is run
+# - Function check_exit_code is defined;
+#   scripts/utils.sh in EESSI/software-layer repository defines this function, hence
+#   scripts/utils.sh shall be sourced before this script is run
 #
 # This script is part of the EESSI software layer, see
 # https://github.com/EESSI/software-layer.git


### PR DESCRIPTION
This is heavily based on `load_easybuild_module.sh`. It should help resolving issues we have seen when start building for a new CPU microarchitecture and when rebuilding the `EESSI-extend` module. See related PRs
- https://github.com/EESSI/software-layer/pull/801
- https://github.com/EESSI/software-layer/pull/808
- https://github.com/EESSI/software-layer/pull/810

#810 supersedes this PR.