### PR TITLE
clean `${tmpdir}` after iterations in `install_cuda_and_libraries.sh`

### DIFF
--- a/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
+++ b/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
@@ -239,9 +239,9 @@ for EASYSTACK_FILE in ${TOPDIR}/easystacks/eessi-*CUDA*.yml; do
       echo_green "all installations at ${EESSI_SITE_SOFTWARE_PATH}/software/... succeeded!"
     fi
 
+    # clean up tmpdir content
+    rm -rf "${tmpdir}"/*
+
     # Restore MODULEPATH for next loop iteration
     MODULEPATH=${SAVE_MODULEPATH}
 done
-
-# clean up tmpdir
-rm -rf "${tmpdir}"

--- a/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
+++ b/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
@@ -239,9 +239,9 @@ for EASYSTACK_FILE in ${TOPDIR}/easystacks/eessi-*CUDA*.yml; do
       echo_green "all installations at ${EESSI_SITE_SOFTWARE_PATH}/software/... succeeded!"
     fi
 
-    # clean up tmpdir
-    rm -rf "${tmpdir}"
-
     # Restore MODULEPATH for next loop iteration
     MODULEPATH=${SAVE_MODULEPATH}
 done
+
+# clean up tmpdir
+rm -rf "${tmpdir}"


### PR DESCRIPTION
The `${tmpdir}` can be cleaned after all iterations are done when having multiple `easystacks/eessi-*CUDA*.yml` files