### PR TITLE
Improved workaround that solves permission issues for rebuilds

### DIFF
--- a/EESSI-remove-software.sh
+++ b/EESSI-remove-software.sh
@@ -130,13 +130,13 @@ if [ $EUID -eq 0 ]; then
                     echo_yellow "Removing ${app_dir} and ${app_module}..."
                     rm -rf ${app_dir}
                     rm -rf ${app_module}
-                    # recreate the installation directories and first-level subdirectories to work around permission denied
-                    # issues when rebuilding the package (see https://github.com/EESSI/software-layer/issues/556)
+                    # recreate the installation directory and do an ls on the first-level subdirectories to work around
+                    # permission issues when reinstalling the application (see https://github.com/EESSI/software-layer/issues/556)
                     echo_yellow "Recreating an empty ${app_dir}..."
                     mkdir -p ${app_dir}
-                    for app_subdir in ${app_subdirs}; do
-                        mkdir -p ${app_subdir}
-                    done
+                    # these subdirs don't (and shouldn't) exist, but we need to do the ls anyway as a workaround,
+                    # so redirect to /dev/null and ignore the exit code
+                    ls ${app_subdirs} >& /dev/null || true
                 done
             else
                 fatal_error "Easystack file ${easystack_file} not found!"


### PR DESCRIPTION
Instead of recreating all first-level subdirs (as done in #871), this just does an `ls` on the (removed / non-existing) subdirs. https://github.com/EESSI/software-layer/issues/556#issuecomment-2422511346 showed that would solve the issue too, and I tested it in https://github.com/EESSI/software-layer/pull/788#issuecomment-2631277686.

The original workaround caused issues for LAMMPS, as it didn't like the empty `examples` subdir in the installation directory. With the new approach, the installation directory itself is still precreated (and not removed+recreated again by EB), but completely empty. It's cleaner anyway, and also solves the issue for LAMMPS.