### PR TITLE
Print LmodError when loading GCCcore-12.2.0-based modules on `zen4`

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -52,10 +52,10 @@ def is_gcccore_1220_based(**kwargs):
     :param str tcname: Toolchain name specified in the EasyConfig
     :param str tcversion: Toolchain version specified in the EasyConfig
     """
-    ecname = kwargs.get['ecname', None]
-    ecversion = kwargs.get['ecversion', None]
-    tcname = kwargs.get['tcname', None]
-    tcversion = kwargs.get['tcversion', None]
+    ecname = kwargs.get('ecname', None)
+    ecversion = kwargs.get('ecversion', None)
+    tcname = kwargs.get('tcname', None)
+    tcversion = kwargs.get('tcversion', None)
 
     gcccore_based_names = ['GCCcore', 'GCC']
     foss_based_names = ['gfbf', 'gompi', 'foss']
@@ -405,7 +405,8 @@ def parse_hook_zen4_module_only(ec, eprefix):
     This toolchain will not be supported on Zen4, so we will generate a modulefile
     and have it print an LmodError.
     """
-    if is_gcccore_1220_based(ec['name'], ec['version'], ec['toolchain']['name'], ec['toolchain']['version']):
+    if is_gcccore_1220_based(ecname=ec['name'], ecversion=ec['version'], tcname=ec['toolchain']['name'],
+                             tcversion=ec['toolchain']['version']):
         env_varname = EESSI_IGNORE_ZEN4_GCC1220_ENVVAR
         # TODO: create a docs page to which we can refer for more info here
         # TODO: then update the link to the known issues page to the _specific_ issue
@@ -432,7 +433,8 @@ def pre_fetch_hook_zen4_gcccore1220(self, *args, **kwargs):
     This toolchain will not be supported on Zen4, so we will generate a modulefile
     and have it print an LmodError.
     """
-    if is_gcccore_1220_based(self.name, self.version, self.toolchain.name, self.toolchain.version):
+    if is_gcccore_1220_based(ecname=self.name, ecversion=self.version, tcname=self.toolchain.name,
+                             tcversion=self.toolchain.version):
         if hasattr(self, EESSI_MODULE_ONLY_ATTR):
             raise EasyBuildError("'self' already has attribute %s! Can't use pre_fetch hook.",
                                  EESSI_MODULE_ONLY_ATTR)
@@ -450,7 +452,8 @@ def pre_fetch_hook_zen4_gcccore1220(self, *args, **kwargs):
 
 def post_module_hook_zen4_gcccore1220(self, *args, **kwargs):
     """Revert changes from pre_fetch_hook_zen4_gcccore1220"""
-    if is_gcccore_1220_based(self.name, self.version, self.toolchain.name, self.toolchain.version):
+    if is_gcccore_1220_based(ecname=self.name, ecversion=self.version, tcname=self.toolchain.name,
+                             tcversion=self.toolchain.version):
         if hasattr(self, EESSI_MODULE_ONLY_ATTR):
             update_build_option('module_only', getattr(self, EESSI_MODULE_ONLY_ATTR))
             print_msg("Restored original build option 'module_only' to %s" % getattr(self, EESSI_MODULE_ONLY_ATTR))
@@ -471,13 +474,15 @@ def post_module_hook_zen4_gcccore1220(self, *args, **kwargs):
 # _with_ the warning for the current software being installed)
 def pre_prepare_hook_ignore_zen4_gcccore1220_error(self, *args, **kwargs):
     """Set environment variable to ignore the LmodError from parse_hook_zen4_module_only during build phase"""
-    if is_gcccore_1220_based(self.name, self.version, self.toolchain.name, self.toolchain.version):
+    if is_gcccore_1220_based(ecname=self.name, ecversion=self.version, tcname=self.toolchain.name,
+                             tcversion=self.toolchain.version):
         os.environ[EESSI_IGNORE_ZEN4_GCC1220_ENVVAR] = "1"
 
 
 def post_prepare_hook_ignore_zen4_gcccore1220_error(self, *args, **kwargs):
     """Unset environment variable to ignore the LmodError from parse_hook_zen4_module_only during build phase"""
-    if is_gcccore_1220_based(self.name, self.version, self.toolchain.name, self.toolchain.version):
+    if is_gcccore_1220_based(ecname=self.name, ecversion=self.version, tcname=self.toolchain.name,
+                             tcversion=self.toolchain.version):
         del os.environ[EESSI_IGNORE_ZEN4_GCC1220_ENVVAR]
 
 

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -371,13 +371,17 @@ def parse_hook_zen4_module_only(ec, eprefix):
         (ecname in ['foss', 'gompi'] and ecversion == '2022b') or
         (ecname in ['GCC', 'GCCcore'] and LooseVersion(ecversion) == LooseVersion('12.2.0'))
     ):
+        env_varname="EESSI_IGNORE_LMOD_ERROR_ZEN4_GCC1220"
+        # TODO: I need to think about how to unset this, at the end of the build for this module
+        # Maybe I shouldn't do it in the parse hook, but set it in a step hook, and unset it in a another step hook?
+        os.environ[env_varname] = "1"
         update_build_option('force', 'True')
         update_build_option('module_only', 'True')
         # TODO: create a docs page to which we can refer for more info here
         # TODO: then update the link to the known issues page to the _specific_ issue
         errmsg = "Toolchains based on GCCcore-12.2.0 are not supported for the Zen4 architecture."
         errmsg += " See https://www.eessi.io/docs/known_issues/eessi-2023.06/"
-        ec['modluafooter'] = 'LmodError(%s)' % errmsg
+        ec['modluafooter'] = 'if (not os.getenv("%s")) then LmodError("%s") end' % (env_varname, errmsg)
 
 def pre_prepare_hook_highway_handle_test_compilation_issues(self, *args, **kwargs):
     """

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -401,18 +401,6 @@ def parse_hook_zen4_module_only(ec, eprefix):
         ec['modluafooter'] = 'if (not os.getenv("%s")) then LmodError("%s") end' % (env_varname, errmsg)
 
 
-def pre_fetch_hook(ec, *args, **kwargs):
-    """Main parse hook: trigger custom functions based on software name."""
-
-    if ec.name in PRE_FETCH_HOOKS:
-        PRE_FETCH_HOOKS[ec.name](ec, *args, **kwargs)
-
-    # Always trigger this one, regardless of ec.name
-    cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
-    if cpu_target == CPU_TARGET_ZEN4:
-        pre_fetch_hook_ignore_zen4_gcccore1220_error(ec, *args, **kwargs)
-
-
 # We do this as early as possible - and remove it all the way in the last step hook (post_testcases_hook)
 def pre_prepare_hook_ignore_zen4_gcccore1220_error(self, *args, **kwargs):
     """Set environment variable to ignore the LmodError from parse_hook_zen4_module_only during build phase"""

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -392,8 +392,6 @@ def parse_hook_zen4_module_only(ec, eprefix):
     """
     if is_gcccore_1220_based(ec['name'], ec['version'], ec['toolchain']['name'], ec['toolchain']['version']):
         env_varname = EESSI_IGNORE_ZEN4_GCC1220_ENVVAR
-        # update_build_option('force', 'True')
-        # update_build_option('module_only', 'True')
         # TODO: create a docs page to which we can refer for more info here
         # TODO: then update the link to the known issues page to the _specific_ issue
         # Need to escape newline character so that the newline character actually ends up in the module file
@@ -411,10 +409,10 @@ def pre_fetch_hook(self, *args, **kwargs):
     # Always trigger this one, regardless of self.name
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
     if cpu_target == CPU_TARGET_ZEN4:
-        pre_fetch_hook_ignore_zen4_gcccore1220_error(self, *args, **kwargs)
+        pre_fetch_hook_zen4_gcccore1220(self, *args, **kwargs)
 
 
-def pre_fetch_hook_ignore_zen4_gcccore1220_error(self, *args, **kwargs):
+def pre_fetch_hook_zen4_gcccore1220(self, *args, **kwargs):
     """Use --force --module-only if building a foss-2022b-based EasyConfig for Zen4.
     This toolchain will not be supported on Zen4, so we will generate a modulefile
     and have it print an LmodError.
@@ -435,8 +433,8 @@ def pre_fetch_hook_ignore_zen4_gcccore1220_error(self, *args, **kwargs):
         print_msg("Updated build option 'force' to 'True'")
 
 
-def post_module_hook_ignore_zen4_gcccore1220_error(self, *args, **kwargs):
-    """Revert changes from pre_fetch_hook_ignore_zen4_gcccore1220_error"""
+def post_module_hook_zen4_gcccore1220(self, *args, **kwargs):
+    """Revert changes from pre_fetch_hook_zen4_gcccore1220"""
     if is_gcccore_1220_based(self.name, self.version, self.toolchain.name, self.toolchain.version):
         if hasattr(self, EESSI_MODULE_ONLY_ATTR):
             update_build_option('module_only', getattr(self, EESSI_MODULE_ONLY_ATTR))
@@ -1088,7 +1086,7 @@ def post_module_hook(self, *args, **kwargs):
     # Always trigger this one, regardless of self.name
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
     if cpu_target == CPU_TARGET_ZEN4:
-        post_module_hook_ignore_zen4_gcccore1220_error(self, *args, **kwargs)
+        post_module_hook_zen4_gcccore1220(self, *args, **kwargs)
 
 
 PARSE_HOOKS = {


### PR DESCRIPTION
- [x] Depends on: https://github.com/EESSI/docs/pull/357

Implements the idea from https://gitlab.com/eessi/support/-/issues/37#note_2159031831

But, not currently working, because the first module that gets installed that uses GCCcore-12.2.0 as dependency will try to load it (even with `--module-only`), which then fails:

```
== creating module...
  >> generating module file @ /home/casparl/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/modules/all/GCCcore/12.2.0.lua
== ... (took < 1 sec)
== permissions [skipped]
== packaging [skipped]
  >> running command:
        [started at: 2024-12-10 18:12:47]
        [working dir: /gpfs/home4/casparl/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/modules]
        [output logged in /scratch-local/casparl.8987353/eb-bscq9hvh/easybuild-run_cmd-pxom1tke.log]
        bzip2 /home/casparl/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/software/GCCcore/12.2.0/easybuild/easybuild-GCCcore-12.2.0-20241210.181247.log
  >> command completed: exit 0, ran in < 1s
== COMPLETED: Installation ended successfully (took 1 secs)
== Results of the build can be found in the log file(s) /home/casparl/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/software/GCCcore/12.2.0/easybuild/easybuild-GCCcore-12.2.0-20241210.181247.log.bz2
== processing EasyBuild easyconfig /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4/software/EasyBuild/4.9.4/easybuild/easyconfigs/p/pkgconf/pkgconf-1.9.3-GCCcore-12.2.0.eb
== building and installing pkgconf/1.9.3-GCCcore-12.2.0...
  >> installation prefix: /home/casparl/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/software/pkgconf/1.9.3-GCCcore-12.2.0
== fetching files [skipped]
== creating build dir, resetting environment...
  >> build dir: /tmp/casparl/easybuild/build/pkgconf/1.9.3/GCCcore-12.2.0
== Running post-ready hook...
== ... (took < 1 sec)
== unpacking [skipped]
== patching [skipped]
== preparing...
== Running pre-prepare hook...
== ... (took < 1 sec)
== FAILED: Installation ended unsuccessfully (build directory: /tmp/casparl/easybuild/build/pkgconf/1.9.3/GCCcore-12.2.0): build failed (first 300 chars): Module command '/usr/share/lmod/lmod/libexec/lmod python show GCCcore/12.2.0' failed with exit code 1; stderr: Lmod has detected
the following error: Unable to load module because of error when evaluating modulefile:
     /home/casparl/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/modules/al (took 0 secs)
== Results of the build can be found in the log file(s) /scratch-local/casparl.8987353/eb-bscq9hvh/easybuild-pkgconf-1.9.3-20241210.181248.DZrFb.log
0:00:02  1 out of 37 easyconfigs done: GCCcore/12.2.0 (OK)
ERROR: Build of /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4/software/EasyBuild/4.9.4/easybuild/easyconfigs/p/pkgconf/pkgconf-1.9.3-GCCcore-12.2.0.eb failed (err: "build failed (first 300 chars): Module command '/usr/share/lmod/lmod/libexec/lmod python show GCCcore/12.2.0' failed with exit code 1; stderr: Lmod has detected the following error: Unable to load module because of error when evaluating modulefile:\n     /home/casparl/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/modules/al")
```
_maybe_ we can make that pre-prepare hook do nothing. Or skip the prepare phase. NOt sure...