### PR TITLE
{2023.06}[2023a,grace] Remaining apps from EB 4.8.2 2023a easystack

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -26,7 +26,7 @@ easyconfigs:
       options:
         # source URLs for Boost.* have changed, corresponding PR is
         # https://github.com/easybuilders/easybuild-easyconfigs/pull/22240
-        # # Boost.Python is a dependency of Boost
+        # Boost.Python is a dependency of Boost
         from-commit: e610fe1ac5393d1de668a466fdaaea74c580ee03
   - netCDF-4.9.2-gompi-2023a.eb
   - FFmpeg-6.0-GCCcore-12.3.0.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -26,6 +26,7 @@ easyconfigs:
       options:
         # source URLs for Boost.* have changed, corresponding PR is
         # https://github.com/easybuilders/easybuild-easyconfigs/pull/22240
+        # # Boost.Python is a dependency of Boost
         from-commit: e610fe1ac5393d1de668a466fdaaea74c580ee03
   - netCDF-4.9.2-gompi-2023a.eb
   - FFmpeg-6.0-GCCcore-12.3.0.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -22,12 +22,6 @@ easyconfigs:
         # source URLs for Boost have changed, corresponding PR is
         # https://github.com/easybuilders/easybuild-easyconfigs/pull/22157
         from-commit: 5bebccf792ccf35a8ee3250bc8fed86dff5d5df9
-  - Boost.Python-1.82.0-GCC-12.3.0.eb:
-      options:
-        # source URLs for Boost.* have changed, corresponding PR is
-        # https://github.com/easybuilders/easybuild-easyconfigs/pull/22240
-        # Boost.Python is a dependency of Boost
-        from-commit: e610fe1ac5393d1de668a466fdaaea74c580ee03
   - netCDF-4.9.2-gompi-2023a.eb
   - FFmpeg-6.0-GCCcore-12.3.0.eb
   - ALL-0.9.2-foss-2023a.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -17,3 +17,20 @@ easyconfigs:
   - LHAPDF-6.5.4-GCC-12.3.0.eb
   - LoopTools-2.15-GCC-12.3.0.eb
   - R-4.3.2-gfbf-2023a.eb
+  - Boost-1.82.0-GCC-12.3.0.eb:
+      options:
+        # source URLs for Boost have changed, corresponding PR is
+        # https://github.com/easybuilders/easybuild-easyconfigs/pull/22157
+        # Boost is a dependency of AOFlagger
+        from-commit: 5bebccf792ccf35a8ee3250bc8fed86dff5d5df9
+  - Boost.Python-1.82.0-GCC-12.3.0.eb:
+      options:
+        # source URLs for Boost.* have changed, corresponding PR is
+        # https://github.com/easybuilders/easybuild-easyconfigs/pull/22240
+        # Boost.Python is a dependency of AOFlagger
+        from-commit: e610fe1ac5393d1de668a466fdaaea74c580ee03
+  - netCDF-4.9.2-gompi-2023a.eb
+  - FFmpeg-6.0-GCCcore-12.3.0.eb
+  - ALL-0.9.2-foss-2023a.eb
+  - CDO-2.2.2-gompi-2023a.eb
+  - BWA-0.7.17-20220923-GCCcore-12.3.0.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -21,13 +21,11 @@ easyconfigs:
       options:
         # source URLs for Boost have changed, corresponding PR is
         # https://github.com/easybuilders/easybuild-easyconfigs/pull/22157
-        # Boost is a dependency of AOFlagger
         from-commit: 5bebccf792ccf35a8ee3250bc8fed86dff5d5df9
   - Boost.Python-1.82.0-GCC-12.3.0.eb:
       options:
         # source URLs for Boost.* have changed, corresponding PR is
         # https://github.com/easybuilders/easybuild-easyconfigs/pull/22240
-        # Boost.Python is a dependency of AOFlagger
         from-commit: e610fe1ac5393d1de668a466fdaaea74c580ee03
   - netCDF-4.9.2-gompi-2023a.eb
   - FFmpeg-6.0-GCCcore-12.3.0.eb


### PR DESCRIPTION
Boost sources could not be fetched, and thus it was failing in #985, `from-commit` have been added to Boost

Packages added:
```
ALL/0.9.2-foss-2023a.lua
Boost/1.82.0-GCC-12.3.0.lua
BWA/0.7.17-20220923-GCCcore-12.3.0.lua
CDO/2.2.2-gompi-2023a.lua
ecCodes/2.31.0-gompi-2023a.lua
FFmpeg/6.0-GCCcore-12.3.0.lua
ffnvcodec/12.0.16.0.lua
googletest/1.13.0-GCCcore-12.3.0.lua
LAME/3.100-GCCcore-12.3.0.lua
libaec/1.0.6-GCCcore-12.3.0.lua
netCDF/4.9.2-gompi-2023a.lua
nlohmann_json/3.11.2-GCCcore-12.3.0.lua
PROJ/9.2.0-GCCcore-12.3.0.lua
SDL2/2.28.2-GCCcore-12.3.0.lua
UDUNITS/2.2.28-GCCcore-12.3.0.lua
VTK/9.3.0-foss-2023a.lua
x264/20230226-GCCcore-12.3.0.lua
x265/3.5-GCCcore-12.3.0.lua
```