### PR TITLE
{2023.06}[2023a,grace] foss 2023a, Rust 1.70.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -1,2 +1,6 @@
 easyconfigs:
   - GCCcore-12.3.0.eb
+  - OpenBLAS-0.3.23-GCC-12.3.0.eb
+  - Rust-1.70.0-GCCcore-12.3.0.eb
+  - OpenMPI-4.1.5-GCC-12.3.0
+  - foss-2023a.eb


### PR DESCRIPTION
Packages added:
```
BLIS/0.9.0-GCC-12.3.0
CMake/3.26.3-GCCcore-12.3.0
cURL/8.0.1-GCCcore-12.3.0
FFTW/3.3.10-GCC-12.3.0
FFTW.MPI/3.3.10-gompi-2023a
FlexiBLAS/3.3.1-GCC-12.3.0
foss/2023a
GCC/12.3.0
gompi/2023a
hwloc/2.9.1-GCCcore-12.3.0
libarchive/3.6.2-GCCcore-12.3.0
libevent/2.1.12-GCCcore-12.3.0
libfabric/1.18.0-GCCcore-12.3.0
libffi/3.4.4-GCCcore-12.3.0
libpciaccess/0.17-GCCcore-12.3.0
libxml2/2.11.4-GCCcore-12.3.0
make/4.4.1-GCCcore-12.3.0
Ninja/1.11.1-GCCcore-12.3.0
numactl/2.0.16-GCCcore-12.3.0
OpenBLAS/0.3.23-GCC-12.3.0
OpenMPI/4.1.5-GCC-12.3.0
OpenSSL/1.1
patchelf/0.18.0-GCCcore-12.3.0
Perl/5.36.1-GCCcore-12.3.0
pkgconf/1.8.0
pkgconf/1.9.5-GCCcore-12.3.0
PMIx/4.2.4-GCCcore-12.3.0
Python/3.11.3-GCCcore-12.3.0
Rust/1.70.0-GCCcore-12.3.0
ScaLAPACK/2.2.0-gompi-2023a-fb
SQLite/3.42.0-GCCcore-12.3.0
Tcl/8.6.13-GCCcore-12.3.0
UCC/1.2.0-GCCcore-12.3.0
UCX/1.14.1-GCCcore-12.3.0
UnZip/6.0-GCCcore-12.3.0
xorg-macros/1.20.0-GCCcore-12.3.0
```