### PR TITLE
Add OpenMPI host injection script

### DIFF
--- a/scripts/mpi_support/install_openmpi_host_injection.sh
+++ b/scripts/mpi_support/install_openmpi_host_injection.sh
@@ -149,8 +149,9 @@ inject_mpi() {
     readarray -d '' dlopen_libs < <(find ${MPI_PATH} -mindepth 2 -name "*.so*")
 
     # Get all library names and paths in associative array
+    # If library is libfabric, libpmix, or from the MPI path
+    # modify libpath in assoc array to point to host_injection_mpi_path
     while read -r libname libpath; do
-        # If library is libfabric or from the MPI path, modify libpath in assoc array to point to host_injection_mpi_path
         if [[ ${libname} =~ libfabric\.so ]] && [[ ! -f ${temp_inject_path}/${libname} ]]; then
             local libdir="$(dirname ${libpath})/"     # without trailing slash the find does not work
             find ${libdir} -maxdepth 1 -type f -name "libfabric.so*" -exec cp {} ${temp_inject_path} \;
@@ -188,7 +189,7 @@ inject_mpi() {
                  <(for dlopen in ${dlopen_libs[@]}; do ${system_ldd} ${dlopen}; done) \
             | awk '/=>/ {print $1, $3}' | sort | uniq)
 
-    # Get MPI related lib dependencies not resolved by EESSI ldd
+    # Do library injection to openmpi libs, libfabric and libpmix
     local lib
     while read -r lib; do
         local dep

--- a/scripts/mpi_support/install_openmpi_host_injection.sh
+++ b/scripts/mpi_support/install_openmpi_host_injection.sh
@@ -208,7 +208,7 @@ inject_mpi() {
             if ${PATCHELF_BIN} --print-needed ${lib} | grep -q "${dep}"; then
                 ${PATCHELF_BIN} --replace-needed ${dep} ${libs_dict[${dep}]} ${lib}
             else
-                ${PATCHELF_BIN} --add-needed ${dep} ${libs_dict[${dep}]} ${lib}
+                ${PATCHELF_BIN} --add-needed ${libs_dict[${dep}]} ${lib}
             fi
         done < <(${eessi_ldd} ${lib} | awk '/not found/ {print $1}' | sort | uniq)
 

--- a/scripts/mpi_support/install_openmpi_host_injection.sh
+++ b/scripts/mpi_support/install_openmpi_host_injection.sh
@@ -151,7 +151,7 @@ inject_mpi() {
     # Get all library names and paths in associative array
     while read -r libname libpath; do
         # If library is libfabric or from the MPI path, modify libpath in assoc array to point to host_injection_mpi_path
-        if [[ ${libname} =~ libfabric\.so\.?.* ]] && [[ ! -f ${temp_inject_path}/${libname} ]]; then
+        if [[ ${libname} =~ libfabric\.so ]] && [[ ! -f ${temp_inject_path}/${libname} ]]; then
             local libdir="$(dirname ${libpath})/"     # without trailing slash the find does not work
             find ${libdir} -maxdepth 1 -type f -name "libfabric.so*" -exec cp {} ${temp_inject_path} \;
             find ${libdir} -maxdepth 1 -type l -name "libfabric.so*" -exec cp -P {} ${host_injection_mpi_path} \;
@@ -164,7 +164,7 @@ inject_mpi() {
             libpath=${host_injection_mpi_path}/$(basename ${libpath})
         fi
 
-        if [[ ${libname} =~ libpmix\.so\.?.* ]] && [[ ! -f ${temp_inject_path}/${libname} ]]; then
+        if [[ ${libname} =~ libpmix\.so ]] && [[ ! -f ${temp_inject_path}/${libname} ]]; then
             local libdir="$(dirname ${libpath})/"     # without trailing slash the find does not work
             [ -n "${PMIX_PATH}" ] && pmixpath="${PMIX_PATH}/pmix" || pmixpath="$(dirname ${libpath})/pmix"
             find ${libdir} -maxdepth 1 -type f -name "libpmix.so*" -exec cp {} ${temp_inject_path} \;
@@ -218,7 +218,7 @@ inject_mpi() {
         fi
 
         # Force system libefa, librdmacm, libibverbs and libpsm2 (present in the EESSI compat layer)
-        if [[ ${lib} =~ libfabric\.so\.?.* ]]; then
+        if [[ ${lib} =~ libfabric\.so ]]; then
             while read -r dep; do
                 ${PATCHELF_BIN} --replace-needed ${dep} ${libs_dict[${dep}]} ${lib}
             done < <(${system_ldd} ${lib} | awk '/libefa/ || /libibverbs/ || /libpsm2/ || /librdmacm/ {print $1}' | sort | uniq)

--- a/scripts/mpi_support/install_openmpi_host_injection.sh
+++ b/scripts/mpi_support/install_openmpi_host_injection.sh
@@ -20,7 +20,7 @@ show_help() {
     echo "Options:"
     echo "  --help                           Display this help message"
     echo "  --mpi-path /path/to/mpi          Specify the path to the MPI host installation"
-	echo "  --pmix-path /path/to/mpi         Specify the path to the PMIX host installation"
+    echo "  --pmix-path /path/to/mpi         Specify the path to the PMIX host installation"
     echo "  -t, --temp-dir /path/to/tmpdir   Specify a location to use for temporary"
     echo "                                   storage during the mpi injection"
     echo "                                   (must have >10GB available)"
@@ -35,54 +35,54 @@ get_os_release() {
     local value
 
     while read -r key value; do
-	OS_RELEASE[${key}]="${value}"
+    OS_RELEASE[${key}]="${value}"
     done < <(awk -F = 'gsub(/"/, "", $2); {print $1, $2}' /etc/os-release)
 }
 
 
 parse_cmdline() {
-	while [[ $# -gt 0 ]]; do
-		case "$1" in
-			--help)
-				show_help
-				exit 0
-				;;
-			--mpi-path)
-				if [ -n "$2" ]; then
-					MPI_PATH="$2"
-					shift 2
-				else
-					echo "Error: Argument required for $1"
-					show_help
-					exit 1
-				fi
-				;;
-			--pmix-path)
-				if [ -n "$2" ]; then
-					PMIX_PATH="$2"
-					shift 2
-				else
-					echo "Error: Argument required for $1"
-					show_help
-					exit 1
-				fi
-				;;
-			-t|--temp-dir)
-				if [ -n "$2" ]; then
-					TEMP_DIR="$2"
-					shift 2
-				else
-					echo "Error: Argument required for $1"
-					show_help
-					exit 1
-				fi
-				;;
-			*)
-				show_help
-				fatal_error "Error: Unknown option: $1"
-				;;
-		esac
-	done
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --help)
+                show_help
+                exit 0
+                ;;
+            --mpi-path)
+                if [ -n "$2" ]; then
+                    MPI_PATH="$2"
+                    shift 2
+                else
+                    echo "Error: Argument required for $1"
+                    show_help
+                    exit 1
+                fi
+                ;;
+            --pmix-path)
+                if [ -n "$2" ]; then
+                    PMIX_PATH="$2"
+                    shift 2
+                else
+                    echo "Error: Argument required for $1"
+                    show_help
+                    exit 1
+                fi
+                ;;
+            -t|--temp-dir)
+                if [ -n "$2" ]; then
+                    TEMP_DIR="$2"
+                    shift 2
+                else
+                    echo "Error: Argument required for $1"
+                    show_help
+                    exit 1
+                fi
+                ;;
+            *)
+                show_help
+                fatal_error "Error: Unknown option: $1"
+                ;;
+        esac
+    done
 }
 
 
@@ -113,13 +113,13 @@ inject_mpi() {
 
     local host_injection_mpi_path
 
-	host_injection_mpi_path=${EESSI_SOFTWARE_PATH/versions/host_injections}
+    host_injection_mpi_path=${EESSI_SOFTWARE_PATH/versions/host_injections}
     host_injection_mpi_path+="/software/${EESSI_OS_TYPE}/${EESSI_SOFTWARE_SUBDIR}"
     host_injection_mpi_path+="/rpath_overrides/OpenMPI/system/lib"
 
     if [ -d ${host_injection_mpi_path} ]; then
-		echo "MPI was already injected"
-		return 0
+        echo "MPI was already injected"
+        return 0
     fi
 
     sudo mkdir -p ${host_injection_mpi_path}
@@ -143,42 +143,42 @@ inject_mpi() {
     local -A libs_arr
 
     while read -r libname libpath; do
-	[[ ${libpath} =~ ${AMAZON_PATH}/.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
-	[[ ${libname} =~ libefa\.so\.?.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
-	[[ ${libname} =~ libibverbs\.so\.?.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
-	libs_arr[${libname}]=${libpath}
+    [[ ${libpath} =~ ${AMAZON_PATH}/.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
+    [[ ${libname} =~ libefa\.so\.?.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
+    [[ ${libname} =~ libibverbs\.so\.?.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
+    libs_arr[${libname}]=${libpath}
     done < <(cat <(${system_ldd} ${temp_inject_path}/*) <(find ${openmpi_path} -mindepth 3 -name "*.so*" -print0 | xargs -0 ${system_ldd}) | awk '/=>/{print $1, $3}' | sort | uniq)
 
     # Get MPI related lib dependencies not resolved by EESSI ldd
     local lib
 
     while read -r lib; do
-	local dep
+    local dep
 
-	${PATCHELF_BIN} --set-rpath "" ${lib}
+    ${PATCHELF_BIN} --set-rpath "" ${lib}
 
-	while read -r dep; do
-	    if ${PATCHELF_BIN} --print-needed ${lib} | grep -q "${dep}"; then
-			${PATCHELF_BIN} --replace-needed ${dep} ${libs_arr[${dep}]} ${lib}
-	    fi
-	done < <(${eessi_ldd} ${lib} | awk '/not found/ || /libefa/ || /libibverbs/ {print $1}' | sort | uniq)
+    while read -r dep; do
+        if ${PATCHELF_BIN} --print-needed ${lib} | grep -q "${dep}"; then
+            ${PATCHELF_BIN} --replace-needed ${dep} ${libs_arr[${dep}]} ${lib}
+        fi
+    done < <(${eessi_ldd} ${lib} | awk '/not found/ || /libefa/ || /libibverbs/ {print $1}' | sort | uniq)
 
-	# Inject into libmpi.so non resolved dependencies from dlopen libraries that are not already present in libmpi.so
-	if [[ ${lib} =~ libmpi\.so ]]; then
-	    while read -r dep; do
-			${PATCHELF_BIN} --add-needed ${libs_arr[${dep}]} ${lib}
-	    done < <(comm -23 <(find ${openmpi_path} -mindepth 3 -name "*.so*" -print0 | xargs -0 ${eessi_ldd} | awk '/not found/ {print $1}' | sort | uniq) <(${PATCHELF_BIN} --print-needed ${lib} | sort))
-	fi
+    # Inject into libmpi.so non resolved dependencies from dlopen libraries that are not already present in libmpi.so
+    if [[ ${lib} =~ libmpi\.so ]]; then
+        while read -r dep; do
+            ${PATCHELF_BIN} --add-needed ${libs_arr[${dep}]} ${lib}
+        done < <(comm -23 <(find ${openmpi_path} -mindepth 3 -name "*.so*" -print0 | xargs -0 ${eessi_ldd} | awk '/not found/ {print $1}' | sort | uniq) <(${PATCHELF_BIN} --print-needed ${lib} | sort))
+    fi
 
     done < <(find ${temp_inject_path} -type f)
 
     # Sanity check MPI injection
     if ${eessi_ldd} ${temp_inject_path}/* &> /dev/null; then
-		sudo cp ${temp_inject_path}/* -t ${host_injection_mpi_path}
-		echo_green "MPI injection was successful"
-		return 0
+        sudo cp ${temp_inject_path}/* -t ${host_injection_mpi_path}
+        echo_green "MPI injection was successful"
+        return 0
     else
-		fatal_error "MPI host injection failed. EESSI will use its own MPI libraries"
+        fatal_error "MPI host injection failed. EESSI will use its own MPI libraries"
     fi
 }
 
@@ -186,21 +186,21 @@ inject_mpi() {
 main() {
     process_cmdline "$@"
     get_os_release
-	check_eessi_initialised
+    check_eessi_initialised
 
-	# we need a directory we can use for temporary storage
-	if [[ -z "${TEMP_DIR}" ]]; then
-		tmpdir=$(mktemp -d)
-	else
-		tmpdir="${TEMP_DIR}"/temp
-		if ! mkdir -p "$tmpdir" ; then
-			fatal_error "Could not create directory ${tmpdir}"
-		fi
-	fi
+    # we need a directory we can use for temporary storage
+    if [[ -z "${TEMP_DIR}" ]]; then
+        tmpdir=$(mktemp -d)
+    else
+        tmpdir="${TEMP_DIR}"/temp
+        if ! mkdir -p "$tmpdir" ; then
+            fatal_error "Could not create directory ${tmpdir}"
+        fi
+    fi
 
-	echo "OpenMPI version to inject: ${OPENMPI_VERSION}"
-	download_patchelf
-	inject_mpi
+    echo "OpenMPI version to inject: ${OPENMPI_VERSION}"
+    download_patchelf
+    inject_mpi
 
     rm -rf "${tmpdir}"
     echo "EESSI setup completed with success"

--- a/scripts/mpi_support/install_openmpi_host_injection.sh
+++ b/scripts/mpi_support/install_openmpi_host_injection.sh
@@ -23,6 +23,7 @@ show_help() {
     echo "  -t, --temp-dir /path/to/tmpdir   Specify a location to use for temporary"
     echo "                                   storage during the mpi injection"
     echo "  --noclean                        Do not remove the temporary directory and the host injected libraries after finishing injection"
+    echo "  --force                          Force MPI injection even if it is already done"
 }
 
 
@@ -57,6 +58,10 @@ parse_cmdline() {
                 CLEAN=false
                 shift 1
                 ;;
+            --force)
+                FORCE=true
+                shift 1
+                ;;
             *)
                 echo_red "Error: Unknown option: $1"
                 show_help
@@ -71,6 +76,7 @@ parse_cmdline() {
     fi
 
     readonly CLEAN=${CLEAN:=true}
+    readonly FORCE=${FORCE:=false}
 }
 
 
@@ -111,7 +117,11 @@ inject_mpi() {
     if [ -d ${host_injection_mpi_path} ]; then
         if [ -n "$(ls -A ${host_injection_mpi_path})" ]; then
             echo "MPI was already injected"
-            return 0
+            if ${FORCE}; then
+                echo "Forcing new MPI injection"
+            else
+                return 0
+            fi
         fi
     fi
 

--- a/scripts/mpi_support/install_openmpi_host_injection.sh
+++ b/scripts/mpi_support/install_openmpi_host_injection.sh
@@ -70,11 +70,6 @@ parse_cmdline() {
         exit 0
     fi
 
-    if [ -z "${PMIX_PATH}" ]; then
-        echo_yellow "PMIX path was not specified"
-        echo_yellow "Assuming it is the directory where libpmix is found"
-    fi
-
     readonly CLEAN=${CLEAN:=true}
 }
 

--- a/scripts/mpi_support/install_openmpi_host_injection.sh
+++ b/scripts/mpi_support/install_openmpi_host_injection.sh
@@ -155,6 +155,12 @@ inject_mpi() {
             local libdir="$(dirname ${libpath})/"     # without trailing slash the find does not work
             find ${libdir} -maxdepth 1 -type f -name "libfabric.so*" -exec cp {} ${temp_inject_path} \;
             find ${libdir} -maxdepth 1 -type l -name "libfabric.so*" -exec cp -P {} ${host_injection_mpi_path} \;
+
+            local depname deppath
+            while read -r depname deppath; do
+                libs_dict[${depname}]=${deppath}
+            done < <(${system_ldd} ${libpath} | awk '/=>/ {print $1, $3}' | sort | uniq)
+
             libpath=${host_injection_mpi_path}/$(basename ${libpath})
         fi
 

--- a/scripts/mpi_support/install_openmpi_host_injection.sh
+++ b/scripts/mpi_support/install_openmpi_host_injection.sh
@@ -143,10 +143,10 @@ inject_mpi() {
     local -A libs_arr
 
     while read -r libname libpath; do
-    [[ ${libpath} =~ ${AMAZON_PATH}/.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
-    [[ ${libname} =~ libefa\.so\.?.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
-    [[ ${libname} =~ libibverbs\.so\.?.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
-    libs_arr[${libname}]=${libpath}
+        [[ ${libpath} =~ ${AMAZON_PATH}/.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
+        [[ ${libname} =~ libefa\.so\.?.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
+        [[ ${libname} =~ libibverbs\.so\.?.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
+        libs_arr[${libname}]=${libpath}
     done < <(cat <(${system_ldd} ${temp_inject_path}/*) <(find ${openmpi_path} -mindepth 3 -name "*.so*" -print0 | xargs -0 ${system_ldd}) | awk '/=>/{print $1, $3}' | sort | uniq)
 
     # Get MPI related lib dependencies not resolved by EESSI ldd

--- a/scripts/mpi_support/install_openmpi_host_injection.sh
+++ b/scripts/mpi_support/install_openmpi_host_injection.sh
@@ -149,7 +149,7 @@ inject_mpi() {
             libpath=${host_injection_mpi_path}/$(basename ${libpath})
         fi
 
-        if [[ ${libpath} =~ ${MPI_PATH}/.* ]]; then
+        if [[ ${libpath} =~ ${MPI_PATH} ]]; then
             libpath=${host_injection_mpi_path}/$(basename ${libpath})
         fi
         
@@ -173,9 +173,11 @@ inject_mpi() {
         if [[ ${lib} =~ libmpi\.so ]]; then
             while read -r dep; do
                 if ! ${PATCHELF_BIN} --print-needed ${lib} | grep -q "${dep}"; then
-                    ${PATCHELF_BIN} --add-needed ${libs_dict[${dep}]} ${lib}                    
+                    ${PATCHELF_BIN} --add-needed ${libs_dict[${dep}]} ${lib}
                 fi
-            done < <(for dlopen in ${dlopen_libs[@]}; do ${eessi_ldd} ${dlopen}; done | awk '/not found/ {print $1}' | sort | uniq)
+            done < <(for dlopen in ${dlopen_libs[@]}; do ${eessi_ldd} ${dlopen}; done \
+                     | grep -e "=> not found" -e "=> ${MPI_PATH}" | awk '!/libmpi\.so.*/ {print $1}' | sort | uniq)
+        fi
         fi
 
         # Force system libefa, librdmacm, libibverbs and libpsm2 (present in the EESSI compat layer)

--- a/scripts/mpi_support/install_openmpi_host_injection.sh
+++ b/scripts/mpi_support/install_openmpi_host_injection.sh
@@ -11,7 +11,7 @@
 
 # Initialise our bash functions
 TOPDIR=$(dirname $(realpath $BASH_SOURCE))
-source "$TOPDIR"/../../utils.sh
+source "$TOPDIR"/../utils.sh
 
 
 # Function to display help message
@@ -19,24 +19,10 @@ show_help() {
     echo "Usage: $0 [OPTIONS]"
     echo "Options:"
     echo "  --help                           Display this help message"
-    echo "  --mpi-path /path/to/mpi          Specify the path to the MPI host installation"
-    echo "  --pmix-path /path/to/mpi         Specify the path to the PMIX host installation"
+    echo "  --mpi-path /path/to/mpi          Specify the path to the MPI host installation (Required)"
     echo "  -t, --temp-dir /path/to/tmpdir   Specify a location to use for temporary"
     echo "                                   storage during the mpi injection"
-    echo "                                   (must have >10GB available)"
-}
-
-
-# Global associative array with os-release info
-declare -A OS_RELEASE
-
-get_os_release() {
-    local key
-    local value
-
-    while read -r key value; do
-    OS_RELEASE[${key}]="${value}"
-    done < <(awk -F = 'gsub(/"/, "", $2); {print $1, $2}' /etc/os-release)
+    echo "  --noclean                        Do not remove the temporary directory after finishing injection"
 }
 
 
@@ -49,67 +35,72 @@ parse_cmdline() {
                 ;;
             --mpi-path)
                 if [ -n "$2" ]; then
-                    MPI_PATH="$2"
+                    readonly MPI_PATH="$2"
                     shift 2
                 else
-                    echo "Error: Argument required for $1"
-                    show_help
-                    exit 1
-                fi
-                ;;
-            --pmix-path)
-                if [ -n "$2" ]; then
-                    PMIX_PATH="$2"
-                    shift 2
-                else
-                    echo "Error: Argument required for $1"
+                    echo_red "Error: Argument required for $1"
                     show_help
                     exit 1
                 fi
                 ;;
             -t|--temp-dir)
                 if [ -n "$2" ]; then
-                    TEMP_DIR="$2"
+                    readonly TEMP_DIR="$2"
                     shift 2
                 else
-                    echo "Error: Argument required for $1"
+                    echo_red "Error: Argument required for $1"
                     show_help
                     exit 1
                 fi
                 ;;
+            --noclean)
+                CLEAN=false
+                shift 1
+                ;;
             *)
+                echo_red "Error: Unknown option: $1"
                 show_help
-                fatal_error "Error: Unknown option: $1"
+                exit 1
                 ;;
         esac
     done
+    if [ -z "${MPI_PATH}" ]; then
+        echo_yellow "MPI path was not specified and it is required"
+        show_help
+        exit 0
+    fi
+    readonly CLEAN=${CLEAN:=true}
 }
 
 
 # ****Warning: patchelf v0.18.0 (currently shipped with EESSI) does not work.****
 # We get v0.17.2
 download_patchelf() {
+    # Temporary directory to save patchelf
+    local tmpdir=$1
+
     local patchelf_version="0.17.2"
     local url
+    local curl_opts="-L --silent --show-error --fail"
 
     url="https://github.com/NixOS/patchelf/releases/download/${patchelf_version}/"
     url+="patchelf-${patchelf_version}-${EESSI_CPU_FAMILY}.tar.gz"
 
-    curl ${url} ${CURL_OPTS} -o ${TEMP_DIR}/patchelf.tar.gz
-    tar -xf ${TEMP_DIR}/patchelf.tar.gz -C ${TEMP_DIR}
-    PATCHELF_BIN=${TEMP_DIR}/bin/patchelf
+    local patchelf_path=${tmpdir}/patchelf
+    mkdir ${patchelf_path}
+
+    curl ${url} ${curl_opts} -o ${patchelf_path}/patchelf.tar.gz
+    tar -xf ${patchelf_path}/patchelf.tar.gz -C ${patchelf_path}
+    PATCHELF_BIN=${patchelf_path}/bin/patchelf
 }
 
 
 inject_mpi() {
-    local efa_path="${AMAZON_PATH}/efa"
-    local openmpi_path="${MPI_PATH}"
-    local pmix_path="${PMIX_PATH}"
+    # Temporary directory for injection
+    local tmpdir=$1
 
     local eessi_ldd="${EESSI_EPREFIX}/usr/bin/ldd"
     local system_ldd="/usr/bin/ldd"
-
-    (( OPENMPI_VERSION == 5 )) && openmpi_path+=5
 
     local host_injection_mpi_path
 
@@ -118,63 +109,81 @@ inject_mpi() {
     host_injection_mpi_path+="/rpath_overrides/OpenMPI/system/lib"
 
     if [ -d ${host_injection_mpi_path} ]; then
-        echo "MPI was already injected"
-        return 0
+        if [ -n "$(ls -A ${host_injection_mpi_path})" ]; then
+            echo "MPI was already injected"
+            return 0
+        fi
     fi
 
-    sudo mkdir -p ${host_injection_mpi_path}
+    mkdir -p ${host_injection_mpi_path}
 
-    local temp_inject_path="${TEMP_DIR}/mpi_inject"
+    local temp_inject_path="${tmpdir}/mpi_inject"
     mkdir ${temp_inject_path}
 
-    # Get all library files from efa and openmpi dirs
-    find ${efa_path} ${openmpi_path} ${pmix_path} -maxdepth 2 -type f -name "*.so*" -exec cp {} ${temp_inject_path} \;
+    # Get all library files from openmpi dir
+    find ${MPI_PATH} -maxdepth 1 -type f -name "*.so*" -exec cp {} ${temp_inject_path} \;
 
     # Copy library links to host injection path
-    sudo find ${efa_path} ${openmpi_path} ${pmix_path} -maxdepth 2 -type l -name "*.so*" -exec cp -P {} ${host_injection_mpi_path} \;
-
-    # Get system libefa.so and libibverbs.so
-    find /lib/ /lib64/ \( -name "libefa.so*" -or -name "libibverbs.so*" \) -type f -exec cp {} ${temp_inject_path} \;
-    sudo find /lib/ /lib64/ \( -name "libefa.so*" -or -name "libibverbs.so*" \) -type l -exec cp -P {} ${host_injection_mpi_path} \;
-
+    find ${MPI_PATH} -maxdepth 1 -type l -name "*.so*" -exec cp -P {} ${host_injection_mpi_path} \;
 
     # Get MPI libs dependencies from system ldd
     local libname libpath
-    local -A libs_arr
+    local -A libs_dict
+    local -a dlopen_libs
 
+    readarray -d '' dlopen_libs < <(find ${MPI_PATH} -mindepth 2 -name "*.so*")
+
+    # Get all library names and paths in associative array
     while read -r libname libpath; do
-        [[ ${libpath} =~ ${AMAZON_PATH}/.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
-        [[ ${libname} =~ libefa\.so\.?.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
-        [[ ${libname} =~ libibverbs\.so\.?.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
-        libs_arr[${libname}]=${libpath}
-    done < <(cat <(${system_ldd} ${temp_inject_path}/*) <(find ${openmpi_path} -mindepth 3 -name "*.so*" -print0 | xargs -0 ${system_ldd}) | awk '/=>/{print $1, $3}' | sort | uniq)
+        # If library is libfabric or from the MPI path, modify libpath in assoc array to point to host_injection_mpi_path
+        if [[ ${libname} =~ libfabric\.so\.?.* ]] && [[ ! -f ${temp_inject_path}/${libname} ]]; then
+            local libdir="$(dirname ${libpath})/"     # without trailing slash the find does not work
+            find ${libdir} -maxdepth 1 -type f -name "libfabric.so*" -exec cp {} ${temp_inject_path} \;
+            find ${libdir} -maxdepth 1 -type l -name "libfabric.so*" -exec cp -P {} ${host_injection_mpi_path} \;
+            libpath=${host_injection_mpi_path}/$(basename ${libpath})
+        fi
+
+        if [[ ${libpath} =~ ${MPI_PATH}/.* ]]; then
+            libpath=${host_injection_mpi_path}/$(basename ${libpath})
+        fi
+        
+        libs_dict[${libname}]=${libpath}
+    done < <(cat <(find ${temp_inject_path} -maxdepth 1 -type f -name "*.so*" -exec ${system_ldd} {} \;) \
+                 <(for dlopen in ${dlopen_libs[@]}; do ${system_ldd} ${dlopen}; done) \
+            | awk '/=>/ {print $1, $3}' | sort | uniq)
 
     # Get MPI related lib dependencies not resolved by EESSI ldd
     local lib
-
     while read -r lib; do
         local dep
 
-        ${PATCHELF_BIN} --set-rpath "" ${lib}
-
+        ${PATCHELF_BIN} --set-rpath "${host_injection_mpi_path}" ${lib}
         while read -r dep; do
-            if ${PATCHELF_BIN} --print-needed ${lib} | grep -q "${dep}"; then
-                ${PATCHELF_BIN} --replace-needed ${dep} ${libs_arr[${dep}]} ${lib}
-            fi
-        done < <(${eessi_ldd} ${lib} | awk '/not found/ || /libefa/ || /libibverbs/ {print $1}' | sort | uniq)
+            ${PATCHELF_BIN} --replace-needed ${dep} ${libs_dict[${dep}]} ${lib}
+        done < <(${eessi_ldd} ${lib} | awk '/not found/ {print $1}' | sort | uniq)
 
         # Inject into libmpi.so non resolved dependencies from dlopen libraries that are not already present in libmpi.so
         if [[ ${lib} =~ libmpi\.so ]]; then
             while read -r dep; do
-                ${PATCHELF_BIN} --add-needed ${libs_arr[${dep}]} ${lib}
-            done < <(comm -23 <(find ${openmpi_path} -mindepth 3 -name "*.so*" -print0 | xargs -0 ${eessi_ldd} | awk '/not found/ {print $1}' | sort | uniq) <(${PATCHELF_BIN} --print-needed ${lib} | sort))
+                if ! ${PATCHELF_BIN} --print-needed ${lib} | grep -q "${dep}"; then
+                    ${PATCHELF_BIN} --add-needed ${libs_dict[${dep}]} ${lib}                    
+                fi
+            done < <(for dlopen in ${dlopen_libs[@]}; do ${eessi_ldd} ${dlopen}; done \
+                     | grep -e "=> not found" -e "=> ${MPI_PATH}" | awk '{print $1}' | sort | uniq)
+        fi
+
+        # Force system libefa, librdmacm, libibverbs and libpsm2 (present in the EESSI compat layer)
+        if [[ ${lib} =~ libfabric\.so\.?.* ]]; then
+            while read -r dep; do
+                ${PATCHELF_BIN} --replace-needed ${dep} ${libs_dict[${dep}]} ${lib}
+            done < <(${system_ldd} ${lib} | awk '/libefa/ || /libibverbs/ || /libpsm2/ || /librdmacm/ {print $1}' | sort | uniq)
         fi
 
     done < <(find ${temp_inject_path} -type f)
 
     # Sanity check MPI injection
     if ${eessi_ldd} ${temp_inject_path}/* &> /dev/null; then
-        sudo cp ${temp_inject_path}/* -t ${host_injection_mpi_path}
+        cp ${temp_inject_path}/* -t ${host_injection_mpi_path}
         echo_green "MPI injection was successful"
         return 0
     else
@@ -184,9 +193,12 @@ inject_mpi() {
 
 
 main() {
-    process_cmdline "$@"
-    get_os_release
+    parse_cmdline "$@"
     check_eessi_initialised
+
+    # Create directory linked by host_injections
+    local inject_dir=$(readlink -f /cvmfs/software.eessi.io/host_injections)
+    [[ ! -d ${inject_dir} ]] && mkdir -p ${inject_dir}
 
     # we need a directory we can use for temporary storage
     if [[ -z "${TEMP_DIR}" ]]; then
@@ -198,12 +210,14 @@ main() {
         fi
     fi
 
-    echo "OpenMPI version to inject: ${OPENMPI_VERSION}"
-    download_patchelf
-    inject_mpi
+    echo "Temporary directory for injection: ${tmpdir}"
 
-    rm -rf "${tmpdir}"
-    echo "EESSI setup completed with success"
+    download_patchelf ${tmpdir}
+    inject_mpi ${tmpdir}
+
+    if ${CLEAN}; then
+        rm -rf "${tmpdir}"
+    fi
 }
 
 main "$@"

--- a/scripts/mpi_support/install_openmpi_host_injection.sh
+++ b/scripts/mpi_support/install_openmpi_host_injection.sh
@@ -168,8 +168,7 @@ inject_mpi() {
                 if ! ${PATCHELF_BIN} --print-needed ${lib} | grep -q "${dep}"; then
                     ${PATCHELF_BIN} --add-needed ${libs_dict[${dep}]} ${lib}                    
                 fi
-            done < <(for dlopen in ${dlopen_libs[@]}; do ${eessi_ldd} ${dlopen}; done \
-                     | grep -e "=> not found" -e "=> ${MPI_PATH}" | awk '{print $1}' | sort | uniq)
+            done < <(for dlopen in ${dlopen_libs[@]}; do ${eessi_ldd} ${dlopen}; done | awk '/not found/ {print $1}' | sort | uniq)
         fi
 
         # Force system libefa, librdmacm, libibverbs and libpsm2 (present in the EESSI compat layer)

--- a/scripts/mpi_support/install_openmpi_host_injection.sh
+++ b/scripts/mpi_support/install_openmpi_host_injection.sh
@@ -105,7 +105,6 @@ inject_mpi() {
     local host_injection_mpi_path
 
     host_injection_mpi_path=${EESSI_SOFTWARE_PATH/versions/host_injections}
-    host_injection_mpi_path+="/software/${EESSI_OS_TYPE}/${EESSI_SOFTWARE_SUBDIR}"
     host_injection_mpi_path+="/rpath_overrides/OpenMPI/system/lib"
 
     if [ -d ${host_injection_mpi_path} ]; then

--- a/scripts/mpi_support/install_openmpi_host_injection.sh
+++ b/scripts/mpi_support/install_openmpi_host_injection.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+
+# This script can be used to install the host MPI libraries under the `.../host_injections` directory.
+# It allows EESSI software to use the MPI stack from the host.
+#
+# The `host_injections` directory is a variant symlink that by default points to
+# `/opt/eessi`, unless otherwise defined in the local CVMFS configuration (see
+# https://cvmfs.readthedocs.io/en/stable/cpt-repo.html#variant-symlinks). For the
+# installation to be successful, this directory needs to be writeable by the user
+# executing this script.
+
+# Initialise our bash functions
+TOPDIR=$(dirname $(realpath $BASH_SOURCE))
+source "$TOPDIR"/../../utils.sh
+
+
+# Function to display help message
+show_help() {
+    echo "Usage: $0 [OPTIONS]"
+    echo "Options:"
+    echo "  --help                           Display this help message"
+    echo "  --mpi-path /path/to/mpi          Specify the path to the MPI host installation"
+	echo "  --pmix-path /path/to/mpi         Specify the path to the PMIX host installation"
+    echo "  -t, --temp-dir /path/to/tmpdir   Specify a location to use for temporary"
+    echo "                                   storage during the mpi injection"
+    echo "                                   (must have >10GB available)"
+}
+
+
+# Global associative array with os-release info
+declare -A OS_RELEASE
+
+get_os_release() {
+    local key
+    local value
+
+    while read -r key value; do
+	OS_RELEASE[${key}]="${value}"
+    done < <(awk -F = 'gsub(/"/, "", $2); {print $1, $2}' /etc/os-release)
+}
+
+
+parse_cmdline() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--help)
+				show_help
+				exit 0
+				;;
+			--mpi-path)
+				if [ -n "$2" ]; then
+					MPI_PATH="$2"
+					shift 2
+				else
+					echo "Error: Argument required for $1"
+					show_help
+					exit 1
+				fi
+				;;
+			--pmix-path)
+				if [ -n "$2" ]; then
+					PMIX_PATH="$2"
+					shift 2
+				else
+					echo "Error: Argument required for $1"
+					show_help
+					exit 1
+				fi
+				;;
+			-t|--temp-dir)
+				if [ -n "$2" ]; then
+					TEMP_DIR="$2"
+					shift 2
+				else
+					echo "Error: Argument required for $1"
+					show_help
+					exit 1
+				fi
+				;;
+			*)
+				show_help
+				fatal_error "Error: Unknown option: $1"
+				;;
+		esac
+	done
+}
+
+
+# ****Warning: patchelf v0.18.0 (currently shipped with EESSI) does not work.****
+# We get v0.17.2
+download_patchelf() {
+    local patchelf_version="0.17.2"
+    local url
+
+    url="https://github.com/NixOS/patchelf/releases/download/${patchelf_version}/"
+    url+="patchelf-${patchelf_version}-${EESSI_CPU_FAMILY}.tar.gz"
+
+    curl ${url} ${CURL_OPTS} -o ${TEMP_DIR}/patchelf.tar.gz
+    tar -xf ${TEMP_DIR}/patchelf.tar.gz -C ${TEMP_DIR}
+    PATCHELF_BIN=${TEMP_DIR}/bin/patchelf
+}
+
+
+inject_mpi() {
+    local efa_path="${AMAZON_PATH}/efa"
+    local openmpi_path="${MPI_PATH}"
+    local pmix_path="${PMIX_PATH}"
+
+    local eessi_ldd="${EESSI_EPREFIX}/usr/bin/ldd"
+    local system_ldd="/usr/bin/ldd"
+
+    (( OPENMPI_VERSION == 5 )) && openmpi_path+=5
+
+    local host_injection_mpi_path
+
+	host_injection_mpi_path=${EESSI_SOFTWARE_PATH/versions/host_injections}
+    host_injection_mpi_path+="/software/${EESSI_OS_TYPE}/${EESSI_SOFTWARE_SUBDIR}"
+    host_injection_mpi_path+="/rpath_overrides/OpenMPI/system/lib"
+
+    if [ -d ${host_injection_mpi_path} ]; then
+		echo "MPI was already injected"
+		return 0
+    fi
+
+    sudo mkdir -p ${host_injection_mpi_path}
+
+    local temp_inject_path="${TEMP_DIR}/mpi_inject"
+    mkdir ${temp_inject_path}
+
+    # Get all library files from efa and openmpi dirs
+    find ${efa_path} ${openmpi_path} ${pmix_path} -maxdepth 2 -type f -name "*.so*" -exec cp {} ${temp_inject_path} \;
+
+    # Copy library links to host injection path
+    sudo find ${efa_path} ${openmpi_path} ${pmix_path} -maxdepth 2 -type l -name "*.so*" -exec cp -P {} ${host_injection_mpi_path} \;
+
+    # Get system libefa.so and libibverbs.so
+    find /lib/ /lib64/ \( -name "libefa.so*" -or -name "libibverbs.so*" \) -type f -exec cp {} ${temp_inject_path} \;
+    sudo find /lib/ /lib64/ \( -name "libefa.so*" -or -name "libibverbs.so*" \) -type l -exec cp -P {} ${host_injection_mpi_path} \;
+
+
+    # Get MPI libs dependencies from system ldd
+    local libname libpath
+    local -A libs_arr
+
+    while read -r libname libpath; do
+	[[ ${libpath} =~ ${AMAZON_PATH}/.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
+	[[ ${libname} =~ libefa\.so\.?.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
+	[[ ${libname} =~ libibverbs\.so\.?.* ]] && libpath=${host_injection_mpi_path}/$(basename ${libpath})
+	libs_arr[${libname}]=${libpath}
+    done < <(cat <(${system_ldd} ${temp_inject_path}/*) <(find ${openmpi_path} -mindepth 3 -name "*.so*" -print0 | xargs -0 ${system_ldd}) | awk '/=>/{print $1, $3}' | sort | uniq)
+
+    # Get MPI related lib dependencies not resolved by EESSI ldd
+    local lib
+
+    while read -r lib; do
+	local dep
+
+	${PATCHELF_BIN} --set-rpath "" ${lib}
+
+	while read -r dep; do
+	    if ${PATCHELF_BIN} --print-needed ${lib} | grep -q "${dep}"; then
+			${PATCHELF_BIN} --replace-needed ${dep} ${libs_arr[${dep}]} ${lib}
+	    fi
+	done < <(${eessi_ldd} ${lib} | awk '/not found/ || /libefa/ || /libibverbs/ {print $1}' | sort | uniq)
+
+	# Inject into libmpi.so non resolved dependencies from dlopen libraries that are not already present in libmpi.so
+	if [[ ${lib} =~ libmpi\.so ]]; then
+	    while read -r dep; do
+			${PATCHELF_BIN} --add-needed ${libs_arr[${dep}]} ${lib}
+	    done < <(comm -23 <(find ${openmpi_path} -mindepth 3 -name "*.so*" -print0 | xargs -0 ${eessi_ldd} | awk '/not found/ {print $1}' | sort | uniq) <(${PATCHELF_BIN} --print-needed ${lib} | sort))
+	fi
+
+    done < <(find ${temp_inject_path} -type f)
+
+    # Sanity check MPI injection
+    if ${eessi_ldd} ${temp_inject_path}/* &> /dev/null; then
+		sudo cp ${temp_inject_path}/* -t ${host_injection_mpi_path}
+		echo_green "MPI injection was successful"
+		return 0
+    else
+		fatal_error "MPI host injection failed. EESSI will use its own MPI libraries"
+    fi
+}
+
+
+main() {
+    process_cmdline "$@"
+    get_os_release
+	check_eessi_initialised
+
+	# we need a directory we can use for temporary storage
+	if [[ -z "${TEMP_DIR}" ]]; then
+		tmpdir=$(mktemp -d)
+	else
+		tmpdir="${TEMP_DIR}"/temp
+		if ! mkdir -p "$tmpdir" ; then
+			fatal_error "Could not create directory ${tmpdir}"
+		fi
+	fi
+
+	echo "OpenMPI version to inject: ${OPENMPI_VERSION}"
+	download_patchelf
+	inject_mpi
+
+    rm -rf "${tmpdir}"
+    echo "EESSI setup completed with success"
+}
+
+main "$@"

--- a/scripts/mpi_support/install_openmpi_host_injection.sh
+++ b/scripts/mpi_support/install_openmpi_host_injection.sh
@@ -205,7 +205,11 @@ inject_mpi() {
         # Do injection of unresolved libraries
         ${PATCHELF_BIN} --set-rpath "${host_injection_mpi_path}" ${lib}
         while read -r dep; do
-            ${PATCHELF_BIN} --replace-needed ${dep} ${libs_dict[${dep}]} ${lib}
+            if ${PATCHELF_BIN} --print-needed ${lib} | grep -q "${dep}"; then
+                ${PATCHELF_BIN} --replace-needed ${dep} ${libs_dict[${dep}]} ${lib}
+            else
+                ${PATCHELF_BIN} --add-needed ${dep} ${libs_dict[${dep}]} ${lib}
+            fi
         done < <(${eessi_ldd} ${lib} | awk '/not found/ {print $1}' | sort | uniq)
 
         # Inject into libmpi.so non resolved dependencies from dlopen libraries that are not already present in libmpi.so


### PR DESCRIPTION
Bash script that given a path to an OpenMPI installation in the host, makes a copy of the  OpenMPI libraries,
libfabric and libpmix and inject the necessary host libraries with the absolute path. In order to know which libraries must be injected it uses `ldd` from EESSI (`${EESSI_EPREFIX}/usr/bin/ldd`) and the host (`/usr/bin/ldd`).

The script is organized in functions. The function inject_mpi is the one actually performing the injection. There is a download_patchelf function in charge of downloading version v0.17.2 of patchelf, because the patchelf shipped with EESSI could not do the injection successfully.

The initial injection happens in a temporary directory, that can be specified from the command line, but if not specified it uses `mktemp -d`. At the end the temporary directory is removed, unless `--noclean` is specified in command line execution of the script.

The script, by default, does not perform the injection if the directory `.../host_injections/rpath_overrides/OpenMPI/system/lib` is not empty, unless `--force` is given to the script.

