### PR TITLE
{2023.06}[2023a,sapphirerapids] Add EB 4.9.3 easystack for 2023a

### DIFF
--- a/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.3-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/sapphirerapids/eessi-2023.06-eb-4.9.3-2023a.yml
@@ -1,0 +1,8 @@
+easyconfigs:
+  - ccache-4.9-GCCcore-12.3.0.eb
+  - GDB-13.2-GCCcore-12.3.0.eb
+  - tmux-3.3a-GCCcore-12.3.0.eb
+  - Vim-9.1.0004-GCCcore-12.3.0.eb
+  - gmsh-4.12.2-foss-2023a.eb
+  - basemap-1.3.9-foss-2023a.eb
+  - geopandas-0.14.2-foss-2023a.eb


### PR DESCRIPTION
This depends on #945, so that one needs to be ingested first.

Edit: also the remaining apps of the EB 4.9.2 / 2023a easystack need to be built first (#954).