### PR TITLE
{2023.06}[2023a] archspec 0.2.5

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -45,3 +45,7 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22145
         from-commit: 31478e5c9869de3add74d0a02dd5df01ea65b21e
+  - archspec-0.2.5-GCCcore-12.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22235
+        from-commit: 01dd97ea62fe4d7d0df040ede3af03eb2f1b8641


### PR DESCRIPTION
Required to rebuild LAMMPS 2Aug2023 with proper Sapphire Rapids support.