### PR TITLE
{2023.06}[foss/2023a] add 'lit' a new missing dependency for R-bundle-CRAN/2023.12-foss-2023a

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -54,3 +54,8 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22610
         from-commit: 10e47e2fdd4f23fd5a52ae167771f8e9c78da411
+  - lit-18.1.2-GCCcore-12.3.0.eb
+      # needed due to changed/new dependencies for R-bundle-CRAN-2023.12-foss-2023a.eb
+      # without any from-commit this will use a version from April 6, 2024
+      # https://github.com/easybuilders/easybuild-easyconfigs/blob/88f6f9c7439c535e62461e6e71b1961c7be118b8/easybuild/easyconfigs/l/lit/lit-18.1.2-GCCcore-12.3.0.eb
+      # EB 5.0.0 has a few changes to that


### PR DESCRIPTION
Uses the version available with EasyBuild/4.9.4 Since then the easyconfig has changed a little
```bash
git diff 88f6f9c7439c535e62461e6e71b1961c7be118b8 947051eed1af47f0ed16c2f3174e82b98efc7ed7 -- easybuild/easyconfigs/l/lit/lit-18.1.2-GCCcore-12.3.0.eb
```

```diff
diff --git a/easybuild/easyconfigs/l/lit/lit-18.1.2-GCCcore-12.3.0.eb b/easybuild/easyconfigs/l/lit/lit-18.1.2-GCCcore-12.3.0.eb
index 6a3a7a8985..11b2d02b94 100644
--- a/easybuild/easyconfigs/l/lit/lit-18.1.2-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/l/lit/lit-18.1.2-GCCcore-12.3.0.eb
@@ -18,6 +18,13 @@ dependencies = [
 ]

 exts_list = [
+    ('ptyprocess', '0.7.0', {
+        'source_tmpl': '%(name)s-%(version)s-py2.py3-none-any.whl',
+        'checksums': ['4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35'],
+    }),
+    ('pexpect', '4.9.0', {
+        'checksums': ['ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f'],
+    }),
     (name, version, {
         'checksums': ['fdead6e464f9d975d31a937b82e1162d0768d61a0e5d8ee55991a33ed4aa7128'],
     }),
```