### PR TITLE
{2023.06}[2023a] Rebuild R-bundle-Bioconductor 3.18 to sync the set of extensions between all CPU targets

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20250228-eb-4.9.4-R-bundle-Bioconductor-additional-extensions.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20250228-eb-4.9.4-R-bundle-Bioconductor-additional-extensions.yml
@@ -1,0 +1,9 @@
+# 2025.02.28
+# R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb rebuild to account for easyconfig changed upstream
+# (additional extensions have been added)
+# see https://github.com/easybuilders/easybuild-easyconfigs/pull/21948
+easyconfigs:
+  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21948
+        from-commit: f9cfe6ac7d9019970c2be3e8b09db4d846cf005a


### PR DESCRIPTION
Sapphire Rapids used the latest easyconfig, which has a few more extensions. This rebuilds ensures that all stack have the same set of extensions again.