### PR TITLE
Workaround that solves permission issues for rebuilds

### DIFF
--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -336,7 +336,15 @@ else
         if [ -f ${easystack_file} ]; then
             echo_green "Feeding easystack file ${easystack_file} to EasyBuild..."
 
-            ${EB} --easystack ${easystack_file} --robot
+            if [[ ${easystack_file} == *"/rebuilds/"* ]]; then
+                # the removal script should have removed the original directory and created a new and empty one
+                # to work around permission issues:
+                # https://github.com/EESSI/software-layer/issues/556
+                echo_yellow "This is a rebuild, so using --try-amend=keeppreviousinstall=True to reuse the already created directory"
+                ${EB} --easystack ${easystack_file} --robot --try-amend=keeppreviousinstall=True
+            else
+                ${EB} --easystack ${easystack_file} --robot
+            fi
             ec=$?
 
             # copy EasyBuild log file if EasyBuild exited with an error

--- a/EESSI-remove-software.sh
+++ b/EESSI-remove-software.sh
@@ -125,13 +125,18 @@ if [ $EUID -eq 0 ]; then
                     # Two dirname invocations, so returns e.g. /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2
                     app_installprefix=$(dirname $(dirname ${app_modulepath}))
                     app_dir=${app_installprefix}/software/${app}
+                    app_subdirs=$(find ${app_dir} -mindepth 1 -maxdepth 1 -type d)
                     app_module=${app_installprefix}/modules/all/${app}.lua
                     echo_yellow "Removing ${app_dir} and ${app_module}..."
                     rm -rf ${app_dir}
                     rm -rf ${app_module}
-                    # recreate some directory to work around permission denied
-                    # issues when rebuilding the package
-                    mkdir -p ${app_dir}/easybuild
+                    # recreate the installation directories and first-level subdirectories to work around permission denied
+                    # issues when rebuilding the package (see https://github.com/EESSI/software-layer/issues/556)
+                    echo_yellow "Recreating an empty ${app_dir}..."
+                    mkdir -p ${app_dir}
+                    for app_subdir in ${app_subdirs}; do
+                        mkdir -p ${app_subdir}
+                    done
                 done
             else
                 fatal_error "Easystack file ${easystack_file} not found!"


### PR DESCRIPTION
Solves #556, tested in #866.

It works around the issue by removing the original directory, then creating a new one with the first-level subdirs (e.g. `bin`, `lib`, `easybuild`, etc), and it makes sure that EB is then run with `--try-amend=keeppreviousinstall=True` to prevent EB from wiping it again (as it would otherwise run into the same issue again).