### PR TITLE
Fix bug when defining multiple modules in app.cfg

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -115,7 +115,8 @@ mkdir -p ${SINGULARITY_TMPDIR}
 
 # load modules if LOAD_MODULES is not empty
 if [[ ! -z ${LOAD_MODULES} ]]; then
-    for mod in $(echo ${LOAD_MODULES} | tr ',' '\n')
+    IFS=',' read -r -a modules <<< "$(echo "${LOAD_MODULES}")"
+    for mod in "${modules[@]}";
     do
         echo "bot/build.sh: loading module '${mod}'"
         module load ${mod}

--- a/bot/test.sh
+++ b/bot/test.sh
@@ -135,7 +135,8 @@ mkdir -p ${SINGULARITY_TMPDIR}
 
 # load modules if LOAD_MODULES is not empty
 if [[ ! -z ${LOAD_MODULES} ]]; then
-    for mod in $(echo ${LOAD_MODULES} | tr ',' '\n')
+    IFS=',' read -r -a modules <<< "$(echo "${LOAD_MODULES}")"
+    for mod in "${modules[@]}";
     do
         echo "bot/test.sh: loading module '${mod}'"
         module load ${mod}


### PR DESCRIPTION
Fix bug when multiple modules where defined. In the old syntax, they were interpreted as a single string, with space. I.e. only one iteration of hte for loop was executed. Using bash arrays, we no longer have this issue

See https://github.com/EESSI/software-layer/pull/903#issuecomment-2635259858