### PR TITLE
{2023.06}[2023a,sapphire_rapids] Remaining apps for EB 4.9.2 2023a easystack (except librosa)

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -32,3 +32,52 @@ easyconfigs:
         from-commit: dbdaacc0739fdee91baa9123864ea4428cf21273
         # see https://github.com/easybuilders/easybuild-easyblocks/pull/3338
         include-easyblocks-from-commit: 32e45bd1f2d916732ca5852d55d17fa4d99e388b
+  - CP2K-2023.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20951
+        from-commit: a92667fe32396bbd4106243658625f7ff2adcd68
+  - amdahl-0.3.1-gompi-2023a.eb
+  - librosa-0.10.1-foss-2023a.eb
+  - xarray-2023.9.0-gfbf-2023a.eb
+  - SciTools-Iris-3.9.0-foss-2023a.eb
+  - OpenFOAM-v2312-foss-2023a.eb:
+      options:
+        # https://github.com/easybuilders/easybuild-easyblocks/pull/3388
+        include-easyblocks-from-commit: c8256a36e7062bc09f5ce30552a9de9827054c9e
+        # https://github.com/easybuilders/easybuild-easyconfigs/pull/20841
+        from-commit: f0e91e6e430ebf902f7788ebb47f0203dee60649
+  - BioPerl-1.7.8-GCCcore-12.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21136
+        from-commit: d8076ebaf8cb915762adebf88d385cc672b350dc
+  - grpcio-1.57.0-GCCcore-12.3.0.eb
+  - orjson-3.9.15-GCCcore-12.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20880
+        from-commit: bc6e08f89759b8b70166de5bfcb5056b9db8ec90
+  - wradlib-2.0.3-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21094
+        from-commit: 3a2e0b8e6ee45277d01fb7e2eb93027a28c9461a
+  - MBX-1.1.0-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21155
+        from-commit: 6929a67401f2a2ec58f91fb306332a77497d73ff
+  - Transrate-1.0.3-GCC-12.3.0.eb:
+      options:
+        # https://github.com/easybuilders/easybuild-easyblocks/pull/3381
+        include-easyblocks-from-commit: bb86f05d4917b29e022023f152efdf0ca5c14ded
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20964
+        from-commit: 7d539a9e599d8bc5ac2bda6ee9587ef62351ee03
+  - Critic2-1.2-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20833
+        from-commit: 78426c2383fc7e4b9b9e77d7a77f336e1bee3843
+  - LRBinner-0.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21310
+        from-commit: 799d9101df2cf81aabe252f00cc82a7246363f53
+  - Redland-1.0.17-GCC-12.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21227
+        from-commit: 4c5e3455dec31e68e8383c7fd86d1f80c434676d

--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -37,7 +37,6 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20951
         from-commit: a92667fe32396bbd4106243658625f7ff2adcd68
   - amdahl-0.3.1-gompi-2023a.eb
-  - librosa-0.10.1-foss-2023a.eb
   - xarray-2023.9.0-gfbf-2023a.eb
   - SciTools-Iris-3.9.0-foss-2023a.eb
   - OpenFOAM-v2312-foss-2023a.eb:


### PR DESCRIPTION
This needs to wait for #896 to get ingested/merged.

```
4 out of 70 required modules missing:

* libxsmm/1.17-GCC-12.3.0 (libxsmm-1.17-GCC-12.3.0.eb)
* libvori/220621-GCCcore-12.3.0 (libvori-220621-GCCcore-12.3.0.eb)
* Libint/2.7.2-GCC-12.3.0-lmax-6-cp2k (Libint-2.7.2-GCC-12.3.0-lmax-6-cp2k.eb)
* CP2K/2023.1-foss-2023a (CP2K-2023.1-foss-2023a.eb)


1 out of 25 required modules missing:

* amdahl/0.3.1-gompi-2023a (amdahl-0.3.1-gompi-2023a.eb)


3 out of 99 required modules missing:

* LLVM/14.0.6-GCCcore-12.3.0-llvmlite (LLVM-14.0.6-GCCcore-12.3.0-llvmlite.eb)
* numba/0.58.1-foss-2023a (numba-0.58.1-foss-2023a.eb)
* librosa/0.10.1-foss-2023a (librosa-0.10.1-foss-2023a.eb)


1 out of 41 required modules missing:

* xarray/2023.9.0-gfbf-2023a (xarray-2023.9.0-gfbf-2023a.eb)


8 out of 127 required modules missing:

* xxHash/0.8.2-GCCcore-12.3.0 (xxHash-0.8.2-GCCcore-12.3.0.eb)
* python-xxhash/3.4.1-GCCcore-12.3.0 (python-xxhash-3.4.1-GCCcore-12.3.0.eb)
* Shapely/2.0.1-gfbf-2023a (Shapely-2.0.1-gfbf-2023a.eb)
* pyproj/3.6.0-GCCcore-12.3.0 (pyproj-3.6.0-GCCcore-12.3.0.eb)
* netcdf4-python/1.6.4-foss-2023a (netcdf4-python-1.6.4-foss-2023a.eb)
* Fiona/1.9.5-foss-2023a (Fiona-1.9.5-foss-2023a.eb)
* Cartopy/0.22.0-foss-2023a (Cartopy-0.22.0-foss-2023a.eb)
* SciTools-Iris/3.9.0-foss-2023a (SciTools-Iris-3.9.0-foss-2023a.eb)


2 out of 116 required modules missing:

* KaHIP/3.16-gompi-2023a (KaHIP-3.16-gompi-2023a.eb)
* OpenFOAM/v2312-foss-2023a (OpenFOAM-v2312-foss-2023a.eb)


6 out of 13 required modules missing:

* groff/1.22.4-GCCcore-12.3.0 (groff-1.22.4-GCCcore-12.3.0.eb)
* DB/18.1.40-GCCcore-12.3.0 (DB-18.1.40-GCCcore-12.3.0.eb)
* Perl-bundle-CPAN/5.36.1-GCCcore-12.3.0 (Perl-bundle-CPAN-5.36.1-GCCcore-12.3.0.eb)
* XML-LibXML/2.0209-GCCcore-12.3.0 (XML-LibXML-2.0209-GCCcore-12.3.0.eb)
* DB_File/1.859-GCCcore-12.3.0 (DB_File-1.859-GCCcore-12.3.0.eb)
* BioPerl/1.7.8-GCCcore-12.3.0 (BioPerl-1.7.8-GCCcore-12.3.0.eb)


1 out of 17 required modules missing:

* grpcio/1.57.0-GCCcore-12.3.0 (grpcio-1.57.0-GCCcore-12.3.0.eb)


3 out of 18 required modules missing:

* Rust/1.75.0-GCCcore-12.3.0 (Rust-1.75.0-GCCcore-12.3.0.eb)
* maturin/1.4.0-GCCcore-12.3.0-Rust-1.75.0 (maturin-1.4.0-GCCcore-12.3.0-Rust-1.75.0.eb)
* orjson/3.9.15-GCCcore-12.3.0 (orjson-3.9.15-GCCcore-12.3.0.eb)


13 out of 137 required modules missing:

* psycopg2/2.9.9-GCCcore-12.3.0 (psycopg2-2.9.9-GCCcore-12.3.0.eb)
* xarray/2023.9.0-gfbf-2023a (xarray-2023.9.0-gfbf-2023a.eb)
* Shapely/2.0.1-gfbf-2023a (Shapely-2.0.1-gfbf-2023a.eb)
* SQLAlchemy/2.0.25-GCCcore-12.3.0 (SQLAlchemy-2.0.25-GCCcore-12.3.0.eb)
* pyproj/3.6.0-GCCcore-12.3.0 (pyproj-3.6.0-GCCcore-12.3.0.eb)
* LLVM/14.0.6-GCCcore-12.3.0-llvmlite (LLVM-14.0.6-GCCcore-12.3.0-llvmlite.eb)
* numba/0.58.1-foss-2023a (numba-0.58.1-foss-2023a.eb)
* netcdf4-python/1.6.4-foss-2023a (netcdf4-python-1.6.4-foss-2023a.eb)
* h5netcdf/1.2.0-foss-2023a (h5netcdf-1.2.0-foss-2023a.eb)
* Fiona/1.9.5-foss-2023a (Fiona-1.9.5-foss-2023a.eb)
* geopandas/0.14.2-foss-2023a (geopandas-0.14.2-foss-2023a.eb)
* Cartopy/0.22.0-foss-2023a (Cartopy-0.22.0-foss-2023a.eb)
* wradlib/2.0.3-foss-2023a (wradlib-2.0.3-foss-2023a.eb)


1 out of 57 required modules missing:

* MBX/1.1.0-foss-2023a (MBX-1.1.0-foss-2023a.eb)


5 out of 10 required modules missing:

* Ruby/3.3.0-GCCcore-12.3.0 (Ruby-3.3.0-GCCcore-12.3.0.eb)
* crb-blast/0.6.9-GCC-12.3.0 (crb-blast-0.6.9-GCC-12.3.0.eb)
* colorize/0.7.7-GCC-12.3.0 (colorize-0.7.7-GCC-12.3.0.eb)
* yell/2.2.2-GCC-12.3.0 (yell-2.2.2-GCC-12.3.0.eb)
* Transrate/1.0.3-GCC-12.3.0 (Transrate-1.0.3-GCC-12.3.0.eb)


2 out of 58 required modules missing:

* libcint/5.4.0-gfbf-2023a (libcint-5.4.0-gfbf-2023a.eb)
* Critic2/1.2-foss-2023a (Critic2-1.2-foss-2023a.eb)


5 out of 120 required modules missing:

* tqdm/4.66.1-GCCcore-12.3.0 (tqdm-4.66.1-GCCcore-12.3.0.eb)
* FragGeneScan/1.31-GCCcore-12.3.0 (FragGeneScan-1.31-GCCcore-12.3.0.eb)
* HDBSCAN/0.8.38.post1-foss-2023a (HDBSCAN-0.8.38.post1-foss-2023a.eb)
* Seaborn/0.13.2-gfbf-2023a (Seaborn-0.13.2-gfbf-2023a.eb)
* LRBinner/0.1-foss-2023a (LRBinner-0.1-foss-2023a.eb)


18 out of 52 required modules missing:

* libgpg-error/1.48-GCCcore-12.3.0 (libgpg-error-1.48-GCCcore-12.3.0.eb)
* libgcrypt/1.10.3-GCCcore-12.3.0 (libgcrypt-1.10.3-GCCcore-12.3.0.eb)
* unixODBC/2.3.12-GCCcore-12.3.0 (unixODBC-2.3.12-GCCcore-12.3.0.eb)
* libaio/0.3.113-GCCcore-12.3.0 (libaio-0.3.113-GCCcore-12.3.0.eb)
* LZO/2.10-GCCcore-12.3.0 (LZO-2.10-GCCcore-12.3.0.eb)
* Raptor/2.0.16-GCCcore-12.3.0 (Raptor-2.0.16-GCCcore-12.3.0.eb)
* jemalloc/5.3.0-GCCcore-12.3.0 (jemalloc-5.3.0-GCCcore-12.3.0.eb)
* Pygments/2.18.0-GCCcore-12.3.0 (Pygments-2.18.0-GCCcore-12.3.0.eb)
* mallard-ducktype/1.0.2-GCCcore-12.3.0 (mallard-ducktype-1.0.2-GCCcore-12.3.0.eb)
* Judy/1.0.5-GCCcore-12.3.0 (Judy-1.0.5-GCCcore-12.3.0.eb)
* libxml2-python/2.11.4-GCCcore-12.3.0 (libxml2-python-2.11.4-GCCcore-12.3.0.eb)
* ITSTool/2.0.7-GCCcore-12.3.0 (ITSTool-2.0.7-GCCcore-12.3.0.eb)
* yelp-xsl/42.1-GCCcore-12.3.0 (yelp-xsl-42.1-GCCcore-12.3.0.eb)
* yelp-tools/42.1-GCCcore-12.3.0 (yelp-tools-42.1-GCCcore-12.3.0.eb)
* gtk-doc/1.34.0-GCCcore-12.3.0 (gtk-doc-1.34.0-GCCcore-12.3.0.eb)
* Rasqal/0.9.33-GCCcore-12.3.0 (Rasqal-0.9.33-GCCcore-12.3.0.eb)
* MariaDB/11.6.0-GCC-12.3.0 (MariaDB-11.6.0-GCC-12.3.0.eb)
* Redland/1.0.17-GCC-12.3.0 (Redland-1.0.17-GCC-12.3.0.eb)
```
