### PR TITLE
{2023.06}[2023a] librosa 0.10.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphire_rapids/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - librosa-0.10.1-foss-2023a.eb


### PR DESCRIPTION
The build of librosa with EB 4.9.2 failed in https://github.com/EESSI/software-layer/pull/897#issuecomment-2614568203, but a newer version of the easyconfig is available in 4.9.4, and it should fix this issue (see https://github.com/easybuilders/easybuild-easyconfigs/pull/21434).

Note that this shouldn't be merged yet, as it has dependencies on packages that are still being built in #897 (LLVM and numba), but I'm just giving it a try here already to make sure that it indeed fixes the issue.

If it works, we may want to consider doing a rebuild for the other CPU targets (though I'm not sure if it really changes much).