### PR TITLE
Add pre-install hook that raises an error in case `keeppreviousinstall` (used for rebuilds) is set but the installation directory still contains files

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -452,6 +452,12 @@ def pre_fetch_hook_zen4_gcccore1220(self, *args, **kwargs):
 
 def pre_install_hook(self, *args, **kwargs):
     """Main pre install hook: trigger custom functions based on software name."""
+
+    # To work around a permission issue fo rebuilds (see https://github.com/EESSI/software-layer/issues/556),
+    # a solution was implemented (see https://github.com/EESSI/software-layer/issues/556)
+    # that removes the existing installation directory, creates a new one (with some empty top-level subdirs),
+    # and calls EasyBuild with --try-amend=keeppreviousinstall=True (to prevent it from removing it and recreating it once again).
+    # To be sure, we check here if this parameter is used, and if so, if the directory really does not contain any files anymore.
     if 'keeppreviousinstall' in self.cfg and self.cfg['keeppreviousinstall']:
         if dir_contains_files(self.installdir, recursive=True):
             raise EasyBuildError("Parameter keeppreviousinstall is set to True, but the installation directory still contains files!")


### PR DESCRIPTION
This is an enhancement for #871 and implements the comment from @boegel in https://github.com/EESSI/software-layer/pull/871#issuecomment-2606523933.

I've tested it locally with `EESSI-extend` for the following scenarios:
- no `keeppreviousinstall` -> this always works, as expected
- with `--try-amend=keeppreviousinstall=True`:
  - empty install dir -> works
  - only some empty subdirs in the install dir -> works
  - file in the root of install dir -> error
  - file in a subdir -> error

You can test it by loading `EESSI-extend`, overriding `EASYBUILD_HOOKS` and setting it to the hooks file of this PR, and doing a small build with or without `--try-amend=keeppreviousinstall=True`.