### PR TITLE
{2023.06}[2023a,sapphirerapids] Batch of apps for EB 4.9.2 / 2023a

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -7,4 +7,34 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20958
         from-commit: dbadb2074464d816740ee0e95595c2cb31b6338f
-
+  - BCFtools-1.18-GCC-12.3.0.eb
+  - BWA-0.7.18-GCCcore-12.3.0.eb
+  - CapnProto-1.0.1-GCCcore-12.3.0.eb
+  - DendroPy-4.6.1-GCCcore-12.3.0.eb
+  - DIAMOND-2.1.8-GCC-12.3.0.eb
+  - FastME-2.1.6.3-GCC-12.3.0.eb
+  - fastp-0.23.4-GCC-12.3.0.eb
+  - HMMER-3.4-gompi-2023a.eb
+  - IQ-TREE-2.3.5-gompi-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20955
+        from-commit: 185f88b9a03d65a7fb74edc7acb4221e87e90784
+  - KronaTools-2.8.1-GCCcore-12.3.0.eb
+  - LSD2-2.4.1-GCCcore-12.3.0.eb
+  - MAFFT-7.520-GCC-12.3.0-with-extensions.eb
+  - ncbi-vdb-3.0.10-gompi-2023a.eb
+  - MetalWalls-21.06.1-foss-2023a.eb
+  - QuantumESPRESSO-7.3.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20138
+        from-commit: dbdaacc0739fdee91baa9123864ea4428cf21273
+        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3338
+        include-easyblocks-from-commit: 32e45bd1f2d916732ca5852d55d17fa4d99e388b
+  - CP2K-2023.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20951
+        from-commit: a92667fe32396bbd4106243658625f7ff2adcd68
+  - amdahl-0.3.1-gompi-2023a.eb
+  - librosa-0.10.1-foss-2023a.eb
+  - xarray-2023.9.0-gfbf-2023a.eb
+  - SciTools-Iris-3.9.0-foss-2023a.eb

--- a/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.2-2023a.yml
@@ -35,6 +35,11 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20951
         from-commit: a92667fe32396bbd4106243658625f7ff2adcd68
   - amdahl-0.3.1-gompi-2023a.eb
-  - librosa-0.10.1-foss-2023a.eb
+  - LLVM-14.0.6-GCCcore-12.3.0-llvmlite.eb
+  - numba-0.58.1-foss-2023a.eb
+  - librosa-0.10.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21434
+        from-commit: 4b6170603150c9c93602b0deb726869d19a390f0
   - xarray-2023.9.0-gfbf-2023a.eb
   - SciTools-Iris-3.9.0-foss-2023a.eb


### PR DESCRIPTION
```
Missing modules:

* HTSlib/1.18-GCC-12.3.0 (HTSlib-1.18-GCC-12.3.0.eb)
* BCFtools/1.18-GCC-12.3.0 (BCFtools-1.18-GCC-12.3.0.eb)

* BWA/0.7.18-GCCcore-12.3.0 (BWA-0.7.18-GCCcore-12.3.0.eb)

* CapnProto/1.0.1-GCCcore-12.3.0 (CapnProto-1.0.1-GCCcore-12.3.0.eb)

* DendroPy/4.6.1-GCCcore-12.3.0 (DendroPy-4.6.1-GCCcore-12.3.0.eb)

* fastp/0.23.4-GCC-12.3.0 (fastp-0.23.4-GCC-12.3.0.eb)

* HMMER/3.4-gompi-2023a (HMMER-3.4-gompi-2023a.eb)

* LSD2/2.4.1-GCCcore-12.3.0 (LSD2-2.4.1-GCCcore-12.3.0.eb)
* IQ-TREE/2.3.5-gompi-2023a (IQ-TREE-2.3.5-gompi-2023a.eb)

* KronaTools/2.8.1-GCCcore-12.3.0 (KronaTools-2.8.1-GCCcore-12.3.0.eb)

* LSD2/2.4.1-GCCcore-12.3.0 (LSD2-2.4.1-GCCcore-12.3.0.eb)

* MAFFT/7.520-GCC-12.3.0-with-extensions (MAFFT-7.520-GCC-12.3.0-with-extensions.eb)

* ncbi-vdb/3.0.10-gompi-2023a (ncbi-vdb-3.0.10-gompi-2023a.eb)

* Meson/1.3.1-GCCcore-12.3.0 (Meson-1.3.1-GCCcore-12.3.0.eb)
* meson-python/0.15.0-GCCcore-12.3.0 (meson-python-0.15.0-GCCcore-12.3.0.eb)
* f90wrap/0.2.13-foss-2023a (f90wrap-0.2.13-foss-2023a.eb)
* MetalWalls/21.06.1-foss-2023a (MetalWalls-21.06.1-foss-2023a.eb)

* QuantumESPRESSO/7.3.1-foss-2023a (QuantumESPRESSO-7.3.1-foss-2023a.eb)

* libxsmm/1.17-GCC-12.3.0 (libxsmm-1.17-GCC-12.3.0.eb)
* libvori/220621-GCCcore-12.3.0 (libvori-220621-GCCcore-12.3.0.eb)
* Libint/2.7.2-GCC-12.3.0-lmax-6-cp2k (Libint-2.7.2-GCC-12.3.0-lmax-6-cp2k.eb)
* CP2K/2023.1-foss-2023a (CP2K-2023.1-foss-2023a.eb)

* amdahl/0.3.1-gompi-2023a (amdahl-0.3.1-gompi-2023a.eb)

* LLVM/14.0.6-GCCcore-12.3.0-llvmlite (LLVM-14.0.6-GCCcore-12.3.0-llvmlite.eb)
* numba/0.58.1-foss-2023a (numba-0.58.1-foss-2023a.eb)
* librosa/0.10.1-foss-2023a (librosa-0.10.1-foss-2023a.eb)

* xarray/2023.9.0-gfbf-2023a (xarray-2023.9.0-gfbf-2023a.eb)

* xxHash/0.8.2-GCCcore-12.3.0 (xxHash-0.8.2-GCCcore-12.3.0.eb)
* python-xxhash/3.4.1-GCCcore-12.3.0 (python-xxhash-3.4.1-GCCcore-12.3.0.eb)
* Shapely/2.0.1-gfbf-2023a (Shapely-2.0.1-gfbf-2023a.eb)
* pyproj/3.6.0-GCCcore-12.3.0 (pyproj-3.6.0-GCCcore-12.3.0.eb)
* netcdf4-python/1.6.4-foss-2023a (netcdf4-python-1.6.4-foss-2023a.eb)
* Fiona/1.9.5-foss-2023a (Fiona-1.9.5-foss-2023a.eb)
* Cartopy/0.22.0-foss-2023a (Cartopy-0.22.0-foss-2023a.eb)
* SciTools-Iris/3.9.0-foss-2023a (SciTools-Iris-3.9.0-foss-2023a.eb)

```

I.e., no overlap with #944, so should be safe to build in parallel.