### PR TITLE
{2023.06}[2023b,sapphirerapids] EB 4.9.4 easystack for 2023b

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.4-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.4-2023b.yml
@@ -1,0 +1,39 @@
+easyconfigs:
+  - SIONlib-1.7.7-GCCcore-13.2.0-tools.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21752
+        from-commit: 6b8b53493a1188a5baa56a133574daac239730e7
+  - Score-P-8.4-gompi-2023b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3496
+        include-easyblocks-from-commit: 60633b0acfd41a0732992d9e16800dae71a056eb
+  - Cython-3.0.10-GCCcore-13.2.0.eb
+  - Mustache-1.3.3-foss-2023b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21783
+        from-commit: 5fa3db9eb36f91cba3fbf351549f8ba2849abc33 
+  - GDRCopy-2.4-GCCcore-13.2.0.eb
+  - GROMACS-2024.4-foss-2023b.eb:
+      options:
+        # https://github.com/easybuilders/easybuild-easyconfigs/pull/21851
+        from-commit: f0fa64b440deaf5fb0a6d26ff1bb3e9f36626c8a
+  - SlurmViewer-1.0.1-GCCcore-13.2.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21899
+        from-commit: 0bdeb23c9ea5a3caefd353ecd936919424c1bba4
+  - wxWidgets-3.2.6-GCC-13.2.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21915
+        from-commit: 58f16c0caf8c5494c68e9eda8cbf19e9145d3cfa
+  - DP3-6.2-foss-2023b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21765
+        from-commit: c7e4bfe1a57cf9781ce346ba8ae9081644408c23
+  - WSClean-3.5-foss-2023b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21765
+        from-commit: c7e4bfe1a57cf9781ce346ba8ae9081644408c23
+  - EveryBeam-0.6.1-foss-2023b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21765
+        from-commit: c7e4bfe1a57cf9781ce346ba8ae9081644408c23 


### PR DESCRIPTION
```
1 out of 2 required modules missing:

* SIONlib/1.7.7-GCCcore-13.2.0-tools (SIONlib-1.7.7-GCCcore-13.2.0-tools.eb)


7 out of 49 required modules missing:

* CubeLib/4.8.2-GCCcore-13.2.0 (CubeLib-4.8.2-GCCcore-13.2.0.eb)
* CubeWriter/4.8.2-GCCcore-13.2.0 (CubeWriter-4.8.2-GCCcore-13.2.0.eb)
* OPARI2/2.0.8-GCCcore-13.2.0 (OPARI2-2.0.8-GCCcore-13.2.0.eb)
* SIONlib/1.7.7-GCCcore-13.2.0-tools (SIONlib-1.7.7-GCCcore-13.2.0-tools.eb)
* PDT/3.25.2-GCCcore-13.2.0 (PDT-3.25.2-GCCcore-13.2.0.eb)
* OTF2/3.0.3-GCCcore-13.2.0 (OTF2-3.0.3-GCCcore-13.2.0.eb)
* Score-P/8.4-gompi-2023b (Score-P-8.4-gompi-2023b.eb)


1 out of 10 required modules missing:

* Cython/3.0.10-GCCcore-13.2.0 (Cython-3.0.10-GCCcore-13.2.0.eb)


13 out of 81 required modules missing:

* dill/0.3.8-GCCcore-13.2.0 (dill-0.3.8-GCCcore-13.2.0.eb)
* pyfaidx/0.8.1.1-GCCcore-13.2.0 (pyfaidx-0.8.1.1-GCCcore-13.2.0.eb)
* statsmodels/0.14.1-gfbf-2023b (statsmodels-0.14.1-gfbf-2023b.eb)
* hic-straw/1.3.1-foss-2023b (hic-straw-1.3.1-foss-2023b.eb)
* h5py/3.11.0-foss-2023b (h5py-3.11.0-foss-2023b.eb)
* RapidJSON/1.1.0-20240409-GCCcore-13.2.0 (RapidJSON-1.1.0-20240409-GCCcore-13.2.0.eb)
* utf8proc/2.9.0-GCCcore-13.2.0 (utf8proc-2.9.0-GCCcore-13.2.0.eb)
* Abseil/20240116.1-GCCcore-13.2.0 (Abseil-20240116.1-GCCcore-13.2.0.eb)
* RE2/2024-03-01-GCCcore-13.2.0 (RE2-2024-03-01-GCCcore-13.2.0.eb)
* Arrow/16.1.0-gfbf-2023b (Arrow-16.1.0-gfbf-2023b.eb)
* multiprocess/0.70.16-gfbf-2023b (multiprocess-0.70.16-gfbf-2023b.eb)
* cooler/0.10.2-foss-2023b (cooler-0.10.2-foss-2023b.eb)
* Mustache/1.3.3-foss-2023b (Mustache-1.3.3-foss-2023b.eb)


1 out of 3 required modules missing:

* GDRCopy/2.4-GCCcore-13.2.0 (GDRCopy-2.4-GCCcore-13.2.0.eb)


1 out of 60 required modules missing:

* GROMACS/2024.4-foss-2023b (GROMACS-2024.4-foss-2023b.eb)


5 out of 32 required modules missing:

* typing-extensions/4.10.0-GCCcore-13.2.0 (typing-extensions-4.10.0-GCCcore-13.2.0.eb)
* Rust/1.76.0-GCCcore-13.2.0 (Rust-1.76.0-GCCcore-13.2.0.eb)
* maturin/1.5.0-GCCcore-13.2.0-Rust-1.76.0 (maturin-1.5.0-GCCcore-13.2.0-Rust-1.76.0.eb)
* pydantic/2.7.4-GCCcore-13.2.0 (pydantic-2.7.4-GCCcore-13.2.0.eb)
* SlurmViewer/1.0.1-GCCcore-13.2.0 (SlurmViewer-1.0.1-GCCcore-13.2.0.eb)


5 out of 67 required modules missing:

* SDL2/2.28.5-GCCcore-13.2.0 (SDL2-2.28.5-GCCcore-13.2.0.eb)
* Graphene/1.10.8-GCCcore-13.2.0 (Graphene-1.10.8-GCCcore-13.2.0.eb)
* GStreamer/1.24.8-GCC-13.2.0 (GStreamer-1.24.8-GCC-13.2.0.eb)
* GST-plugins-base/1.24.8-GCC-13.2.0 (GST-plugins-base-1.24.8-GCC-13.2.0.eb)
* wxWidgets/3.2.6-GCC-13.2.0 (wxWidgets-3.2.6-GCC-13.2.0.eb)


2 out of 87 required modules missing:

* EveryBeam/0.6.1-foss-2023b (EveryBeam-0.6.1-foss-2023b.eb)
* DP3/6.2-foss-2023b (DP3-6.2-foss-2023b.eb)


2 out of 83 required modules missing:

* EveryBeam/0.6.1-foss-2023b (EveryBeam-0.6.1-foss-2023b.eb)
* WSClean/3.5-foss-2023b (WSClean-3.5-foss-2023b.eb)


1 out of 81 required modules missing:

* EveryBeam/0.6.1-foss-2023b (EveryBeam-0.6.1-foss-2023b.eb)
```

I don't see any overlap with #946, which also builds for 2023b. So, should be okay to build this one in parallel.