### PR TITLE
{2023.06}[GCC/13.2.0] wxWidgets v3.2.6

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023b.yml
@@ -21,3 +21,7 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21899
         from-commit: 0bdeb23c9ea5a3caefd353ecd936919424c1bba4
+  - wxWidgets-3.2.6-GCC-13.2.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21915
+        from-commit: 58f16c0caf8c5494c68e9eda8cbf19e9145d3cfa


### PR DESCRIPTION
missing packages:
```
Graphene/1.10.8-GCCcore-13.2.0
GST-plugins-base/1.24.8-GCC-13.2.0
GStreamer/1.24.8-GCC-13.2.0
wxWidgets/3.2.6-GCC-13.2.0
```