### PR TITLE
{2023.06}[2023a,sapphire_rapids] Dependencies of PyTorch 2.1.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -17,3 +17,11 @@ easyconfigs:
   - Rivet-3.1.9-gompi-2023a-HepMC3-3.2.6.eb:
       options:
         from-pr: 19679
+  - Pillow-10.0.0-GCCcore-12.3.0.eb
+  - sympy-1.12-gfbf-2023a.eb
+  - networkx-3.1-gfbf-2023a.eb
+  - expecttest-0.1.5-GCCcore-12.3.0.eb
+  - PyYAML-6.0-GCCcore-12.3.0.eb
+  - pytest-flakefinder-1.1.0-GCCcore-12.3.0.eb
+  - pytest-rerunfailures-12.0-GCCcore-12.3.0.eb
+  - pytest-shard-0.1.2-GCCcore-12.3.0.eb


### PR DESCRIPTION
I'm trying to look into the test failures from https://github.com/EESSI/software-layer/pull/875. One of the culprits may be Z3, see https://github.com/easybuilders/easybuild-easyconfigs/issues/20222. This PR adds all dependencies except Z3, I'll do a test build after this one to find out if this new Z3 version makes a difference.