### PR TITLE
{2023.06}[2022b,2023a,2023b,sapphire_rapids] OpenMPI 4.1.4 + 4.1.5 + 4.1.6

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -3,3 +3,6 @@ easyconfigs:
   - Python-3.10.8-GCCcore-12.2.0-bare.eb
   - make-4.3-GCCcore-12.2.0.eb
   - cairo-1.17.4-GCCcore-12.2.0.eb
+  - UCC-1.1.0-GCCcore-12.2.0.eb
+  - PMIx-4.2.2-GCCcore-12.2.0.eb
+  - libfabric-1.16.1-GCCcore-12.2.0.eb

--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2022b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - OpenMPI-4.1.4-GCC-12.2.0.eb

--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -2,3 +2,6 @@ easyconfigs:
   - GCCcore-12.3.0.eb:
       options:
         from-pr: 20218
+  - OpenMPI-4.1.5-GCC-12.3.0:
+      options:
+        from-pr: 19940

--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -2,3 +2,6 @@ easyconfigs:
   - GCCcore-13.2.0.eb:
       options:
         from-pr: 19974
+  - OpenMPI-4.1.6-GCC-13.2.0:
+      options:
+        from-pr: 19940


### PR DESCRIPTION
Based on how things were (re)built for the other architectures: for 4.1.4 we build all dependencies with EB 4.8.2, and OpenMPI itself with 4.9.0. For the 4.1.5 and 4.1.6, everything is built with EB 4.9.0.