### PR TITLE
{2023.06}{2022b, sapphire_rapids} GObject-Introspection 1.74.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -2,3 +2,4 @@ easyconfigs:
   - GCC-12.2.0.eb
   - Python-3.10.8-GCCcore-12.2.0-bare.eb
   - make-4.3-GCCcore-12.2.0.eb
+  - cairo-1.17.4-GCCcore-12.2.0.eb

--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.2-2022b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - GObject-Introspection-1.74.0-GCCcore-12.2.0.eb


### PR DESCRIPTION
This makes sure that the dependencies are built with EB 4.8.2, and GObject-Introspection itself with EB 4.9.2, as we've done for other architectures with a rebuild (to make sure a new hook was picked up).