### PR TITLE
{2023.06}[2023a] OpenCV 4.8.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -49,3 +49,4 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22235
         from-commit: 01dd97ea62fe4d7d0df040ede3af03eb2f1b8641
+  - OpenCV-4.8.1-foss-2023a-contrib.eb


### PR DESCRIPTION
```
6 out of 120 required modules missing:

* ant/1.10.14-Java-11 (ant-1.10.14-Java-11.eb)
* PyCairo/1.25.0-GCCcore-12.3.0 (PyCairo-1.25.0-GCCcore-12.3.0.eb)
* PyGObject/3.46.0-GCCcore-12.3.0 (PyGObject-3.46.0-GCCcore-12.3.0.eb)
* GST-plugins-bad/1.22.5-GCC-12.3.0 (GST-plugins-bad-1.22.5-GCC-12.3.0.eb)
* GTK4/4.13.1-GCC-12.3.0 (GTK4-4.13.1-GCC-12.3.0.eb)
* OpenCV/4.8.1-foss-2023a-contrib (OpenCV-4.8.1-foss-2023a-contrib.eb)
```