### PR TITLE
Always set `$STORAGE` and `$JOB_STORAGE` in `bot/test.sh`

### DIFF
--- a/bot/test.sh
+++ b/bot/test.sh
@@ -103,25 +103,25 @@ fi
 RESUME_DIR=$(grep 'Using .* as tmp directory' slurm-${SLURM_JOBID}.out | head -1 | awk '{print $2}')
 
 if [[ -z ${RESUME_DIR} ]]; then
-  echo -n "setting \$STORAGE by replacing any var in '${LOCAL_TMP}' -> "
-  # replace any env variable in ${LOCAL_TMP} with its
-  #   current value (e.g., a value that is local to the job)
-  STORAGE=$(envsubst <<< ${LOCAL_TMP})
-  echo "'${STORAGE}'"
-
-  # make sure ${STORAGE} exists
-  mkdir -p ${STORAGE}
-
-  # make sure the base tmp storage is unique
-  JOB_STORAGE=$(mktemp --directory --tmpdir=${STORAGE} bot_job_tmp_XXX)
-  echo "bot/test.sh: created unique base tmp storage directory at ${JOB_STORAGE}"
-
   RESUME_TGZ=${PWD}/previous_tmp/build_step/$(ls previous_tmp/build_step)
   if [[ -z ${RESUME_TGZ} ]]; then
     echo "bot/test.sh: no information about tmp directory and tarball of build step; --> giving up"
     exit 2
   fi
 fi
+
+echo -n "setting \$STORAGE by replacing any var in '${LOCAL_TMP}' -> "
+# replace any env variable in ${LOCAL_TMP} with its
+#   current value (e.g., a value that is local to the job)
+STORAGE=$(envsubst <<< ${LOCAL_TMP})
+echo "'${STORAGE}'"
+
+# make sure ${STORAGE} exists
+mkdir -p ${STORAGE}
+
+# make sure the base tmp storage is unique
+JOB_STORAGE=$(mktemp --directory --tmpdir=${STORAGE} bot_job_tmp_XXX)
+echo "bot/test.sh: created unique base tmp storage directory at ${JOB_STORAGE}"
 
 # obtain list of modules to be loaded
 LOAD_MODULES=$(cfg_get_value "site_config" "load_modules")

--- a/bot/test.sh
+++ b/bot/test.sh
@@ -130,7 +130,7 @@ echo "bot/test.sh: LOAD_MODULES='${LOAD_MODULES}'"
 # singularity/apptainer settings: CONTAINER, HOME, TMPDIR, BIND
 CONTAINER=$(cfg_get_value "repository" "container")
 export SINGULARITY_HOME="${PWD}:/eessi_bot_job"
-export SINGULARITY_TMPDIR="${PWD}/singularity_tmpdir"
+export SINGULARITY_TMPDIR="${JOB_STORAGE:-${PWD}}/singularity_tmpdir"
 mkdir -p ${SINGULARITY_TMPDIR}
 
 # load modules if LOAD_MODULES is not empty


### PR DESCRIPTION
Even when resuming from a previous directory/tarball, `$STORAGE` and `$JOB_STORAGE` are not set, so I think we should always do this. For that reason, I moved them out of the if statement.

Also, this sets `$SINGULARITY_TMPDIR` to a subdir of `$JOB_STORAGE`, similar to the change made in #836.