### PR TITLE
{2023.06}[foss/2023a] LightGBM v4.5.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -25,3 +25,7 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21657
         from-commit: 7f1f0e60487e7e1fcb5c4e6bc4fbc4f89994e3fd
+  - LightGBM-4.5.0-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21699
+        from-commit: e3407bd127d248c08960f6b09c973da0fdecc2c3


### PR DESCRIPTION
missing packages :
```
libidn2/2.3.7-GCCcore-12.3.0.lua
LightGBM/4.5.0-foss-2023a.lua
scikit-build-core/0.9.3-GCCcore-12.3.0.lua
wget/1.24.5-GCCcore-12.3.0.lua
```