### PR TITLE
use variable for CVMFS repository in Lmod initialization scripts

### DIFF
--- a/init/lmod/bash
+++ b/init/lmod/bash
@@ -1,8 +1,10 @@
+# Choose an EESSI CVMFS repository
+EESSI_CVMFS_REPO="${EESSI_CVMFS_REPO:-/cvmfs/software.eessi.io}"
 # Choose an EESSI version
 EESSI_VERSION="${EESSI_VERSION:-2023.06}"
 # Path to top-level module tree
-export MODULEPATH=/cvmfs/software.eessi.io/versions/"$EESSI_VERSION"/init/modules
-. /cvmfs/software.eessi.io/versions/"$EESSI_VERSION"/compat/linux/$(uname -m)/usr/share/Lmod/init/bash
+export MODULEPATH="${EESSI_CVMFS_REPO}/versions/${EESSI_VERSION}/init/modules"
+. "${EESSI_CVMFS_REPO}/versions/${EESSI_VERSION}/compat/linux/$(uname -m)/usr/share/Lmod/init/bash"
 
 if [ -z "$__Init_Default_Modules" ]; then
    export __Init_Default_Modules=1;

--- a/init/lmod/csh
+++ b/init/lmod/csh
@@ -1,8 +1,10 @@
+# Choose an EESSI CVMFS repository
+if (! $?EESSI_CVMFS_REPO) then; set EESSI_CVMFS_REPO = "/cvmfs/software.eessi.io"; endif
 # Choose an EESSI version
 if (! $?EESSI_VERSION) then; set EESSI_VERSION = "2023.06"; endif
 # Path to top-level module tree
-setenv MODULEPATH /cvmfs/software.eessi.io/versions/"$EESSI_VERSION"/init/modules
-source /cvmfs/software.eessi.io/versions/"$EESSI_VERSION"/compat/linux/`uname -m`/usr/share/Lmod/init/csh
+setenv MODULEPATH "${EESSI_CVMFS_REPO}/versions/${EESSI_VERSION}/init/modules"
+source "${EESSI_CVMFS_REPO}/versions/${EESSI_VERSION}/compat/linux/$(uname -m)/usr/share/Lmod/init/csh"
 
 if (! $?__Init_Default_Modules ) then
 	setenv __Init_Default_Modules 1;

--- a/init/lmod/fish
+++ b/init/lmod/fish
@@ -4,7 +4,7 @@ set EESSI_CVMFS_REPO (set -q EESSI_CVMFS_REPO; and echo "$EESSI_CVMFS_REPO"; or 
 set EESSI_VERSION (set -q EESSI_VERSION; and echo "$EESSI_VERSION"; or echo "2023.06")
 # Path to top-level module tree
 set -x MODULEPATH MODULEPATH="$EESSI_CVMFS_REPO/versions/$EESSI_VERSION/init/modules"
-. "$EESSI_CVMFS_REPO/versions/$EESSI_VERSION/compat/linux/$(uname -m)/usr/share/Lmod/init/fish"
+. "$EESSI_CVMFS_REPO/versions/$EESSI_VERSION/compat/linux/(uname -m)/usr/share/Lmod/init/fish"
 
 if test -z "$__Init_Default_Modules"
 	export __Init_Default_Modules=1;

--- a/init/lmod/fish
+++ b/init/lmod/fish
@@ -3,8 +3,8 @@ set EESSI_CVMFS_REPO (set -q EESSI_CVMFS_REPO; and echo "$EESSI_CVMFS_REPO"; or 
 # Choose an EESSI version
 set EESSI_VERSION (set -q EESSI_VERSION; and echo "$EESSI_VERSION"; or echo "2023.06")
 # Path to top-level module tree
-set -x MODULEPATH MODULEPATH="${EESSI_CVMFS_REPO}/versions/${EESSI_VERSION}/init/modules"
-. "${EESSI_CVMFS_REPO}/versions/${EESSI_VERSION}/compat/linux/$(uname -m)/usr/share/Lmod/init/fish"
+set -x MODULEPATH MODULEPATH="$EESSI_CVMFS_REPO/versions/$EESSI_VERSION/init/modules"
+. "$EESSI_CVMFS_REPO/versions/$EESSI_VERSION/compat/linux/$(uname -m)/usr/share/Lmod/init/fish"
 
 if test -z "$__Init_Default_Modules"
 	export __Init_Default_Modules=1;

--- a/init/lmod/fish
+++ b/init/lmod/fish
@@ -3,7 +3,7 @@ set EESSI_CVMFS_REPO (set -q EESSI_CVMFS_REPO; and echo "$EESSI_CVMFS_REPO"; or 
 # Choose an EESSI version
 set EESSI_VERSION (set -q EESSI_VERSION; and echo "$EESSI_VERSION"; or echo "2023.06")
 # Path to top-level module tree
-set -x MODULEPATH MODULEPATH="$EESSI_CVMFS_REPO"/versions/"$EESSI_VERSION"/init/modules
+set -x MODULEPATH "$EESSI_CVMFS_REPO"/versions/"$EESSI_VERSION"/init/modules
 . "$EESSI_CVMFS_REPO"/versions/"$EESSI_VERSION"/compat/linux/(uname -m)/usr/share/Lmod/init/fish
 
 if test -z "$__Init_Default_Modules"

--- a/init/lmod/fish
+++ b/init/lmod/fish
@@ -3,8 +3,8 @@ set EESSI_CVMFS_REPO (set -q EESSI_CVMFS_REPO; and echo "$EESSI_CVMFS_REPO"; or 
 # Choose an EESSI version
 set EESSI_VERSION (set -q EESSI_VERSION; and echo "$EESSI_VERSION"; or echo "2023.06")
 # Path to top-level module tree
-set -x MODULEPATH MODULEPATH="$EESSI_CVMFS_REPO/versions/$EESSI_VERSION/init/modules"
-. "$EESSI_CVMFS_REPO/versions/$EESSI_VERSION/compat/linux/(uname -m)/usr/share/Lmod/init/fish"
+set -x MODULEPATH MODULEPATH="$EESSI_CVMFS_REPO"/versions/"$EESSI_VERSION"/init/modules
+. "$EESSI_CVMFS_REPO}"/versions/"$EESSI_VERSION"/compat/linux/(uname -m)/usr/share/Lmod/init/fish
 
 if test -z "$__Init_Default_Modules"
 	export __Init_Default_Modules=1;

--- a/init/lmod/fish
+++ b/init/lmod/fish
@@ -4,7 +4,7 @@ set EESSI_CVMFS_REPO (set -q EESSI_CVMFS_REPO; and echo "$EESSI_CVMFS_REPO"; or 
 set EESSI_VERSION (set -q EESSI_VERSION; and echo "$EESSI_VERSION"; or echo "2023.06")
 # Path to top-level module tree
 set -x MODULEPATH MODULEPATH="$EESSI_CVMFS_REPO"/versions/"$EESSI_VERSION"/init/modules
-. "$EESSI_CVMFS_REPO}"/versions/"$EESSI_VERSION"/compat/linux/(uname -m)/usr/share/Lmod/init/fish
+. "$EESSI_CVMFS_REPO"/versions/"$EESSI_VERSION"/compat/linux/(uname -m)/usr/share/Lmod/init/fish
 
 if test -z "$__Init_Default_Modules"
 	export __Init_Default_Modules=1;

--- a/init/lmod/fish
+++ b/init/lmod/fish
@@ -1,8 +1,10 @@
+# Choose an EESSI CVMFS repository
+set EESSI_CVMFS_REPO (set -q EESSI_CVMFS_REPO; and echo "$EESSI_CVMFS_REPO"; or echo "/cvmfs/software.eessi.io")
 # Choose an EESSI version
 set EESSI_VERSION (set -q EESSI_VERSION; and echo "$EESSI_VERSION"; or echo "2023.06")
 # Path to top-level module tree
-set -x MODULEPATH /cvmfs/software.eessi.io/versions/"$EESSI_VERSION"/init/modules
-. /cvmfs/software.eessi.io/versions/"$EESSI_VERSION"/compat/linux/(uname -m)/usr/share/Lmod/init/fish
+set -x MODULEPATH MODULEPATH="${EESSI_CVMFS_REPO}/versions/${EESSI_VERSION}/init/modules"
+. "${EESSI_CVMFS_REPO}/versions/${EESSI_VERSION}/compat/linux/$(uname -m)/usr/share/Lmod/init/fish"
 
 if test -z "$__Init_Default_Modules"
 	export __Init_Default_Modules=1;

--- a/init/lmod/ksh
+++ b/init/lmod/ksh
@@ -1,8 +1,10 @@
+# Choose an EESSI CVMFS repository
+EESSI_CVMFS_REPO="${EESSI_CVMFS_REPO:-/cvmfs/software.eessi.io}"
 # Choose an EESSI version
 EESSI_VERSION="${EESSI_VERSION:-2023.06}"
 # Path to top-level module tree
-export MODULEPATH=/cvmfs/software.eessi.io/versions/"$EESSI_VERSION"/init/modules
-. /cvmfs/software.eessi.io/versions/"$EESSI_VERSION"/compat/linux/$(uname -m)/usr/share/Lmod/init/ksh
+export MODULEPATH="${EESSI_CVMFS_REPO}/versions/${EESSI_VERSION}/init/modules"
+. "${EESSI_CVMFS_REPO}/versions/${EESSI_VERSION}/compat/linux/$(uname -m)/usr/share/Lmod/init/ksh"
 
 if [ -z "$__Init_Default_Modules" ]; then
    export __Init_Default_Modules=1;

--- a/init/lmod/zsh
+++ b/init/lmod/zsh
@@ -1,8 +1,10 @@
+# Choose an EESSI CVMFS repository
+EESSI_CVMFS_REPO="${EESSI_CVMFS_REPO:-/cvmfs/software.eessi.io}"
 # Choose an EESSI version
 EESSI_VERSION="${EESSI_VERSION:-2023.06}"
 # Path to top-level module tree
-export MODULEPATH=/cvmfs/software.eessi.io/versions/"$EESSI_VERSION"/init/modules
-. /cvmfs/software.eessi.io/versions/"$EESSI_VERSION"/compat/linux/$(uname -m)/usr/share/Lmod/init/zsh
+export MODULEPATH="${EESSI_CVMFS_REPO}/versions/${EESSI_VERSION}/init/modules"
+. "${EESSI_CVMFS_REPO}/versions/${EESSI_VERSION}/compat/linux/$(uname -m)/usr/share/Lmod/init/zsh"
 
 if [ -z "$__Init_Default_Modules" ]; then
    export __Init_Default_Modules=1;


### PR DESCRIPTION
This is required for the RISC-V build bot (see #803).