### PR TITLE
{2023.06}[foss/2023a] Tombo v1.5.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -71,7 +71,3 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21227
         from-commit: 4c5e3455dec31e68e8383c7fd86d1f80c434676d
-  - Tombo-1.5.1-foss-2023a.eb:
-      options:
-        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21925
-        from-commit: 522ca010ab11949ab9594037f72b975cf1cd0d33

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -71,3 +71,7 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21227
         from-commit: 4c5e3455dec31e68e8383c7fd86d1f80c434676d
+  - Tombo-1.5.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21925
+        from-commit: 522ca010ab11949ab9594037f72b975cf1cd0d33

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -37,3 +37,7 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20230
         from-commit: 91c8df6b4c0810061e9f325427c9c79e961bc4b0
+  - Tombo-1.5.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21925
+        from-commit: 522ca010ab11949ab9594037f72b975cf1cd0d33


### PR DESCRIPTION
missing packages:
```
rpy2/3.5.15-foss-2023a
Tombo/1.5.1-foss-2023a
```