### PR TITLE
{2023.06}[2023a,2023b] rebuild CUDA/* modules to update module files

### DIFF
--- a/EESSI-determine-rebuilds.sh
+++ b/EESSI-determine-rebuilds.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+#
+# Script to determine which parts of the EESSI software stack (version set through init/eessi_defaults)
+# have to be rebuilt
+
+# see example parsing of command line arguments at
+#   https://wiki.bash-hackers.org/scripting/posparams#using_a_while_loop
+#   https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
+
+display_help() {
+  echo "usage: $0 [OPTIONS]"
+  echo "  -g | --generic         -  instructs script to build for generic architecture target"
+  echo "  -h | --help            -  display this usage information"
+}
+
+POSITIONAL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -g|--generic)
+      DETECTION_PARAMETERS="--generic"
+      shift
+      ;;
+    -h|--help)
+      display_help  # Call your function
+      # no shifting needed here, we're done.
+      exit 0
+      ;;
+    -*|--*)
+      echo "Error: Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)  # No more options
+      POSITIONAL_ARGS+=("$1") # save positional arg
+      shift
+      ;;
+  esac
+done
+
+set -- "${POSITIONAL_ARGS[@]}"
+
+TOPDIR=$(dirname $(realpath $0))
+
+export TMPDIR=$(mktemp -d /tmp/eessi-remove.XXXXXXXX)
+
+source $TOPDIR/scripts/utils.sh
+
+echo ">> Determining software subdirectory to use for current build host..."
+if [ -z $EESSI_SOFTWARE_SUBDIR_OVERRIDE ]; then
+  export EESSI_SOFTWARE_SUBDIR_OVERRIDE=$(python3 $TOPDIR/eessi_software_subdir.py $DETECTION_PARAMETERS)
+  echo ">> Determined \$EESSI_SOFTWARE_SUBDIR_OVERRIDE via 'eessi_software_subdir.py $DETECTION_PARAMETERS' script"
+else
+  echo ">> Picking up pre-defined \$EESSI_SOFTWARE_SUBDIR_OVERRIDE: ${EESSI_SOFTWARE_SUBDIR_OVERRIDE}"
+fi
+
+echo ">> Setting up environment..."
+
+source $TOPDIR/init/bash
+
+if [ -d $EESSI_CVMFS_REPO ]; then
+    echo_green "$EESSI_CVMFS_REPO available, OK!"
+else
+    fatal_error "$EESSI_CVMFS_REPO is not available!"
+fi
+
+if [[ -z ${EESSI_SOFTWARE_SUBDIR} ]]; then
+    fatal_error "Failed to determine software subdirectory?!"
+elif [[ "${EESSI_SOFTWARE_SUBDIR}" != "${EESSI_SOFTWARE_SUBDIR_OVERRIDE}" ]]; then
+    fatal_error "Values for EESSI_SOFTWARE_SUBDIR_OVERRIDE (${EESSI_SOFTWARE_SUBDIR_OVERRIDE}) and EESSI_SOFTWARE_SUBDIR (${EESSI_SOFTWARE_SUBDIR}) differ!"
+else
+    echo_green ">> Using ${EESSI_SOFTWARE_SUBDIR} as software subdirectory!"
+fi
+
+echo ">> Configuring EasyBuild..."
+EB="eb"
+source $TOPDIR/configure_easybuild
+
+echo ">> Setting up \$MODULEPATH..."
+# make sure no modules are loaded
+module --force purge
+# ignore current $MODULEPATH entirely
+module unuse $MODULEPATH
+module use $EASYBUILD_INSTALLPATH/modules/all
+if [[ -z ${MODULEPATH} ]]; then
+    fatal_error "Failed to set up \$MODULEPATH?!"
+else
+    echo_green ">> MODULEPATH set up: ${MODULEPATH}"
+fi
+
+# assume there's only one diff file that corresponds to the PR patch file
+pr_diff=$(ls [0-9]*.diff | head -1)
+
+# if this script is run as root, use PR patch file to determine if software needs to be removed first
+changed_easystacks_rebuilds=$(cat ${pr_diff} | grep '^+++' | cut -f2 -d' ' | sed 's@^[a-z]/@@g' | grep '^easystacks/.*yml$' | egrep -v 'known-issues|missing' | grep "/rebuilds/")
+if [ -z ${changed_easystacks_rebuilds} ]; then
+    echo "No software needs to be removed."
+else
+    for easystack_file in ${changed_easystacks_rebuilds}; do
+        # determine version of EasyBuild module to load based on EasyBuild version included in name of easystack file
+        eb_version=$(echo ${easystack_file} | sed 's/.*eb-\([0-9.]*\).*/\1/g')
+
+        # load EasyBuild module (will be installed if it's not available yet)
+        source ${TOPDIR}/load_easybuild_module.sh ${eb_version}
+
+        if [ -f ${easystack_file} ]; then
+            echo_green "Software rebuild(s) requested in ${easystack_file}, so determining which existing installation have to be removed..."
+            # we need to remove existing installation directories first,
+            # so let's figure out which modules have to be rebuilt by doing a dry-run and grepping "someapp/someversion" for the relevant lines (with [R])
+            #  * [R] $CFGS/s/someapp/someapp-someversion.eb (module: someapp/someversion)
+            rebuild_apps=$(eb --dry-run-short --rebuild --easystack ${easystack_file} | grep "^ \* \[R\]" | grep -o "module: .*[^)]" | awk '{print $2}')
+            for app in ${rebuild_apps}; do
+                app_dir=${EASYBUILD_INSTALLPATH}/software/${app}
+                app_module=${EASYBUILD_INSTALLPATH}/modules/all/${app}.lua
+                echo_yellow "Removing ${app_dir} and ${app_module}..."
+                find ${app_dir} -type d | sed -e 's/^/REMOVE_DIRECTORY /'
+                find ${app_dir} -type f | sed -e 's/^/REMOVE_FILE /'
+                echo "REMOVE_MODULE ${app_module}"
+            done
+        else
+            fatal_error "Easystack file ${easystack_file} not found!"
+        fi
+    done
+fi

--- a/EESSI-determine-rebuilds.sh
+++ b/EESSI-determine-rebuilds.sh
@@ -107,6 +107,7 @@ else
             # we need to remove existing installation directories first,
             # so let's figure out which modules have to be rebuilt by doing a dry-run and grepping "someapp/someversion" for the relevant lines (with [R])
             #  * [R] $CFGS/s/someapp/someapp-someversion.eb (module: someapp/someversion)
+            eb --dry-run-short --rebuild --easystack ${easystack_file} | grep "^ \* \[R\]" | grep -o "module: .*[^)]" | awk '{print $2}'
             rebuild_apps=$(eb --dry-run-short --rebuild --easystack ${easystack_file} | grep "^ \* \[R\]" | grep -o "module: .*[^)]" | awk '{print $2}')
             for app in ${rebuild_apps}; do
                 app_dir=${EASYBUILD_INSTALLPATH}/software/${app}

--- a/EESSI-determine-rebuilds.sh
+++ b/EESSI-determine-rebuilds.sh
@@ -107,7 +107,7 @@ else
             # we need to remove existing installation directories first,
             # so let's figure out which modules have to be rebuilt by doing a dry-run and grepping "someapp/someversion" for the relevant lines (with [R])
             #  * [R] $CFGS/s/someapp/someapp-someversion.eb (module: someapp/someversion)
-            eb --dry-run-short --rebuild --easystack ${easystack_file} | grep "^ \* \[R\]" | grep -o "module: .*[^)]" | awk '{print $2}'
+            eb --dry-run-short --rebuild --easystack ${easystack_file}
             rebuild_apps=$(eb --dry-run-short --rebuild --easystack ${easystack_file} | grep "^ \* \[R\]" | grep -o "module: .*[^)]" | awk '{print $2}')
             for app in ${rebuild_apps}; do
                 app_dir=${EASYBUILD_INSTALLPATH}/software/${app}

--- a/EESSI-determine-rebuilds.sh
+++ b/EESSI-determine-rebuilds.sh
@@ -107,8 +107,9 @@ else
             # we need to remove existing installation directories first,
             # so let's figure out which modules have to be rebuilt by doing a dry-run and grepping "someapp/someversion" for the relevant lines (with [R])
             #  * [R] $CFGS/s/someapp/someapp-someversion.eb (module: someapp/someversion)
+            #  * [F] $CFGS/s/someapp/someapp-someversion.eb (module: someapp/someversion)
             eb --dry-run-short --rebuild --easystack ${easystack_file}
-            rebuild_apps=$(eb --dry-run-short --rebuild --easystack ${easystack_file} | grep "^ \* \[R\]" | grep -o "module: .*[^)]" | awk '{print $2}')
+            rebuild_apps=$(eb --dry-run-short --rebuild --easystack ${easystack_file} | grep "^ \* \[[FR]\]" | grep -o "module: .*[^)]" | awk '{print $2}')
             for app in ${rebuild_apps}; do
                 app_dir=${EASYBUILD_INSTALLPATH}/software/${app}
                 app_module=${EASYBUILD_INSTALLPATH}/modules/all/${app}.lua

--- a/EESSI-remove-software.sh
+++ b/EESSI-remove-software.sh
@@ -121,6 +121,7 @@ if [ $EUID -ne 0 ]; then
                 # so let's figure out which modules have to be rebuilt by doing a dry-run and grepping "someapp/someversion" for the relevant lines (with [R])
                 #  * [R] $CFGS/s/someapp/someapp-someversion.eb (module: someapp/someversion)
                 # rebuild_apps=$(eb --allow-use-as-root-and-accept-consequences --dry-run-short --rebuild --easystack ${easystack_file} | grep "^ \* \[R\]" | grep -o "module: .*[^)]" | awk '{print $2}')
+                eb --dry-run-short --rebuild --easystack ${easystack_file} | grep "^ \* \[R\]" | grep -o "module: .*[^)]" | awk '{print $2}'
                 rebuild_apps=$(eb --dry-run-short --rebuild --easystack ${easystack_file} | grep "^ \* \[R\]" | grep -o "module: .*[^)]" | awk '{print $2}')
                 for app in ${rebuild_apps}; do
                     # Returns e.g. /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/modules/all:

--- a/EESSI-remove-software.sh
+++ b/EESSI-remove-software.sh
@@ -121,8 +121,8 @@ if [ $EUID -ne 0 ]; then
                 # so let's figure out which modules have to be rebuilt by doing a dry-run and grepping "someapp/someversion" for the relevant lines (with [R])
                 #  * [R] $CFGS/s/someapp/someapp-someversion.eb (module: someapp/someversion)
                 # rebuild_apps=$(eb --allow-use-as-root-and-accept-consequences --dry-run-short --rebuild --easystack ${easystack_file} | grep "^ \* \[R\]" | grep -o "module: .*[^)]" | awk '{print $2}')
-                eb --dry-run-short --rebuild --easystack ${easystack_file} | grep "^ \* \[R\]" | grep -o "module: .*[^)]" | awk '{print $2}'
-                rebuild_apps=$(eb --dry-run-short --rebuild --easystack ${easystack_file} | grep "^ \* \[R\]" | grep -o "module: .*[^)]" | awk '{print $2}')
+                eb --dry-run-short --rebuild --easystack ${easystack_file}
+                rebuild_apps=$(eb --dry-run-short --rebuild --easystack ${easystack_file} | grep "^ \* \[[FR]\]" | grep -o "module: .*[^)]" | awk '{print $2}')
                 for app in ${rebuild_apps}; do
                     # Returns e.g. /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/modules/all:
                     app_modulepath=$(module --terse av ${app} 2>&1 | head -n 1 | sed 's/://')

--- a/EESSI-remove-software.sh
+++ b/EESSI-remove-software.sh
@@ -134,9 +134,12 @@ if [ $EUID -eq 0 ]; then
                     # permission issues when reinstalling the application (see https://github.com/EESSI/software-layer/issues/556)
                     echo_yellow "Recreating an empty ${app_dir}..."
                     mkdir -p ${app_dir}
-                    # these subdirs don't (and shouldn't) exist, but we need to do the ls anyway as a workaround,
-                    # so redirect to /dev/null and ignore the exit code
-                    ls ${app_subdirs} >& /dev/null || true
+                    for app_subdir in ${app_subdirs}; do
+                        mkdir -p ${app_subdir}
+                    done
+                    ## these subdirs don't (and shouldn't) exist, but we need to do the ls anyway as a workaround,
+                    ## so redirect to /dev/null and ignore the exit code
+                    #ls ${app_subdirs} >& /dev/null || true
                 done
             else
                 fatal_error "Easystack file ${easystack_file} not found!"

--- a/easystacks/software.eessi.io/2023.06/accel/nvidia/rebuilds/20250215-eb-4.9.4-CUDA-update-module-files.yml
+++ b/easystacks/software.eessi.io/2023.06/accel/nvidia/rebuilds/20250215-eb-4.9.4-CUDA-update-module-files.yml
@@ -1,0 +1,13 @@
+# 2025.02.15
+# We need to update the module files for all CUDA installations to add
+# additional directories to LIBRARY_PATH.
+# See https://github.com/easybuilders/easybuild-easyblocks/pull/3516
+easyconfigs:
+  - CUDA-12.1.1.eb:
+      options:
+        accept-eula-for: CUDA
+        include-easyblocks-from-commit: 3469151ce7e4f85415c877dee555aeea7691c757
+  - CUDA-12.4.0.eb:
+      options:
+        accept-eula-for: CUDA
+        include-easyblocks-from-commit: 3469151ce7e4f85415c877dee555aeea7691c757

--- a/easystacks/software.eessi.io/2023.06/accel/nvidia/rebuilds/20250215-eb-4.9.4-CUDA-update-module-files.yml
+++ b/easystacks/software.eessi.io/2023.06/accel/nvidia/rebuilds/20250215-eb-4.9.4-CUDA-update-module-files.yml
@@ -6,6 +6,7 @@ easyconfigs:
   - CUDA-12.1.1.eb:
       options:
         accept-eula-for: CUDA
+        force: True
         include-easyblocks-from-commit: 3469151ce7e4f85415c877dee555aeea7691c757
   - CUDA-12.4.0.eb:
       options:

--- a/eessi_container.sh
+++ b/eessi_container.sh
@@ -798,6 +798,7 @@ do
         EESSI_FUSE_MOUNTS+=("--fusemount" "${EESSI_READONLY}")
 
         EESSI_WRITABLE_OVERLAY="container:fuse-overlayfs"
+        EESSI_WRITABLE_OVERLAY+=" -o debug" # for debug output
         EESSI_WRITABLE_OVERLAY+=" -o lowerdir=/cvmfs_ro/${cvmfs_repo_name}"
         EESSI_WRITABLE_OVERLAY+=" -o upperdir=${TMP_IN_CONTAINER}/${cvmfs_repo_name}/overlay-upper"
         EESSI_WRITABLE_OVERLAY+=" -o workdir=${TMP_IN_CONTAINER}/${cvmfs_repo_name}/overlay-work"

--- a/eessi_container.sh
+++ b/eessi_container.sh
@@ -809,7 +809,7 @@ do
         EESSI_FUSE_MOUNTS+=("--fusemount" "${EESSI_READONLY}")
 
         EESSI_WRITABLE_OVERLAY="container:fuse-overlayfs"
-        EESSI_WRITABLE_OVERLAY+=" -o debug" # for debug output
+        # EESSI_WRITABLE_OVERLAY+=" -o debug" # for debug output
         if [[ -z ${LOWER_DIRS} ]]; then
             # need to convert ':' in LOWER_DIRS to ',' because bind mounts use ',' as
             # separator while the lowerdir overlayfs option uses ':'

--- a/eessi_container.sh
+++ b/eessi_container.sh
@@ -188,7 +188,7 @@ while [[ $# -gt 0 ]]; do
       NVIDIA_MODE="$2"
       shift 2
       ;;
-    -o|--lower_dirs)
+    -o|--lower-dirs)
       LOWER_DIRS="$2"
       shift 2
       ;;


### PR DESCRIPTION
After https://github.com/easybuilders/easybuild-easyblocks/pull/3516 got merged we need to update the module files for CUDA/12.{1.1,4.0}

We need to do that for the architecture combinations:
- `zen2` + `cc80`
- `zen3` + `cc80`
- `zen4` + `cc90`

For the first two we use the build cluster on AWS. For the third we use the build cluster on Azure. Because CUDA is just a binary installation, this should be fine.

Note, while we only need to rebuild the module files, we cannot use `--module-only` as EasyBuild argument because the rebuild procedure removes the whole installation.