### PR TITLE
{2023.06}[2023b,sapphire_rapids] GROMACS 2024.3

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -41,3 +41,26 @@ easyconfigs:
       options:
         from-pr: 19471
         include-easyblocks-from-pr: 3036
+  - matplotlib-3.7.2-gfbf-2023a.eb
+  - PyQt5-5.15.10-GCCcore-12.3.0.eb:
+      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19554
+      options:
+        from-pr: 19554
+  - Pillow-SIMD-9.5.0-GCCcore-12.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19996
+        from-pr: 19996
+  - dask-2023.9.2-foss-2023a.eb
+  - JupyterNotebook-7.0.2-GCCcore-12.3.0.eb
+  - ImageMagick-7.1.1-15-GCCcore-12.3.0.eb:
+      options:
+        from-pr: 20086
+  - Z3-4.12.2-GCCcore-12.3.0.eb:
+      options:
+        # The Z3 dependency of PyTorch had it's versionsuffix removed
+        # and we need to workaround the problem this creates,
+        # see https://github.com/EESSI/software-layer/pull/501 for details
+        from-pr: 20050
+  - PyOpenGL-3.1.7-GCCcore-12.3.0.eb:
+      options:
+        from-pr: 20007

--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.3-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.3-2023b.yml
@@ -1,0 +1,5 @@
+easyconfigs:
+  - GROMACS-2024.3-foss-2023b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21430
+        from-commit: 8b509882d03402e2998ff9b22c154a6957e36d6b


### PR DESCRIPTION
```
2 out of 61 required modules missing:

* Cython/3.0.10-GCCcore-13.2.0 (Cython-3.0.10-GCCcore-13.2.0.eb)
* GROMACS/2024.3-foss-2023b (GROMACS-2024.3-foss-2023b.eb)
```
(i.e. no overlap with open PRs)