### PR TITLE
{2023.06}[2023a,sapphire_rapids] Rebuild hatchling 1.18.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20250120-eb-4.9.2-hatchling-1.18.0-updated-easyconfig-sapphire_rapids.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20250120-eb-4.9.2-hatchling-1.18.0-updated-easyconfig-sapphire_rapids.yml
@@ -1,0 +1,9 @@
+# 2025.01.20
+# hatchling-1.18.0 rebuild to account for easyconfig changed upstream 
+# see https://gitlab.com/eessi/support/-/issues/85 and
+# https://github.com/easybuilders/easybuild-easyconfigs/pull/20389
+easyconfigs:
+  - hatchling-1.18.0-GCCcore-12.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20389
+        from-commit: 9580c0d67d6dd97b160b768a839bfcba6d5b21b9


### PR DESCRIPTION
Doing the same as https://github.com/EESSI/software-layer/blob/2023.06-software.eessi.io/easystacks/software.eessi.io/2023.06/rebuilds/20240814-eb-4.9.2-hatchling-1.18.0-updated-easyconfig.yml.