### PR TITLE
Add Lmod startup hook that prints an error when loading removed/relocated modules

### DIFF
--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -210,6 +210,73 @@ function eessi_load_hook(t)
     end
 end
 
+local function using_eessi_accel_stack ()
+    local modulepath = os.getenv("MODULEPATH") or ""
+    local accel_stack_in_modulepath = false
+
+    -- Check if we are using an EESSI version 2023 accelerator stack by checking if the $MODULEPATH contains
+    -- a path that starts with /cvmfs/software.eessi.io and contains accel/nvidia/ccNN
+    for path in string.gmatch(modulepath, '(.-):') do
+        if string.sub(path, 1, 41) == "/cvmfs/software.eessi.io/versions/2023.06" then
+            if string.find(path, "accel/nvidia/cc%d%d") then
+                accel_stack_in_modulepath = true
+                break
+            end
+        end
+    end
+    return accel_stack_in_modulepath
+end
+
+local function eessi_removed_module_warning_startup_hook(usrCmd)
+    if usrCmd == 'load' then
+        local CUDA_RELOCATION_MSG = [[All CUDA installations and modules depending on CUDA have been relocated to GPU-specific stacks.
+        Please see https://www.eessi.io/docs/site_specific_config/gpu/ for more information.]]
+
+        local RELOCATED_CUDA_MODULES = {
+            ['NCCL'] = CUDA_RELOCATION_MSG,
+            ['NCCL/2.18.3-GCCcore-12.3.0-CUDA-12.1.1'] = CUDA_RELOCATION_MSG,
+            ['UCX-CUDA'] = CUDA_RELOCATION_MSG,
+            ['UCX-CUDA/1.14.1-GCCcore-12.3.0-CUDA-12.1.1'] = CUDA_RELOCATION_MSG,
+            -- we also have non-CUDA versions of OSU Micro Benchmarks, so only match the CUDA version
+            ['OSU-Micro-Benchmarks/7.2-gompi-2023a-CUDA-12.1.1'] = CUDA_RELOCATION_MSG,
+            ['UCC-CUDA'] = CUDA_RELOCATION_MSG,
+            ['UCC-CUDA/1.2.0-GCCcore-12.3.0-CUDA-12.1.1'] = CUDA_RELOCATION_MSG,
+            ['CUDA'] = CUDA_RELOCATION_MSG,
+            ['CUDA/12.1.1'] = CUDA_RELOCATION_MSG,
+            ['CUDA-Samples'] = CUDA_RELOCATION_MSG,
+            ['CUDA-Samples/12.1-GCC-12.3.0-CUDA-12.1.1'] = CUDA_RELOCATION_MSG,
+        }
+
+        local REMOVED_MODULES = {
+            ['ipympl/0.9.3-foss-2023a'] = 'This module has been replaced by ipympl/0.9.3-gfbf-2023a',
+        }
+
+        local masterTbl = masterTbl()
+        local error_msg = ""
+        -- The CUDA messages should only be shown if the accelerator stack is NOT being used
+        if not using_eessi_accel_stack() then
+            for _, module in pairs(masterTbl.pargs) do
+                if RELOCATED_CUDA_MODULES[module] ~= nil then
+                    error_msg = error_msg .. module .. ': ' .. RELOCATED_CUDA_MODULES[module] .. '\\n\\n'
+                end
+            end
+        end
+        for _, module in pairs(masterTbl.pargs) do
+            if REMOVED_MODULES[module] ~= nil then
+                error_msg = error_msg .. module .. ': ' .. REMOVED_MODULES[module] .. '\\n\\n'
+            end
+        end
+        if error_msg ~= "" then
+            LmodError('\\n' .. error_msg)
+        end
+    end
+end
+
+function eessi_startup_hook(usrCmd)
+    eessi_removed_module_warning_startup_hook(usrCmd)
+end
+
+hook.register("startup", eessi_startup_hook)
 hook.register("load", eessi_load_hook)
 
 """

--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -267,7 +267,7 @@ local function eessi_removed_module_warning_startup_hook(usrCmd)
             end
         end
         if error_msg ~= "" then
-            LmodError('\\n' .. error_msg .. 'If you know what you are doing and you want to ignore this check for removed/relocated modules,, set $EESSI_SKIP_REMOVED_MODULES_CHECK to any value.')
+            LmodError('\\n' .. error_msg .. 'If you know what you are doing and you want to ignore this check for removed/relocated modules, set $EESSI_SKIP_REMOVED_MODULES_CHECK to any value.')
         end
     end
 end

--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -228,7 +228,7 @@ local function using_eessi_accel_stack ()
 end
 
 local function eessi_removed_module_warning_startup_hook(usrCmd)
-    if usrCmd == 'load' then
+    if usrCmd == 'load' and not os.getenv("EESSI_SKIP_REMOVED_MODULES_CHECK") then
         local CUDA_RELOCATION_MSG = [[All CUDA installations and modules depending on CUDA have been relocated to GPU-specific stacks.
         Please see https://www.eessi.io/docs/site_specific_config/gpu/ for more information.]]
 
@@ -267,7 +267,7 @@ local function eessi_removed_module_warning_startup_hook(usrCmd)
             end
         end
         if error_msg ~= "" then
-            LmodError('\\n' .. error_msg)
+            LmodError('\\n' .. error_msg .. 'If you know what you are doing and you want to ignore this check for removed/relocated modules,, set $EESSI_SKIP_REMOVED_MODULES_CHECK to any value.')
         end
     end
 end


### PR DESCRIPTION
Implements a fix for https://gitlab.com/eessi/support/-/issues/128, allowing us to remove the CUDA installations from the CPU prefixes.


Tested this a bit in the EESSI container on an AWS VM.

No accelerator stack in `$MODULEPATH`:
```
{EESSI 2023.06} Apptainer> ml CUDA/12.1.1
Lmod has detected the following error: 
CUDA/12.1.1: All CUDA installations and modules depending on CUDA have been relocated to GPU-specific stacks.
        Please see https://www.eessi.io/docs/site_specific_config/gpu/ for more information.




{EESSI 2023.06} Apptainer> ml ipympl/0.9.3-foss-2023a
Lmod has detected the following error: 
ipympl/0.9.3-foss-2023a: This module has been replaced by ipympl/0.9.3-gfbf-2023a




{EESSI 2023.06} Apptainer> ml ipympl/0.9.3-gfbf-2023a

The following have been reloaded with a version change:
  1) ipympl/0.9.3-foss-2023a => ipympl/0.9.3-gfbf-2023a

{EESSI 2023.06} Apptainer> ml NCCL
Lmod has detected the following error: 
NCCL: All CUDA installations and modules depending on CUDA have been relocated to GPU-specific stacks.
        Please see https://www.eessi.io/docs/site_specific_config/gpu/ for more information.


```


Now we add the accelerator prefix to `$MODULEPATH`:
```
export MODULEPATH=/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/accel/nvidia/cc80/modules/all:/cvmfs/software.eessi.io/host_injections/2023.06/software/linux/x86_64/amd/zen2/modules/all:/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/modules/all

{EESSI 2023.06} Apptainer> ml NCCL
{EESSI 2023.06} Apptainer> ml CUDA/12.1.1
Lmod has detected the following error: 
You requested to load CUDA  but while the module file exists, the actual software is not entirely shipped with EESSI due to licencing. You will need to install a full copy of the CUDA package where EESSI can find it.
For more information on how to do this, see https://www.eessi.io/docs/site_specific_config/gpu/.

While processing the following module(s):
    Module fullname  Module Filename
    ---------------  ---------------
    CUDA/12.1.1      /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2/accel/nvidia/cc80/modules/all/CUDA/12.1.1.lua

{EESSI 2023.06} Apptainer> ml ipympl/0.9.3-gfbf-2023a
{EESSI 2023.06} Apptainer> ml ipympl/0.9.3-foss-2023a
Lmod has detected the following error: 
ipympl/0.9.3-foss-2023a: This module has been replaced by ipympl/0.9.3-gfbf-2023a

```

Perhaps someone else could also take this for a spin?