### PR TITLE
Generate and hide zen4 foss2022b modules

### DIFF
--- a/.github/workflows/test-software.eessi.io.yml
+++ b/.github/workflows/test-software.eessi.io.yml
@@ -59,20 +59,6 @@ jobs:
               # first check the CPU-only builds for this CPU target
               echo "just run check_missing_installations.sh (should use easystacks/software.eessi.io/${{matrix.EESSI_VERSION}}/eessi-${{matrix.EESSI_VERSION}}-*.yml with latest EasyBuild release)"
               for easystack_file in $(EESSI_VERSION=${{matrix.EESSI_VERSION}} .github/workflows/scripts/only_latest_easystacks.sh); do
-                  if [ ${{matrix.EESSI_SOFTWARE_SUBDIR_OVERRIDE}} = "x86_64/amd/zen4" ]; then
-                      if grep -q 2022b <<<"${easystack_file}"; then
-                        # skip the check of installed software on zen4 for foss/2022b builds
-                        continue
-                      fi
-                      if [[ $easystack_file == *"rebuilds"* ]]; then
-                        # Also handle rebuilds, make a temporary EasyStack file where we clean out all 2022b stuff and use that
-                        new_easystack=$(mktemp pruned_easystackXXX --suffix=.yml)
-                        # first clean out the options then clean out the .eb name
-                        sed '/2022b\|12\.2\.0/,/\.eb/{/\.eb/!d}' "${easystack_file}" | sed '/2022b\|12\.2\.0/d' > $new_easystack
-                        diff --unified=0 "$easystack_file" "$new_easystack" || :
-                        easystack_file="$new_easystack"
-                      fi
-                  fi
                   echo "check missing installations for ${easystack_file}..."
                   ./check_missing_installations.sh ${easystack_file}
                   ec=$?

--- a/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -1,4 +1,8 @@
 easyconfigs:
+  # Adding OpenMPI explicitely, as defined in 20240301-eb-4.9.0-OpenMPI-4.1.x-fix-smcuda.yml
+  - OpenMPI-4.1.4-GCC-12.2.0.eb:
+      options:
+        from-pr: 19940
   - foss-2022b.eb
   - HarfBuzz-5.3.1-GCCcore-12.2.0.eb:
       options:

--- a/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -1,0 +1,7 @@
+easyconfigs:
+  - foss-2022b.eb
+  - HarfBuzz-5.3.1-GCCcore-12.2.0.eb:
+      options:
+        from-pr: 19339
+  - Qt5-5.15.7-GCCcore-12.2.0.eb
+  - QuantumESPRESSO-7.2-foss-2022b.eb

--- a/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.0-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.0-2022b.yml
@@ -1,0 +1,13 @@
+easyconfigs:
+  - SciPy-bundle-2023.02-gfbf-2022b.eb
+  - GDAL-3.6.2-foss-2022b.eb
+  - waLBerla-6.1-foss-2022b.eb:
+      options:
+        from-pr: 19324
+  - WRF-4.4.1-foss-2022b-dmpar.eb
+  - ImageMagick-7.1.0-53-GCCcore-12.2.0.eb:
+      options:
+        from-pr: 20086
+  - R-4.2.2-foss-2022b.eb:
+      options:
+        from-pr: 20238

--- a/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.0-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.0-2022b.yml
@@ -3,11 +3,17 @@ easyconfigs:
   - Python-3.10.8-GCCcore-12.2.0-bare:
       options:
         # See https://github.com/easybuilders/easybuild-easyblocks/pull/3352
-        include-easyblocks-from-commit: 1ee17c0f7726c69e97442f53c65c5f041d65c94f
+        # Can't use include-easyblocks-from-commit here, as was done for rebuilds for the other archs
+        # because the eb version from this easystack isn't new enough to know it
+        # include-easyblocks-from-commit: 1ee17c0f7726c69e97442f53c65c5f041d65c94f
+        include-easyblocks-from-pr: 3352
   - Python-3.10.8-GCCcore-12.2.0:
       options:
         # See https://github.com/easybuilders/easybuild-easyblocks/pull/3352
-        include-easyblocks-from-commit: 1ee17c0f7726c69e97442f53c65c5f041d65c94f
+        # Can't use include-easyblocks-from-commit here, as was done for rebuilds for the other archs
+        # because the eb version from this easystack isn't new enough to know it
+        # include-easyblocks-from-commit: 1ee17c0f7726c69e97442f53c65c5f041d65c94f
+        include-easyblocks-from-pr: 3352
   - SciPy-bundle-2023.02-gfbf-2022b.eb
   - GDAL-3.6.2-foss-2022b.eb
   - waLBerla-6.1-foss-2022b.eb:

--- a/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.0-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.0-2022b.yml
@@ -1,4 +1,13 @@
 easyconfigs:
+  # Adding Python explicitely, as defined in 20240729-eb-4.9.2-Python-ctypes.yml
+  - Python-3.10.8-GCCcore-12.2.0-bare:
+      options:
+        # See https://github.com/easybuilders/easybuild-easyblocks/pull/3352
+        include-easyblocks-from-commit: 1ee17c0f7726c69e97442f53c65c5f041d65c94f
+  - Python-3.10.8-GCCcore-12.2.0:
+      options:
+        # See https://github.com/easybuilders/easybuild-easyblocks/pull/3352
+        include-easyblocks-from-commit: 1ee17c0f7726c69e97442f53c65c5f041d65c94f
   - SciPy-bundle-2023.02-gfbf-2022b.eb
   - GDAL-3.6.2-foss-2022b.eb
   - waLBerla-6.1-foss-2022b.eb:

--- a/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.1-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.1-2022b.yml
@@ -1,0 +1,8 @@
+easyconfigs:
+  - R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb:
+      options:
+        from-pr: 20379
+  - ParaView-5.11.1-foss-2022b.eb
+  - ASE-3.22.1-gfbf-2022b.eb
+  - SEPP-4.5.1-foss-2022b.eb
+  - Valgrind-3.21.0-gompi-2022b.eb

--- a/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/zen4/eessi-2023.06-eb-4.9.2-2022b.yml
@@ -1,0 +1,52 @@
+easyconfigs:
+  - BLAST+-2.14.0-gompi-2022b.eb
+  - BioPerl-1.7.8-GCCcore-12.2.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21136
+        from-commit: d8076ebaf8cb915762adebf88d385cc672b350dc
+  - gnuplot-5.4.6-GCCcore-12.2.0.eb
+  - h5py-3.8.0-foss-2022b.eb
+  - MDAnalysis-2.4.2-foss-2022b.eb
+  - ncbi-vdb-3.0.5-gompi-2022b.eb
+  - Bio-DB-HTS-3.01-GCC-12.2.0.eb
+  - MAFFT-7.505-GCC-12.2.0-with-extensions.eb
+  - MetaEuk-6-GCC-12.2.0.eb
+  - BamTools-2.5.2-GCC-12.2.0.eb
+  - Bio-SearchIO-hmmer-1.7.3-GCC-12.2.0.eb
+  - Mash-2.3-GCC-12.2.0.eb
+  - CapnProto-0.10.3-GCCcore-12.2.0.eb
+  - WhatsHap-2.1-foss-2022b.eb
+  - SAMtools-1.17-GCC-12.2.0.eb
+  - Bowtie2-2.5.1-GCC-12.2.0.eb
+  - CD-HIT-4.8.1-GCC-12.2.0.eb
+  - VCFtools-0.1.16-GCC-12.2.0.eb
+  - GenomeTools-1.6.2-GCC-12.2.0.eb
+  - Bio-SearchIO-hmmer-1.7.3-GCC-12.2.0.eb
+  - parallel-20230722-GCCcore-12.2.0.eb
+  - BCFtools-1.17-GCC-12.2.0.eb
+  - lpsolve-5.5.2.11-GCC-12.2.0.eb
+  - fastp-0.23.4-GCC-12.2.0.eb
+  - KronaTools-2.8.1-GCCcore-12.2.0.eb
+  - MultiQC-1.14-foss-2022b.eb
+  - CGAL-5.5.2-GCCcore-12.2.0.eb
+  - KaHIP-3.14-gompi-2022b.eb
+  - MPC-1.3.1-GCCcore-12.2.0.eb
+  - MUMPS-5.6.1-foss-2022b-metis.eb
+  - GL2PS-1.4.2-GCCcore-12.2.0.eb
+  - GST-plugins-base-1.22.1-GCC-12.2.0.eb
+  - wxWidgets-3.2.2.1-GCC-12.2.0.eb
+  - Archive-Zip-1.68-GCCcore-12.2.0.eb
+  - jemalloc-5.3.0-GCCcore-12.2.0.eb
+  - Judy-1.0.5-GCCcore-12.2.0.eb
+  - libaio-0.3.113-GCCcore-12.2.0.eb
+  - Z3-4.12.2-GCCcore-12.2.0.eb
+  - tbb-2021.10.0-GCCcore-12.2.0.eb
+  - dask-2023.7.1-foss-2022b.eb
+  - netcdf4-python-1.6.3-foss-2022b.eb
+  - Ruby-3.2.2-GCCcore-12.2.0.eb
+  - ROOT-6.26.10-foss-2022b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21526
+        from-commit: 6cbfbd7d7a55dc7243f46d0beea510278f4718df
+        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3467
+        include-easyblocks-from-commit: c3aebe1f133d064a228c5d6c282e898b83d74601


### PR DESCRIPTION
edit (by @boegel): follow-up for #841, in which logic is added to generate the `2022b` modules for `zen4` to our EasyBuild hooks