### PR TITLE
{2023.06}[system,grace] EasyBuild 4.8.2, 4.9.0, 4.9.1, 4.9.2, 4.9.3, 4.9.4, NextFlow 23.10.0, ReFrame 4.3.3, ReFrame 4.6.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.8.2-001-system.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.8.2-001-system.yml
@@ -1,4 +1,0 @@
-easyconfigs:
-  - Nextflow-23.10.0.eb:
-      options:
-        from-pr: 19172

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.2-001-system.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.2-001-system.yml
@@ -1,7 +1,0 @@
-easyconfigs:
-  - ReFrame-4.6.2.eb:
-      options:
-        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21307
-        from-commit: 0c4bd5c5a80f571a8932fbc38880d72455406816
-        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3431
-        include-easyblocks-from-commit: efddeb02abe1a679324ac01ef19601dedbe79cc0

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-001-system.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-001-system.yml
@@ -8,3 +8,6 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21465
         from-commit: 39cdebd7bd2cb4a9c170ee22439401316b2e7a25
+  - Nextflow-23.10.0.eb
+  - ReFrame-4.3.3.eb
+  - ReFrame-4.6.2.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-001-system.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-001-system.yml
@@ -9,4 +9,8 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21465
         from-commit: 39cdebd7bd2cb4a9c170ee22439401316b2e7a25
   - Nextflow-23.10.0.eb
+  - ReFrame-4.3.3.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22183
+        from-commit: 2b2fe53c885799cbf13b77ddfa9532c48b296e9d  
   - ReFrame-4.6.2.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-001-system.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-001-system.yml
@@ -9,5 +9,4 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21465
         from-commit: 39cdebd7bd2cb4a9c170ee22439401316b2e7a25
   - Nextflow-23.10.0.eb
-  - ReFrame-4.3.3.eb
   - ReFrame-4.6.2.eb


### PR DESCRIPTION
Packages added:
```
EasyBuild/4.8.2
EasyBuild/4.9.0
EasyBuild/4.9.1
EasyBuild/4.9.2
EasyBuild/4.9.3
EasyBuild/4.9.4
EasyBuild/5.0.0
EESSI-extend/2023.06-easybuild
Java/11.0.20
Nextflow/23.10.0
ReFrame/4.3.3
ReFrame/4.6.2
```