### PR TITLE
Improve error message in CUDA host injection script

### DIFF
--- a/scripts/gpu_support/nvidia/install_cuda_host_injections.sh
+++ b/scripts/gpu_support/nvidia/install_cuda_host_injections.sh
@@ -147,9 +147,9 @@ else
   fi
   avail_space=$(df --output=avail "${tmpdir}"/ | tail -n 1 | awk '{print $1}')
   if (( avail_space < required_space_in_tmpdir )); then
-    error="Need at least ${required_space_in_tmpdir} disk space under ${tmpdir}.\n"
-    error="${error}Set the environment variable CUDA_TEMP_DIR to a location with adequate space to pass this check."
-    error="${error}You can alternatively set EASYBUILD_BUILDPATH and/or EASYBUILD_SOURCEPATH "
+    error="Need at least ${required_space_in_tmpdir}GB disk space under ${tmpdir}.\n"
+    error="${error}Set the environment variable CUDA_TEMP_DIR to a location with adequate space to pass this check.\n"
+    error="${error}You can alternatively set EASYBUILD_BUILDPATH and/or EASYBUILD_SOURCEPATH\n"
     error="${error}to reduce this requirement. Exiting now..."
     fatal_error "${error}"
   fi


### PR DESCRIPTION
This is a simple improvement to the error message in the `install_cuda_host_injections.sh` script. Before I got this error message:
```
ERROR: Need at least 33 temporary disk space under /tmp/tmp.iPw2eNWKxR.
Set the environment variable TEMP_DIR to a location with adequate space to pass this check.You can alternatively set EASYBUILD_BUILDPATH and/or EASYBUILD_SOURCEPATHto reduce this requirement. Exiting now...
```