### PR TITLE
{2023.06}[2023b,sapphirerapids] Add EB 4.9.3 easystack for 2023b

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.3-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.3-2023b.yml
@@ -1,0 +1,11 @@
+easyconfigs:
+  - GROMACS-2024.3-foss-2023b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21430
+        from-commit: 8b509882d03402e2998ff9b22c154a6957e36d6b
+  - LAMMPS-29Aug2024-foss-2023b-kokkos.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21436
+        from-commit: 9dc24e57880a8adb06ae10557c5315e66671a533
+        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3569
+        include-easyblocks-from-commit: 362b4679193612e04abe336fa041e2a34d183991


### PR DESCRIPTION
```
1 out of 60 required modules missing:

* GROMACS/2024.3-foss-2023b (GROMACS-2024.3-foss-2023b.eb)


15 out of 118 required modules missing:

* archspec/0.2.2-GCCcore-13.2.0 (archspec-0.2.2-GCCcore-13.2.0.eb)
* Voro++/0.4.6-GCCcore-13.2.0 (Voro++-0.4.6-GCCcore-13.2.0.eb)
* ffnvcodec/12.1.14.0 (ffnvcodec-12.1.14.0.eb)
* kim-api/2.3.0-GCC-13.2.0 (kim-api-2.3.0-GCC-13.2.0.eb)
* x264/20231019-GCCcore-13.2.0 (x264-20231019-GCCcore-13.2.0.eb)
* Yasm/1.3.0-GCCcore-13.2.0 (Yasm-1.3.0-GCCcore-13.2.0.eb)
* x265/3.5-GCCcore-13.2.0 (x265-3.5-GCCcore-13.2.0.eb)
* MDI/1.4.29-gompi-2023b (MDI-1.4.29-gompi-2023b.eb)
* tbb/2021.13.0-GCCcore-13.2.0 (tbb-2021.13.0-GCCcore-13.2.0.eb)
* SDL2/2.28.5-GCCcore-13.2.0 (SDL2-2.28.5-GCCcore-13.2.0.eb)
* FFmpeg/6.0-GCCcore-13.2.0 (FFmpeg-6.0-GCCcore-13.2.0.eb)
* ScaFaCoS/1.0.4-foss-2023b (ScaFaCoS-1.0.4-foss-2023b.eb)
* PLUMED/2.9.2-foss-2023b (PLUMED-2.9.2-foss-2023b.eb)
* VTK/9.3.0-foss-2023b (VTK-9.3.0-foss-2023b.eb)
* LAMMPS/29Aug2024-foss-2023b-kokkos (LAMMPS-29Aug2024-foss-2023b-kokkos.eb)

```