### PR TITLE
{2023.06}[2023a,sapphirerapids] OpenFOAM 10 and 11

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -1,0 +1,10 @@
+easyconfigs:
+  - OpenFOAM-10-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20958
+        from-commit: dbadb2074464d816740ee0e95595c2cb31b6338f
+  - OpenFOAM-11-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20958
+        from-commit: dbadb2074464d816740ee0e95595c2cb31b6338f
+


### PR DESCRIPTION
Based on https://github.com/EESSI/software-layer/blob/2023.06-software.eessi.io/easystacks/software.eessi.io/2023.06/rebuilds/20240706-eb-4.9.2-OpenFOAM-no-ftree-vectorize.yml.

```
1 out of 113 required modules missing:

* OpenFOAM/10-foss-2023a (OpenFOAM-10-foss-2023a.eb)


1 out of 113 required modules missing:

* OpenFOAM/11-foss-2023a (OpenFOAM-11-foss-2023a.eb)
```

So, can be safely built without depending on other PRs.