### PR TITLE
{2023.06}[2023a, sapphire_rapids] TensorFlow 2.13.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -11,3 +11,15 @@ easyconfigs:
   - poetry-1.5.1-GCCcore-12.3.0.eb
   - git-2.41.0-GCCcore-12.3.0-nodocs.eb
   - flit-3.9.0-GCCcore-12.3.0.eb
+  - foss-2023a.eb
+  - pybind11-2.11.1-GCCcore-12.3.0.eb:
+      # avoid indirect dependency on old CMake version built with GCCcore/10.2.0 via Catch2 build dependency;
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19270
+      options:
+        from-pr: 19270
+  - SciPy-bundle-2023.07-gfbf-2023a.eb
+  - TensorFlow-2.13.0-foss-2023a.eb:
+      # patch setup.py for grpcio extension in TensorFlow 2.13.0 easyconfigs to take into account alternate sysroot;
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19268
+      options:
+        from-pr: 19268

--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -22,7 +22,9 @@ easyconfigs:
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19270
       options:
         from-pr: 19270
-  - SciPy-bundle-2023.07-gfbf-2023a.eb
+  - SciPy-bundle-2023.07-gfbf-2023a.eb:
+      options:
+        from-pr: 21693
   - TensorFlow-2.13.0-foss-2023a.eb:
       # patch setup.py for grpcio extension in TensorFlow 2.13.0 easyconfigs to take into account alternate sysroot;
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19268

--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.8.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.8.2-2023a.yml
@@ -11,6 +11,11 @@ easyconfigs:
   - poetry-1.5.1-GCCcore-12.3.0.eb
   - git-2.41.0-GCCcore-12.3.0-nodocs.eb
   - flit-3.9.0-GCCcore-12.3.0.eb
+  - OpenBLAS-0.3.23-GCC-12.3.0.eb:
+      options:
+        # required for Intel Sapphire Rapids support
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19159
+        from-pr: 19159
   - foss-2023a.eb
   - pybind11-2.11.1-GCCcore-12.3.0.eb:
       # avoid indirect dependency on old CMake version built with GCCcore/10.2.0 via Catch2 build dependency;


### PR DESCRIPTION
```
39 out of 82 required modules missing:

* Zip/3.0-GCCcore-12.3.0 (Zip-3.0-GCCcore-12.3.0.eb)
* Eigen/3.4.0-GCCcore-12.3.0 (Eigen-3.4.0-GCCcore-12.3.0.eb)
* Catch2/2.13.9-GCCcore-12.3.0 (Catch2-2.13.9-GCCcore-12.3.0.eb)
* dill/0.3.7-GCCcore-12.3.0 (dill-0.3.7-GCCcore-12.3.0.eb)
* Bazel/6.3.1-GCCcore-12.3.0 (Bazel-6.3.1-GCCcore-12.3.0.eb)
* double-conversion/3.3.0-GCCcore-12.3.0 (double-conversion-3.3.0-GCCcore-12.3.0.eb)
* flatbuffers-python/23.5.26-GCCcore-12.3.0 (flatbuffers-python-23.5.26-GCCcore-12.3.0.eb)
* flatbuffers/23.5.26-GCCcore-12.3.0 (flatbuffers-23.5.26-GCCcore-12.3.0.eb)
* giflib/5.2.1-GCCcore-12.3.0 (giflib-5.2.1-GCCcore-12.3.0.eb)
* Cython/3.0.8-GCCcore-12.3.0 (Cython-3.0.8-GCCcore-12.3.0.eb)
* Szip/2.1.1-GCCcore-12.3.0 (Szip-2.1.1-GCCcore-12.3.0.eb)
* pkgconfig/1.5.5-GCCcore-12.3.0-python (pkgconfig-1.5.5-GCCcore-12.3.0-python.eb)
* hypothesis/6.82.0-GCCcore-12.3.0 (hypothesis-6.82.0-GCCcore-12.3.0.eb)
* pybind11/2.11.1-GCCcore-12.3.0 (pybind11-2.11.1-GCCcore-12.3.0.eb)
* ICU/73.2-GCCcore-12.3.0 (ICU-73.2-GCCcore-12.3.0.eb)
* JsonCpp/1.9.5-GCCcore-12.3.0 (JsonCpp-1.9.5-GCCcore-12.3.0.eb)
* FFTW/3.3.10-GCC-12.3.0 (FFTW-3.3.10-GCC-12.3.0.eb)
* BLIS/0.9.0-GCC-12.3.0 (BLIS-0.9.0-GCC-12.3.0.eb)
* NASM/2.16.01-GCCcore-12.3.0 (NASM-2.16.01-GCCcore-12.3.0.eb)
* make/4.4.1-GCCcore-12.3.0 (make-4.4.1-GCCcore-12.3.0.eb)
* libjpeg-turbo/2.1.5.1-GCCcore-12.3.0 (libjpeg-turbo-2.1.5.1-GCCcore-12.3.0.eb)
* OpenBLAS/0.3.23-GCC-12.3.0 (OpenBLAS-0.3.23-GCC-12.3.0.eb)
* FlexiBLAS/3.3.1-GCC-12.3.0 (FlexiBLAS-3.3.1-GCC-12.3.0.eb)
* gfbf/2023a (gfbf-2023a.eb)
* SciPy-bundle/2023.07-gfbf-2023a (SciPy-bundle-2023.07-gfbf-2023a.eb)
* nsync/1.26.0-GCCcore-12.3.0 (nsync-1.26.0-GCCcore-12.3.0.eb)
* gompi/2023a (gompi-2023a.eb)
* FFTW.MPI/3.3.10-gompi-2023a (FFTW.MPI-3.3.10-gompi-2023a.eb)
* ScaLAPACK/2.2.0-gompi-2023a-fb (ScaLAPACK-2.2.0-gompi-2023a-fb.eb)
* mpi4py/3.1.4-gompi-2023a (mpi4py-3.1.4-gompi-2023a.eb)
* HDF5/1.14.0-gompi-2023a (HDF5-1.14.0-gompi-2023a.eb)
* foss/2023a (foss-2023a.eb)
* h5py/3.9.0-foss-2023a (h5py-3.9.0-foss-2023a.eb)
* snappy/1.1.10-GCCcore-12.3.0 (snappy-1.1.10-GCCcore-12.3.0.eb)
* Abseil/20230125.3-GCCcore-12.3.0 (Abseil-20230125.3-GCCcore-12.3.0.eb)
* protobuf/24.0-GCCcore-12.3.0 (protobuf-24.0-GCCcore-12.3.0.eb)
* protobuf-python/4.24.0-GCCcore-12.3.0 (protobuf-python-4.24.0-GCCcore-12.3.0.eb)
* RE2/2023-08-01-GCCcore-12.3.0 (RE2-2023-08-01-GCCcore-12.3.0.eb)
* TensorFlow/2.13.0-foss-2023a (TensorFlow-2.13.0-foss-2023a.eb)
```