### PR TITLE
This is just to verify that the test step still works after deploying new ReFrame config files

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -50,3 +50,7 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22235
         from-commit: 01dd97ea62fe4d7d0df040ede3af03eb2f1b8641
   - OpenCV-4.8.1-foss-2023a-contrib.eb
+  - FALL3D/FALL3D-9.0.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22610
+        from-commit: cf03728d6105c7f3bb8753b9e304f606bb64d17f

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -50,7 +50,7 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22235
         from-commit: 01dd97ea62fe4d7d0df040ede3af03eb2f1b8641
   - OpenCV-4.8.1-foss-2023a-contrib.eb
-  - FALL3D/FALL3D-9.0.1-foss-2023a.eb:
+  - FALL3D-9.0.1-foss-2023a.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22610
         from-commit: cf03728d6105c7f3bb8753b9e304f606bb64d17f


### PR DESCRIPTION
New ReFrame config files had to be deployed to account for PR258 of the EESSI test suite https://github.com/EESSI/test-suite/pull/258

This PR is just meant to test if the test step works after the update.