### PR TITLE
{2023.06}[2023a] Rebuild LAMMPS 2Aug2023_update2 with proper Sapphire Rapids support

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20250203-eb-4.9.4-LAMMPS-2Aug2023-add-support-for-sapphire_rapids.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20250203-eb-4.9.4-LAMMPS-2Aug2023-add-support-for-sapphire_rapids.yml
@@ -1,0 +1,12 @@
+# 2025.02.03
+# Rebuild LAMMPS 2Aug2023_update2 for Sapphire Rapids,
+# as the existing version used an old version of archspec that detected the CPU as Icelake.
+# See https://github.com/easybuilders/easybuild-easyconfigs/pull/22235
+# and https://github.com/easybuilders/easybuild-easyblocks/pull/3569.
+easyconfigs:
+  - LAMMPS-2Aug2023_update2-foss-2023a-kokkos.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22235
+        from-commit: 01dd97ea62fe4d7d0df040ede3af03eb2f1b8641
+        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3569
+        include-easyblocks-from-commit: b0ce5ec66c8f797220b2c2a773acfc4aeae7a0c7


### PR DESCRIPTION
The existing version was built for Icelake, as the version of archspec (build dependency of LAMMPS) was too old to detect Sapphire Rapids CPUs. This rebuild uses a newer archspec version and an updated easyblock that contains a mapping for Sapphire Rapids.

I don't think we have to rebuild it for any other architectures, because archspec itself is just a build dependency (it has been added to the stack for all CPU targets in #905), and the easyblock does not seem to contain relevant fixes for other architectures (except for generic builds, but that's already handled in https://github.com/EESSI/software-layer/pull/788).

Note: a build should only be triggered after #905 has been ingested.