### PR TITLE
{2023.06}[2023a, sapphirerapids] archspec 0.2.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -29,7 +29,6 @@ easyconfigs:
   - snakemake-8.4.2-foss-2023a.eb:
       options:
         from-pr: 19646
-  - archspec-0.2.1-GCCcore-12.3.0.eb
   - LAMMPS-2Aug2023_update2-foss-2023a-kokkos.eb:
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19471
       # see https://github.com/easybuilders/easybuild-easyblocks/pull/3036

--- a/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -29,6 +29,7 @@ easyconfigs:
   - snakemake-8.4.2-foss-2023a.eb:
       options:
         from-pr: 19646
+  - archspec-0.2.1-GCCcore-12.3.0.eb
   - LAMMPS-2Aug2023_update2-foss-2023a-kokkos.eb:
       # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19471
       # see https://github.com/easybuilders/easybuild-easyblocks/pull/3036

--- a/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - R-bundle-CRAN-2023.12-foss-2023a.eb
+  - archspec-0.2.1-GCCcore-12.3.0.eb


### PR DESCRIPTION
This was previously used for the LAMMPS version in this easystack, and hence it's available for the other CPU targets. Due to `--from-pr` the Sapphire Rapids build picked up a newer version of the LAMMPS easyconfig that depends on archspec 0.2.5, so 0.2.1 is still missing.