### PR TITLE
{2023.06}[2023a,sapphirerapids] Rebuild Z3 with Python bindings for Sapphire Rapids

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20250228-eb-4.9.2-rebuild-z3-with-python-bindings-sapphirerapids.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20250228-eb-4.9.2-rebuild-z3-with-python-bindings-sapphirerapids.yml
@@ -1,0 +1,8 @@
+# 2025.02.28
+# Z3/4.12.2-GCCcore-12.3.0 rebuild to account for easyconfig changed upstream 
+# see https://github.com/easybuilders/easybuild-easyconfigs/pull/20050
+easyconfigs:
+  - Z3-4.12.2-GCCcore-12.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20050
+        from-commit: 985b515a0bff531bdcafc5b83eb4160537c5db2c


### PR DESCRIPTION
This used an outdated version of the easyconfig, which didn't have the Python bindings. The other stacks do have them, so let's rebuild the Sapphire Rapids version. Also see the diff in https://github.com/EESSI/software-layer/actions/runs/13570046441/job/37932471484?pr=913.