### PR TITLE
{2023.06}[2023a, 2023b, sapphire_rapids] Python 3.11 and hatchling 1.18.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -1,0 +1,6 @@
+easyconfigs:
+  - XZ-5.4.2-GCCcore-12.3.0.eb
+  - libffi-3.4.4-GCCcore-12.3.0.eb
+  - SQLite-3.42.0-GCCcore-12.3.0.eb
+  - bzip2-1.0.8-GCCcore-12.3.0.eb
+  - UnZip-6.0-GCCcore-12.3.0.eb

--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023b.yml
@@ -5,3 +5,7 @@ easyconfigs:
   - OpenMPI-4.1.6-GCC-13.2.0:
       options:
         from-pr: 19940
+  - XZ-5.4.4-GCCcore-13.2.0.eb
+  - SQLite-3.43.1-GCCcore-13.2.0.eb
+  - UnZip-6.0-GCCcore-13.2.0.eb
+  - libffi-3.4.4-GCCcore-13.2.0.eb

--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -1,0 +1,3 @@
+easyconfigs:
+  - Python-3.11.3-GCCcore-12.3.0.eb
+  - hatchling-1.18.0-GCCcore-12.3.0.eb

--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.1-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.1-2023b.yml
@@ -1,0 +1,3 @@
+easyconfigs:
+  - Python-3.11.5-GCCcore-13.2.0.eb
+  - hatchling-1.18.0-GCCcore-13.2.0.eb


### PR DESCRIPTION
This takes the rebuilds from https://github.com/EESSI/software-layer/blob/2023.06-software.eessi.io/easystacks/software.eessi.io/2023.06/rebuilds/20240419-eb-4.9.1-move-setuptools_scm-from-hatchling-to-Python.yml into account by building all Python dependencies with the original EB version, and Python itself with 4.9.1. I'll do the PyPI bundle in a follow-up PR.