### PR TITLE
Deploy archdetect spec file that was updated in #889

### DIFF
--- a/init/arch_specs/eessi_arch_x86.spec
+++ b/init/arch_specs/eessi_arch_x86.spec
@@ -1,6 +1,6 @@
 # x86_64 CPU architecture specifications
 # Software path in EESSI 	| Vendor ID 	| List of defining CPU features
-"x86_64/intel/haswell"		"GenuineIntel"	"avx2 fma" 									# Intel Haswell, Broadwell
+"x86_64/intel/haswell"		"GenuineIntel"	"avx2 fma"									# Intel Haswell, Broadwell
 "x86_64/intel/skylake_avx512"	"GenuineIntel"	"avx2 fma avx512f avx512bw avx512cd avx512dq avx512vl"				# Intel Skylake, Cascade Lake
 "x86_64/intel/sapphirerapids"	"GenuineIntel"	"avx2 fma avx512f avx512bw avx512cd avx512dq avx512vl avx512_bf16 amx_tile"	# Intel Sapphire/Emerald Rapids
 "x86_64/amd/zen2"		"AuthenticAMD"	"avx2 fma"									# AMD Rome


### PR DESCRIPTION
We should have triggered a build in #889 in order to deploy the new file, so let's do it here.