### PR TITLE
{2023.06}[foss/2023b] Mustache v1.3.3

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023b.yml
@@ -8,3 +8,7 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyblocks/pull/3496
         include-easyblocks-from-commit: 60633b0acfd41a0732992d9e16800dae71a056eb
   - Cython-3.0.10-GCCcore-13.2.0.eb
+  - Mustache-1.3.3-foss-2023b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyblocks/pull/21783
+        from-commit: 5fa3db9eb36f91cba3fbf351549f8ba2849abc33 

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023b.yml
@@ -10,5 +10,5 @@ easyconfigs:
   - Cython-3.0.10-GCCcore-13.2.0.eb
   - Mustache-1.3.3-foss-2023b.eb:
       options:
-        # see https://github.com/easybuilders/easybuild-easyblocks/pull/21783
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21783
         from-commit: 5fa3db9eb36f91cba3fbf351549f8ba2849abc33 


### PR DESCRIPTION
missing packages :


```
Abseil/20240116.1-GCCcore-13.2.0
Arrow/16.1.0-gfbf-2023b
cooler/0.10.2-foss-2023b
dill/0.3.8-GCCcore-13.2.0
h5py/3.11.0-foss-2023b
hic-straw/1.3.1-foss-2023b
multiprocess/0.70.16-gfbf-2023b
Mustache/1.3.3-foss-2023b
pyfaidx/0.8.1.1-GCCcore-13.2.0
RapidJSON/1.1.0-20240409-GCCcore-13.2.0
RE2/2024-03-01-GCCcore-13.2.0
statsmodels/0.14.1-gfbf-2023b
utf8proc/2.9.0-GCCcore-13.2.0
```
