### PR TITLE
{2023.06}[2023a,sapphire_rapids] PyTorch 2.1.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -31,3 +31,7 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19480
         from-pr: 19480
+  - PyTorch-2.1.2-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19573
+        from-pr: 19573

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -26,6 +26,7 @@ CPU_TARGET_NEOVERSE_V1 = 'aarch64/neoverse_v1'
 CPU_TARGET_AARCH64_GENERIC = 'aarch64/generic'
 CPU_TARGET_A64FX = 'aarch64/a64fx'
 
+CPU_TARGET_SAPPHIRE_RAPIDS = 'x86_64/intel/sapphire_rapids'
 CPU_TARGET_ZEN4 = 'x86_64/amd/zen4'
 
 EESSI_RPATH_OVERRIDE_ATTR = 'orig_rpath_override_dirs'
@@ -817,11 +818,16 @@ def pre_test_hook_ignore_failing_tests_netCDF(self, *args, **kwargs):
 
 def pre_test_hook_increase_max_failed_tests_arm_PyTorch(self, *args, **kwargs):
     """
-    Pre-test hook for PyTorch: increase max failing tests for ARM for PyTorch 2.1.2
-    See https://github.com/EESSI/software-layer/pull/444#issuecomment-1890416171
+    Pre-test hook for PyTorch: increase max failing tests for ARM and Intel Sapphire Rapids for PyTorch 2.1.2
+    See https://github.com/EESSI/software-layer/pull/444#issuecomment-1890416171 and
+    https://github.com/EESSI/software-layer/pull/875#issuecomment-2606854400
     """
-    if self.name == 'PyTorch' and self.version == '2.1.2' and get_cpu_architecture() == AARCH64:
-        self.cfg['max_failed_tests'] = 10
+    cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
+    if self.name == 'PyTorch' and self.version == '2.1.2':
+        if get_cpu_architecture() == AARCH64:
+            self.cfg['max_failed_tests'] = 10
+        if cpu_target == CPU_TARGET_SAPPHIRE_RAPIDS:
+            self.cfg['max_failed_tests'] = 4
 
 
 def pre_single_extension_hook(ext, *args, **kwargs):

--- a/eessi-2023.06-known-issues.yml
+++ b/eessi-2023.06-known-issues.yml
@@ -56,3 +56,7 @@
   - SciPy-bundle-2023.11-gfbf-2023b:
     - issue: https://github.com/EESSI/software-layer/issues/318
     - info: "2 failing tests (vs 54876 passed) in scipy test suite"
+- x86_64/intel/sapphire_rapids:
+  - PyTorch-2.1.2-foss-2023a:
+    - issue: https://github.com/EESSI/software-layer/issues/461
+    - info: "4 failing tests (out of 209567) on x86_64/intel/sapphire_rapids"


### PR DESCRIPTION
Initially I was going to try to use an updated easyconfig for Z3, but looking at it again I don't think it will help. Our PyTorch is still using the Z3 with a Python suffix, so rebuilding Z3 based on https://github.com/easybuilders/easybuild-easyconfigs/pull/20050 will probably not do much. Instead, I've just increased the maximum number of failed tests to 4 to work around the issue described at https://github.com/EESSI/software-layer/pull/875#issuecomment-2606854400.