### PR TITLE
{2023.06}[2023a,sapphire_rapids] First batch of (bioinformatics) apps from EB 4.9.2 2023a easystack

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -13,14 +13,22 @@ easyconfigs:
   - BWA-0.7.18-GCCcore-12.3.0.eb
   - CapnProto-1.0.1-GCCcore-12.3.0.eb
   - DendroPy-4.6.1-GCCcore-12.3.0.eb
+  - DIAMOND-2.1.8-GCC-12.3.0.eb
   - FastME-2.1.6.3-GCC-12.3.0.eb
+  - fastp-0.23.4-GCC-12.3.0.eb
   - HMMER-3.4-gompi-2023a.eb
   - IQ-TREE-2.3.5-gompi-2023a.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20955
-        from-commit: 185f88b9a03d65a7fb74edc7acb4221e87e90784
+        from-commit: 185f88b9a03d65a7fb74edc7acb4221e87e90784      
   - KronaTools-2.8.1-GCCcore-12.3.0.eb
   - LSD2-2.4.1-GCCcore-12.3.0.eb
   - MAFFT-7.520-GCC-12.3.0-with-extensions.eb
   - ncbi-vdb-3.0.10-gompi-2023a.eb
-
+  - MetalWalls-21.06.1-foss-2023a.eb
+  - QuantumESPRESSO-7.3.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20138
+        from-commit: dbdaacc0739fdee91baa9123864ea4428cf21273
+        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3338
+        include-easyblocks-from-commit: 32e45bd1f2d916732ca5852d55d17fa4d99e388b

--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -13,9 +13,7 @@ easyconfigs:
   - BWA-0.7.18-GCCcore-12.3.0.eb
   - CapnProto-1.0.1-GCCcore-12.3.0.eb
   - DendroPy-4.6.1-GCCcore-12.3.0.eb
-  - DIAMOND-2.1.8-GCC-12.3.0.eb
   - FastME-2.1.6.3-GCC-12.3.0.eb
-  - fastp-0.23.4-GCC-12.3.0.eb
   - HMMER-3.4-gompi-2023a.eb
   - IQ-TREE-2.3.5-gompi-2023a.eb:
       options:

--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -9,4 +9,20 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20958
         from-commit: dbadb2074464d816740ee0e95595c2cb31b6338f
+  - BCFtools-1.18-GCC-12.3.0.eb
+  - BWA-0.7.18-GCCcore-12.3.0.eb
+  - CapnProto-1.0.1-GCCcore-12.3.0.eb
+  - DendroPy-4.6.1-GCCcore-12.3.0.eb
+  - DIAMOND-2.1.8-GCC-12.3.0.eb
+  - FastME-2.1.6.3-GCC-12.3.0.eb
+  - fastp-0.23.4-GCC-12.3.0.eb
+  - HMMER-3.4-gompi-2023a.eb
+  - IQ-TREE-2.3.5-gompi-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20955
+        from-commit: 185f88b9a03d65a7fb74edc7acb4221e87e90784
+  - KronaTools-2.8.1-GCCcore-12.3.0.eb
+  - LSD2-2.4.1-GCCcore-12.3.0.eb
+  - MAFFT-7.520-GCC-12.3.0-with-extensions.eb
+  - ncbi-vdb-3.0.10-gompi-2023a.eb
 


### PR DESCRIPTION
```
2 out of 8 required modules missing:

* HTSlib/1.18-GCC-12.3.0 (HTSlib-1.18-GCC-12.3.0.eb)
* BCFtools/1.18-GCC-12.3.0 (BCFtools-1.18-GCC-12.3.0.eb)


1 out of 3 required modules missing:

* BWA/0.7.18-GCCcore-12.3.0 (BWA-0.7.18-GCCcore-12.3.0.eb)


1 out of 2 required modules missing:

* CapnProto/1.0.1-GCCcore-12.3.0 (CapnProto-1.0.1-GCCcore-12.3.0.eb)


1 out of 10 required modules missing:

* DendroPy/4.6.1-GCCcore-12.3.0 (DendroPy-4.6.1-GCCcore-12.3.0.eb)


1 out of 8 required modules missing:

* DIAMOND/2.1.8-GCC-12.3.0 (DIAMOND-2.1.8-GCC-12.3.0.eb)


2 out of 12 required modules missing:

* ISA-L/2.30.0-GCCcore-12.3.0 (ISA-L-2.30.0-GCCcore-12.3.0.eb)
* fastp/0.23.4-GCC-12.3.0 (fastp-0.23.4-GCC-12.3.0.eb)

1 out of 24 required modules missing:

* HMMER/3.4-gompi-2023a (HMMER-3.4-gompi-2023a.eb)

2 out of 34 required modules missing:

* LSD2/2.4.1-GCCcore-12.3.0 (LSD2-2.4.1-GCCcore-12.3.0.eb)
* IQ-TREE/2.3.5-gompi-2023a (IQ-TREE-2.3.5-gompi-2023a.eb)

1 out of 3 required modules missing:

* KronaTools/2.8.1-GCCcore-12.3.0 (KronaTools-2.8.1-GCCcore-12.3.0.eb)

1 out of 7 required modules missing:

* LSD2/2.4.1-GCCcore-12.3.0 (LSD2-2.4.1-GCCcore-12.3.0.eb)

1 out of 3 required modules missing:

* MAFFT/7.520-GCC-12.3.0-with-extensions (MAFFT-7.520-GCC-12.3.0-with-extensions.eb)

1 out of 29 required modules missing:

* ncbi-vdb/3.0.10-gompi-2023a (ncbi-vdb-3.0.10-gompi-2023a.eb)

```

Looks like there is some overlap with #895 (ISA-L), so that one needs to be ingested first.