### PR TITLE
{2023.06}[2023a,sapphirerapids] Add EB 4.9.1 easystack for 2023a

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -1,9 +1,9 @@
 easyconfigs:
   - ncdu-1.18-GCC-12.3.0.eb
   - SAMtools-1.18-GCC-12.3.0.eb
-  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
-      options:
-        from-pr: 20379
+#  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
+#      options:
+#        from-pr: 20379
   - ipympl-0.9.3-gfbf-2023a.eb:
      options:
        from-pr: 18852

--- a/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -1,0 +1,19 @@
+easyconfigs:
+  - ncdu-1.18-GCC-12.3.0.eb
+  - SAMtools-1.18-GCC-12.3.0.eb
+  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
+      options:
+        from-pr: 20379
+  - ipympl-0.9.3-gfbf-2023a.eb:
+     options:
+       from-pr: 18852
+  - ESPResSo-4.2.2-foss-2023a.eb:
+      options:
+        from-pr: 20595
+  - GATK-4.5.0.0-GCCcore-12.3.0-Java-17.eb
+  - WhatsHap-2.2-foss-2023a.eb
+  - BLAST+-2.14.1-gompi-2023a.eb:
+      options:
+        from-pr: 20784
+  - Valgrind-3.21.0-gompi-2023a.eb
+  - OrthoFinder-2.5.5-foss-2023a.eb


### PR DESCRIPTION
R-bundle-Bioconductor depends on the CRAN bundle (#941), so I've temporarily commented it out. Will do that one in a separate PR later.