### PR TITLE
{2023.06}[2023a] Rebuild SciPy-bundle 2023.07 with additional patches

### DIFF
--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -336,7 +336,8 @@ else
         if [ -f ${easystack_file} ]; then
             echo_green "Feeding easystack file ${easystack_file} to EasyBuild..."
 
-            if [[ $stack == *"/rebuilds/"* ]]; then
+            if [[ ${easystack_file} == *"/rebuilds/"* ]]; then
+                echo_yellow "This is a rebuild, so using --try-amend=keeppreviousinstall=True to reuse the already created directory"
                 ${EB} --easystack ${easystack_file} --robot --try-amend=keeppreviousinstall=True
             else
                 ${EB} --easystack ${easystack_file} --robot

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -336,7 +336,11 @@ else
         if [ -f ${easystack_file} ]; then
             echo_green "Feeding easystack file ${easystack_file} to EasyBuild..."
 
-            ${EB} --easystack ${easystack_file} --robot
+            if [[ $stack == *"/rebuilds/"* ]]; then
+                ${EB} --easystack ${easystack_file} --robot --try-amend=keeppreviousinstall=True
+            else
+                ${EB} --easystack ${easystack_file} --robot
+            fi
             ec=$?
 
             # copy EasyBuild log file if EasyBuild exited with an error

--- a/EESSI-remove-software.sh
+++ b/EESSI-remove-software.sh
@@ -131,7 +131,10 @@ if [ $EUID -eq 0 ]; then
                     rm -rf ${app_module}
                     # recreate some directory to work around permission denied
                     # issues when rebuilding the package
+                    mkdir -p ${app_dir}
+                    ls ${app_dir}
                     mkdir -p ${app_dir}/easybuild
+                    ls ${app_dir}/easybuild
                 done
             else
                 fatal_error "Easystack file ${easystack_file} not found!"

--- a/EESSI-remove-software.sh
+++ b/EESSI-remove-software.sh
@@ -127,14 +127,17 @@ if [ $EUID -eq 0 ]; then
                     app_dir=${app_installprefix}/software/${app}
                     app_module=${app_installprefix}/modules/all/${app}.lua
                     echo_yellow "Removing ${app_dir} and ${app_module}..."
+                    app_subdirs=$(find ${app_dir} -mindepth 1 -maxdepth 1 -type d)
                     rm -rf ${app_dir}
                     rm -rf ${app_module}
                     # recreate some directory to work around permission denied
                     # issues when rebuilding the package
                     mkdir -p ${app_dir}
-                    mkdir -p ${app_dir}/easybuild
-                    echo "Running ls ${app_dir}/easybuild"
-                    ls ${app_dir}/easybuild
+                    for app_subdir in ${app_subdirs}; do
+                        echo "Recreating ${app_subdir}..."
+                        mkdir -p ${app_subdir}
+                        ls ${app_subdir}
+                    done
                 done
             else
                 fatal_error "Easystack file ${easystack_file} not found!"

--- a/EESSI-remove-software.sh
+++ b/EESSI-remove-software.sh
@@ -132,8 +132,8 @@ if [ $EUID -eq 0 ]; then
                     # recreate some directory to work around permission denied
                     # issues when rebuilding the package
                     mkdir -p ${app_dir}
-                    ls ${app_dir}
                     mkdir -p ${app_dir}/easybuild
+                    echo "Running ls ${app_dir}/easybuild"
                     ls ${app_dir}/easybuild
                 done
             else

--- a/easystacks/software.eessi.io/2023.06/rebuilds/20250121-eb-4.9.4-SciPy-bundle-2023.07-bug-fixes.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20250121-eb-4.9.4-SciPy-bundle-2023.07-bug-fixes.yml
@@ -1,0 +1,14 @@
+# 2025.01.21
+# While adding support for Intel Sapphire Rapids, additional patches applied to the
+# original easyconfig were required to successfully build SciPy-bundle 2023.07.
+# In order to keep the stack consistent across the different CPUs,
+# a rebuild is done for all CPU targets with this updated easyconfig.
+# See:
+# - https://github.com/easybuilders/easybuild-easyconfigs/pull/19419
+# - https://github.com/easybuilders/easybuild-easyconfigs/pull/20817
+# - https://github.com/easybuilders/easybuild-easyconfigs/pull/21693
+easyconfigs:
+  - SciPy-bundle-2023.07-gfbf-2023a.eb
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21693
+        from-commit: 7c5144d2c1a061cd9f08b5901970b7f6ec5eb5c0

--- a/easystacks/software.eessi.io/2023.06/rebuilds/20250121-eb-4.9.4-SciPy-bundle-2023.07-bug-fixes.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20250121-eb-4.9.4-SciPy-bundle-2023.07-bug-fixes.yml
@@ -8,7 +8,7 @@
 # - https://github.com/easybuilders/easybuild-easyconfigs/pull/20817
 # - https://github.com/easybuilders/easybuild-easyconfigs/pull/21693
 easyconfigs:
-  - SciPy-bundle-2023.07-gfbf-2023a.eb
+  - SciPy-bundle-2023.07-gfbf-2023a.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21693
         from-commit: 7c5144d2c1a061cd9f08b5901970b7f6ec5eb5c0


### PR DESCRIPTION
These patches were used in https://github.com/EESSI/software-layer/pull/864 to successfully build this for Sapphire Rapids, so let's include the same patches for the other architectures by rebuilding this for all targets.