### PR TITLE
{2023.06}[foss/2023b] GDRCopy 2.4

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023b.yml
@@ -12,3 +12,4 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21783
         from-commit: 5fa3db9eb36f91cba3fbf351549f8ba2849abc33 
+  - GDRCopy-2.4-GCCcore-13.2.0.eb


### PR DESCRIPTION
Required for https://github.com/EESSI/software-layer/pull/817.