### PR TITLE
Disable CUDA installation for RISC-V build hosts in `bot/build.sh` (and some other minor enhancements)

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -125,7 +125,9 @@ else
 fi
 
 # determine repository to be used from entry .repository in ${JOB_CFG_FILE}
-REPOSITORY=$(cfg_get_value "repository" "repo_id")
+REPOSITORY_ID=$(cfg_get_value "repository" "repo_id")
+REPOSITORY_NAME=$(cfg_get_value "repository" "repo_name")
+REPOSITORY_VERSION=$(cfg_get_value "repository" "repo_version")
 EESSI_REPOS_CFG_DIR_OVERRIDE=$(cfg_get_value "repository" "repos_cfg_dir")
 export EESSI_REPOS_CFG_DIR_OVERRIDE=${EESSI_REPOS_CFG_DIR_OVERRIDE:-${PWD}/cfg}
 echo "bot/build.sh: EESSI_REPOS_CFG_DIR_OVERRIDE='${EESSI_REPOS_CFG_DIR_OVERRIDE}'"
@@ -134,13 +136,13 @@ echo "bot/build.sh: EESSI_REPOS_CFG_DIR_OVERRIDE='${EESSI_REPOS_CFG_DIR_OVERRIDE
 # here, just set & export EESSI_VERSION_OVERRIDE
 # next script (eessi_container.sh) makes use of it via sourcing init scripts
 # (e.g., init/eessi_defaults or init/minimal_eessi_env)
-export EESSI_VERSION_OVERRIDE=$(cfg_get_value "repository" "repo_version")
+export EESSI_VERSION_OVERRIDE=${REPOSITORY_VERSION}
 echo "bot/build.sh: EESSI_VERSION_OVERRIDE='${EESSI_VERSION_OVERRIDE}'"
 
 # determine CVMFS repo to be used from .repository.repo_name in ${JOB_CFG_FILE}
 # here, just set EESSI_CVMFS_REPO_OVERRIDE, a bit further down
 # "source init/eessi_defaults" via sourcing init/minimal_eessi_env
-export EESSI_CVMFS_REPO_OVERRIDE=/cvmfs/$(cfg_get_value "repository" "repo_name")
+export EESSI_CVMFS_REPO_OVERRIDE=/cvmfs/${REPOSITORY_NAME}
 echo "bot/build.sh: EESSI_CVMFS_REPO_OVERRIDE='${EESSI_CVMFS_REPO_OVERRIDE}'"
 
 # determine CPU architecture to be used from entry .architecture in ${JOB_CFG_FILE}
@@ -169,11 +171,11 @@ COMMON_ARGS+=("--mode" "run")
 [[ ! -z ${CONTAINER} ]] && COMMON_ARGS+=("--container" "${CONTAINER}")
 [[ ! -z ${HTTP_PROXY} ]] && COMMON_ARGS+=("--http-proxy" "${HTTP_PROXY}")
 [[ ! -z ${HTTPS_PROXY} ]] && COMMON_ARGS+=("--https-proxy" "${HTTPS_PROXY}")
-[[ ! -z ${REPOSITORY} ]] && COMMON_ARGS+=("--repository" "${REPOSITORY}")
+[[ ! -z ${REPOSITORY_ID} ]] && COMMON_ARGS+=("--repository" "${REPOSITORY_ID}")
 
 # Also expose software.eessi.io when configured for dev.eessi.io
 # Need software.eessi.io for the compat layer
-if [[ "${REPOSITORY}" == dev.eessi.io ]]; then
+if [[ "${REPOSITORY_NAME}" == "dev.eessi.io" ]]; then
     COMMON_ARGS+=("--repository" "software.eessi.io,access=ro")
 fi
 

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -193,6 +193,12 @@ fi
 [[ ! -z ${BUILD_LOGS_DIR} ]] && INSTALL_SCRIPT_ARGS+=("--build-logs-dir" "${BUILD_LOGS_DIR}")
 [[ ! -z ${SHARED_FS_PATH} ]] && INSTALL_SCRIPT_ARGS+=("--shared-fs-path" "${SHARED_FS_PATH}")
 
+# Skip CUDA installation for riscv.eessi.io
+if [[ "${REPOSITORY_NAME}" == "riscv.eessi.io" ]]; then
+    echo "bot/build.sh: disabling CUDA installation for RISC-V repository (${REPOSITORY_NAME})"
+    INSTALL_SCRIPT_ARGS+=("--skip-cuda-install")
+fi
+
 # determine if the removal step has to be run
 # assume there's only one diff file that corresponds to the PR patch file
 pr_diff=$(ls [0-9]*.diff | head -1)

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -110,7 +110,7 @@ echo "bot/build.sh: LOAD_MODULES='${LOAD_MODULES}'"
 # singularity/apptainer settings: CONTAINER, HOME, TMPDIR, BIND
 CONTAINER=$(cfg_get_value "repository" "container")
 export SINGULARITY_HOME="${PWD}:/eessi_bot_job"
-export SINGULARITY_TMPDIR="${PWD}/singularity_tmpdir"
+export SINGULARITY_TMPDIR="${JOB_STORAGE}/singularity_tmpdir"
 mkdir -p ${SINGULARITY_TMPDIR}
 
 # load modules if LOAD_MODULES is not empty


### PR DESCRIPTION
This PR
- adds some extra variables for the repository id, name, and version, and uses them throughout the script
- changes the check for the dev repo, as it basically checked if the repo id defined in the bot config equals "dev.eessi.io", but the repo id could in principle be anything. It's better to check against the real repository name.
- puts $SINGULARITY_TMPDIR under $JOB_STORAGE (job's temporary directory) instead of under $PWD (shared job dir), as it will only contain temporary files created by Singularity. This solves an issue that I had on the RISC-V cluster (it couldn't remove some files from the home directory at the end of the container session), and I think it's better to do it like this anyway.