### PR TITLE
{2023.06}[2023b] Rebuild `scikit-build-core` to include additional extension

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20250228-eb-4.9.4-scikit-build-core-add-pyproject-metadata.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20250228-eb-4.9.4-scikit-build-core-add-pyproject-metadata.yml
@@ -1,0 +1,8 @@
+# 2025.02.28
+# scikit-build-core-0.9.3-GCCcore-13.2.0.eb to account for easyconfig changed upstream 
+# see https://github.com/easybuilders/easybuild-easyconfigs/pull/21671
+easyconfigs:
+  - scikit-build-core-0.9.3-GCCcore-13.2.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21671
+        from-commit: c38f0637504bcd66e6f7f80277552934e1b03127


### PR DESCRIPTION
This easyconfig was changed upstream, and the new version was picked up by the Sapphire Rapids stack. This rebuild ensures that all stacks have the same version again.