### PR TITLE
{2023.06}[2023a,2023b] rebuild CUDA/* module files (take 2)

### DIFF
--- a/EESSI-remove-software.sh
+++ b/EESSI-remove-software.sh
@@ -116,9 +116,12 @@ if [ $EUID -eq 0 ]; then
             if [ -f ${easystack_file} ]; then
                 echo_green "Software rebuild(s) requested in ${easystack_file}, so determining which existing installation have to be removed..."
                 # we need to remove existing installation directories first,
-                # so let's figure out which modules have to be rebuilt by doing a dry-run and grepping "someapp/someversion" for the relevant lines (with [R])
+                # so let's figure out which modules have to be rebuilt by doing a
+                # dry-run and grepping "someapp/someversion" for the relevant
+                # lines (with [R] or [F])
+                #  * [F] $CFGS/s/someapp/someapp-someversion.eb (module: someapp/someversion)
                 #  * [R] $CFGS/s/someapp/someapp-someversion.eb (module: someapp/someversion)
-                rebuild_apps=$(eb --allow-use-as-root-and-accept-consequences --dry-run-short --rebuild --easystack ${easystack_file} | grep "^ \* \[R\]" | grep -o "module: .*[^)]" | awk '{print $2}')
+                rebuild_apps=$(eb --allow-use-as-root-and-accept-consequences --dry-run-short --rebuild --easystack ${easystack_file} | grep "^ \* \[[FR]\]" | grep -o "module: .*[^)]" | awk '{print $2}')
                 for app in ${rebuild_apps}; do
                     # Returns e.g. /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/modules/all:
                     app_modulepath=$(module --terse av ${app} 2>&1 | head -n 1 | sed 's/://')

--- a/easystacks/software.eessi.io/2023.06/accel/nvidia/rebuilds/20250215-eb-4.9.4-CUDA-update-module-files.yml
+++ b/easystacks/software.eessi.io/2023.06/accel/nvidia/rebuilds/20250215-eb-4.9.4-CUDA-update-module-files.yml
@@ -1,0 +1,14 @@
+# 2025.02.15
+# We need to update the module files for all CUDA installations to add
+# additional directories to LIBRARY_PATH.
+# See https://github.com/easybuilders/easybuild-easyblocks/pull/3516
+easyconfigs:
+  - CUDA-12.1.1.eb:
+      options:
+        accept-eula-for: CUDA
+        force: True
+        include-easyblocks-from-commit: 3469151ce7e4f85415c877dee555aeea7691c757
+  - CUDA-12.4.0.eb:
+      options:
+        accept-eula-for: CUDA
+        include-easyblocks-from-commit: 3469151ce7e4f85415c877dee555aeea7691c757


### PR DESCRIPTION
Renewed version for #918 

After https://github.com/easybuilders/easybuild-easyblocks/pull/3516 got merged we need to update the module files for CUDA/12.{1.1,4.0}

We need to do that for the architecture combinations:
- `zen2` + `cc80`
- `zen3` + `cc80`
- `zen4` + `cc90`

For the first two we use the build cluster on AWS. For the third we use the build cluster on Azure. Because CUDA is just a binary installation, this should be fine.

Note, while we only need to rebuild the module files, we cannot use `--module-only` as EasyBuild argument because the rebuild procedure removes the whole installation.