### PR TITLE
OSU test got renamed in the EESSI test suite. This changes the name accordingly in the test mapping

### DIFF
--- a/tests/eessi_test_mapping/software_to_tests.yml
+++ b/tests/eessi_test_mapping/software_to_tests.yml
@@ -25,11 +25,11 @@ mappings:
   LAMMPS/*:
     - EESSI_LAMMPS
   OSU-Micro-Benchmarks/*:
-    - EESSI_OSU_Micro_Benchmarks
+    - EESSI_OSU
   GROMACS/*:
     - EESSI_GROMACS
   default_tests:
     # Low level tests
-    - EESSI_OSU_Micro_Benchmarks
+    - EESSI_OSU
     # A very quick-to-run high level application test
     - EESSI_LAMMPS


### PR DESCRIPTION
https://github.com/EESSI/test-suite/pull/222 broke the test mapping, due to a change in the name of the OSU test. This PR changes the name used in the mapping file so that it matches again.