### PR TITLE
{2023.06}[2022b,sapphirerapids] foss 2022b

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -1,0 +1,9 @@
+easyconfigs:
+  - OpenBLAS-0.3.21-GCC-12.2.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3492
+        include-easyblocks-from-commit: d06d9617d9bfb63d338b6879eab9da81c8a312d8
+  - OpenMPI-4.1.4-GCC-12.2.0.eb:
+      options:
+        from-pr: 19940
+  - foss-2022b.eb

--- a/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -1,6 +1,9 @@
 easyconfigs:
   - OpenBLAS-0.3.21-GCC-12.2.0.eb:
       options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19159
+        # required for Sapphire Rapids support
+        from-pr: 19159
         # see https://github.com/easybuilders/easybuild-easyblocks/pull/3492
         include-easyblocks-from-pr: 3492
   - OpenMPI-4.1.4-GCC-12.2.0.eb:

--- a/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -2,7 +2,7 @@ easyconfigs:
   - OpenBLAS-0.3.21-GCC-12.2.0.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyblocks/pull/3492
-        include-easyblocks-from-commit: d06d9617d9bfb63d338b6879eab9da81c8a312d8
+        include-easyblocks-from-pr: 3492
   - OpenMPI-4.1.4-GCC-12.2.0.eb:
       options:
         from-pr: 19940


### PR DESCRIPTION
Includes some `from-pr` options for Sapphire Rapids patches and [OpenMPI rebuild](https://github.com/EESSI/software-layer/blob/2023.06-software.eessi.io/easystacks/software.eessi.io/2023.06/rebuilds/20240301-eb-4.9.0-OpenMPI-4.1.x-fix-smcuda.yml).