### PR TITLE
{2023.06}[2023a,sapphirerapids] R-bundle-Bioconductor 3.18

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.1-2023a.yml
@@ -1,9 +1,9 @@
 easyconfigs:
   - ncdu-1.18-GCC-12.3.0.eb
   - SAMtools-1.18-GCC-12.3.0.eb
-#  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
-#      options:
-#        from-pr: 20379
+  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
+      options:
+        from-pr: 20379
   - ipympl-0.9.3-gfbf-2023a.eb:
      options:
        from-pr: 18852


### PR DESCRIPTION
```
5 out of 156 required modules missing:

* RapidJSON/1.1.0-20230928-GCCcore-12.3.0 (RapidJSON-1.1.0-20230928-GCCcore-12.3.0.eb)
* utf8proc/2.8.0-GCCcore-12.3.0 (utf8proc-2.8.0-GCCcore-12.3.0.eb)
* Arrow/14.0.1-gfbf-2023a (Arrow-14.0.1-gfbf-2023a.eb)
* arrow-R/14.0.0.2-foss-2023a-R-4.3.2 (arrow-R-14.0.0.2-foss-2023a-R-4.3.2.eb)
* R-bundle-Bioconductor/3.18-foss-2023a-R-4.3.2 (R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb)
```