### PR TITLE
{2023.06}[2023a,sapphire_rapids] R-bundle-CRAN 2023.12

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -68,3 +68,7 @@ easyconfigs:
   - PyOpenGL-3.1.7-GCCcore-12.3.0.eb:
       options:
         from-pr: 20007
+  - R-bundle-CRAN-2023.12-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20238
+        from-pr: 20238


### PR DESCRIPTION
```
25 out of 148 required modules missing:

* NLopt/2.7.1-GCCcore-12.3.0 (NLopt-2.7.1-GCCcore-12.3.0.eb)
* nettle/3.9.1-GCCcore-12.3.0 (nettle-3.9.1-GCCcore-12.3.0.eb)
* libogg/1.3.5-GCCcore-12.3.0 (libogg-1.3.5-GCCcore-12.3.0.eb)
* FLAC/1.4.2-GCCcore-12.3.0 (FLAC-1.4.2-GCCcore-12.3.0.eb)
* libvorbis/1.3.7-GCCcore-12.3.0 (libvorbis-1.3.7-GCCcore-12.3.0.eb)
* Xvfb/21.1.8-GCCcore-12.3.0 (Xvfb-21.1.8-GCCcore-12.3.0.eb)
* libopus/1.4-GCCcore-12.3.0 (libopus-1.4-GCCcore-12.3.0.eb)
* libsndfile/1.2.2-GCCcore-12.3.0 (libsndfile-1.2.2-GCCcore-12.3.0.eb)
* PostgreSQL/16.1-GCCcore-12.3.0 (PostgreSQL-16.1-GCCcore-12.3.0.eb)
* GEOS/3.12.0-GCC-12.3.0 (GEOS-3.12.0-GCC-12.3.0.eb)
* libgeotiff/1.7.1-GCCcore-12.3.0 (libgeotiff-1.7.1-GCCcore-12.3.0.eb)
* libtirpc/1.3.3-GCCcore-12.3.0 (libtirpc-1.3.3-GCCcore-12.3.0.eb)
* HDF/4.2.16-2-GCCcore-12.3.0 (HDF-4.2.16-2-GCCcore-12.3.0.eb)
* CFITSIO/4.3.0-GCCcore-12.3.0 (CFITSIO-4.3.0-GCCcore-12.3.0.eb)
* arpack-ng/3.9.0-foss-2023a (arpack-ng-3.9.0-foss-2023a.eb)
* Armadillo/12.6.2-foss-2023a (Armadillo-12.6.2-foss-2023a.eb)
* json-c/0.16-GCCcore-12.3.0 (json-c-0.16-GCCcore-12.3.0.eb)
* Xerces-C++/3.2.4-GCCcore-12.3.0 (Xerces-C++-3.2.4-GCCcore-12.3.0.eb)
* Brunsli/0.1-GCCcore-12.3.0 (Brunsli-0.1-GCCcore-12.3.0.eb)
* Imath/3.1.7-GCCcore-12.3.0 (Imath-3.1.7-GCCcore-12.3.0.eb)
* OpenEXR/3.1.7-GCCcore-12.3.0 (OpenEXR-3.1.7-GCCcore-12.3.0.eb)
* LERC/4.0.0-GCCcore-12.3.0 (LERC-4.0.0-GCCcore-12.3.0.eb)
* SWIG/4.1.1-GCCcore-12.3.0 (SWIG-4.1.1-GCCcore-12.3.0.eb)
* GDAL/3.7.1-foss-2023a (GDAL-3.7.1-foss-2023a.eb)
* R-bundle-CRAN/2023.12-foss-2023a (R-bundle-CRAN-2023.12-foss-2023a.eb)
```

Doesn't seem to have any overlap with #892, so should be safe to build it in parallel.