### PR TITLE
{2023.06}[2023a,sapphire_rapids] Another batch of apps from EB 4.9.0 2023a easystack

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -68,3 +68,17 @@ easyconfigs:
   - PyOpenGL-3.1.7-GCCcore-12.3.0.eb:
       options:
         from-pr: 20007
+  - OpenJPEG-2.5.0-GCCcore-12.3.0.eb
+  - Highway-1.0.4-GCCcore-12.3.0.eb
+  - ELPA-2023.05.001-foss-2023a.eb
+  - libxc-6.2.2-GCC-12.3.0.eb
+  - SuperLU_DIST-8.1.2-foss-2023a.eb:
+      options:
+        from-pr: 20162
+  - PETSc-3.20.3-foss-2023a.eb:
+      options:
+        include-easyblocks-from-pr: 3086
+        from-pr: 19686
+  - MODFLOW-6.4.4-foss-2023a.eb:
+      options:
+        from-pr: 20142


### PR DESCRIPTION
```
1 out of 88 required modules missing:

* jedi/0.19.0-GCCcore-12.3.0 (jedi-0.19.0-GCCcore-12.3.0.eb)

1 out of 8 required modules missing:

* Highway/1.0.4-GCCcore-12.3.0 (Highway-1.0.4-GCCcore-12.3.0.eb)

1 out of 35 required modules missing:

* ELPA/2023.05.001-foss-2023a (ELPA-2023.05.001-foss-2023a.eb)

1 out of 9 required modules missing:

* libxc/6.2.2-GCC-12.3.0 (libxc-6.2.2-GCC-12.3.0.eb)

2 out of 36 required modules missing:

* ParMETIS/4.0.3-gompi-2023a (ParMETIS-4.0.3-gompi-2023a.eb)
* SuperLU_DIST/8.1.2-foss-2023a (SuperLU_DIST-8.1.2-foss-2023a.eb)

5 out of 73 required modules missing:

* ParMETIS/4.0.3-gompi-2023a (ParMETIS-4.0.3-gompi-2023a.eb)
* Hypre/2.29.0-foss-2023a (Hypre-2.29.0-foss-2023a.eb)
* SuperLU_DIST/8.1.2-foss-2023a (SuperLU_DIST-8.1.2-foss-2023a.eb)
* SuiteSparse/7.1.0-foss-2023a (SuiteSparse-7.1.0-foss-2023a.eb)
* PETSc/3.20.3-foss-2023a (PETSc-3.20.3-foss-2023a.eb)

7 out of 80 required modules missing:

* ParMETIS/4.0.3-gompi-2023a (ParMETIS-4.0.3-gompi-2023a.eb)
* SuiteSparse/7.1.0-foss-2023a (SuiteSparse-7.1.0-foss-2023a.eb)
* Hypre/2.29.0-foss-2023a (Hypre-2.29.0-foss-2023a.eb)
* SuperLU_DIST/8.1.2-foss-2023a (SuperLU_DIST-8.1.2-foss-2023a.eb)
* netCDF-Fortran/4.6.1-gompi-2023a (netCDF-Fortran-4.6.1-gompi-2023a.eb)
* PETSc/3.20.3-foss-2023a (PETSc-3.20.3-foss-2023a.eb)
* MODFLOW/6.4.4-foss-2023a (MODFLOW-6.4.4-foss-2023a.eb)
```