### PR TITLE
{2023.06}[foss/2023a] LightGBM v4.5.0 w/ CUDA 12.1.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/accel/nvidia/eessi-2023.06-eb-4.9.4-2023a-CUDA.yml
+++ b/easystacks/software.eessi.io/2023.06/accel/nvidia/eessi-2023.06-eb-4.9.4-2023a-CUDA.yml
@@ -1,3 +1,7 @@
 easyconfigs:
   - CUDA-12.1.1.eb
   - cuDNN-8.9.2.26-CUDA-12.1.1.eb
+  - LightGBM-4.5.0-foss-2023a-CUDA-12.1.1.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21699
+        from-commit: e3407bd127d248c08960f6b09c973da0fdecc2c3


### PR DESCRIPTION
missing packages:
```
LightGBM/4.5.0-foss-2023a-CUDA-12.1.1
```