### PR TITLE
{2023.06}[2023a, sapphire_rapids] OpenFOAM 10 and 11

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -5,3 +5,8 @@ easyconfigs:
   - OpenMPI-4.1.5-GCC-12.3.0:
       options:
         from-pr: 19940
+  - METIS-5.1.0-GCCcore-12.3.0.eb
+  - SCOTCH-7.0.3-gompi-2023a.eb
+  - CGAL-5.6-GCCcore-12.3.0.eb
+  - ParaView-5.11.2-foss-2023a.eb
+  - gnuplot-5.4.8-GCCcore-12.3.0.eb

--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -1,3 +1,12 @@
 easyconfigs:
   - GObject-Introspection-1.76.1-GCCcore-12.3.0.eb
   - at-spi2-core-2.49.91-GCCcore-12.3.0.eb
+  - OpenFOAM-10-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20958
+        from-commit: dbadb2074464d816740ee0e95595c2cb31b6338f
+  - OpenFOAM-11-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20958
+        from-commit: dbadb2074464d816740ee0e95595c2cb31b6338f
+


### PR DESCRIPTION
Build the dependencies using EB 4.9.0, and OpenFOAM itself with 4.9.2 (based on https://github.com/EESSI/software-layer/blob/2023.06-software.eessi.io/easystacks/software.eessi.io/2023.06/rebuilds/20240706-eb-4.9.2-OpenFOAM-no-ftree-vectorize.yml).