### PR TITLE
{2023.06}[2023a,sapphirerapids] Redo rebuild of hatchling 1.18.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20250228-eb-4.9.2-hatchling-1.18.0-updated-easyconfig-sapphirerapids.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20250228-eb-4.9.2-hatchling-1.18.0-updated-easyconfig-sapphirerapids.yml
@@ -1,4 +1,4 @@
-# 2025.02.23
+# 2025.02.28
 # hatchling-1.18.0 rebuild to account for easyconfig changed upstream 
 # see https://gitlab.com/eessi/support/-/issues/85 and
 # https://github.com/easybuilders/easybuild-easyconfigs/pull/20389


### PR DESCRIPTION
Trying to solve https://github.com/EESSI/software-layer/pull/954#issuecomment-2690201498. Not sure what went wrong in https://github.com/EESSI/software-layer/pull/933, but it looks like it wasn't properly rebuilt. Maybe having multiple easystacks in that PR caused some weird issue?
Let's try again, and see if this build will include `hatch_requirements_txt`...