### PR TITLE
{2023.06}[system,grace] EasyBuild 4.8.2, 4.9.0, 4.9.1, 4.9.2, 4.9.3, 4.9.4

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-001-system.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-001-system.yml
@@ -1,0 +1,10 @@
+easyconfigs:
+  - EasyBuild-4.8.2.eb
+  - EasyBuild-4.9.0.eb
+  - EasyBuild-4.9.1.eb
+  - EasyBuild-4.9.2.eb
+  - EasyBuild-4.9.3.eb
+  - EasyBuild-4.9.4.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21465
+        from-commit: 39cdebd7bd2cb4a9c170ee22439401316b2e7a25


### PR DESCRIPTION
First PR to start stack for NVIDIA Grace. See #967 for notes & coordination.