### PR TITLE
Bind mount tmpdir

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -115,7 +115,8 @@ mkdir -p ${SINGULARITY_TMPDIR}
 
 # load modules if LOAD_MODULES is not empty
 if [[ ! -z ${LOAD_MODULES} ]]; then
-    for mod in $(echo ${LOAD_MODULES} | tr ',' '\n')
+    IFS=',' read -r -a modules <<< "$(echo "${LOAD_MODULES}")"
+    for mod in "${modules[@]}";
     do
         echo "bot/build.sh: loading module '${mod}'"
         module load ${mod}

--- a/bot/test.sh
+++ b/bot/test.sh
@@ -135,7 +135,8 @@ mkdir -p ${SINGULARITY_TMPDIR}
 
 # load modules if LOAD_MODULES is not empty
 if [[ ! -z ${LOAD_MODULES} ]]; then
-    for mod in $(echo ${LOAD_MODULES} | tr ',' '\n')
+    IFS=',' read -r -a modules <<< "$(echo "${LOAD_MODULES}")"
+    for mod in "${modules[@]}";
     do
         echo "bot/test.sh: loading module '${mod}'"
         module load ${mod}

--- a/eessi_container.sh
+++ b/eessi_container.sh
@@ -382,6 +382,7 @@ else
   # note, (b) & (c) are automatically ensured by using 'mktemp -d --tmpdir' to
   #     create a temporary directory
   if [[ ! -z ${STORAGE} ]]; then
+    [[ ${VERBOSE} -eq 1 ]] && echo "export TMPDIR=${STORAGE}"
     export TMPDIR=${STORAGE}
     # mktemp fails if TMPDIR does not exist, so let's create it
     mkdir -p ${TMPDIR}
@@ -529,6 +530,13 @@ BIND_PATHS="${EESSI_CVMFS_VAR_LIB}:/var/lib/cvmfs,${EESSI_CVMFS_VAR_RUN}:/var/ru
 
 # provide a '/tmp' inside the container
 BIND_PATHS="${BIND_PATHS},${EESSI_TMPDIR}:${TMP_IN_CONTAINER}"
+# if TMPDIR is not empty and if TMP_IN_CONTAINER is not a prefix of TMPDIR, we need to add a bind mount for TMPDIR
+if [[ ! -z ${TMPDIR} && ${TMP_IN_CONTAINER} != ${TMPDIR}* ]]; then
+    echo "TMPDIR is not empty (${TMPDIR}) and TMP_IN_CONTAINER (${TMP_IN_CONTAINER}) is not a prefix of TMPDIR: adding bind mount for TMPDIR"
+    BIND_PATHS="${BIND_PATHS},${TMPDIR}"
+fi
+
+# add bind mount for extra bind paths
 if [[ ! -z ${EXTRA_BIND_PATHS} ]]; then
     BIND_PATHS="${BIND_PATHS},${EXTRA_BIND_PATHS}"
 fi


### PR DESCRIPTION
To avoid issues with `mktemp` inside the container (e.g. called by `create_tarball.sh`) when a TMPDIR is defined in the environment - and the directory it points to is not present in the container by default.