### PR TITLE
{2023.06}[2023b,grace] apps originally built with EB 4.9.2 + changes to bot/build.sh and eessi_container.sh

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -189,6 +189,10 @@ fi
 #  - /dev is needed to access /dev/fuse
 COMMON_ARGS+=("--extra-bind-paths" "${software_layer_dir},/dev")
 
+# pass through '--contain' to avoid leaking in scripts into the container session
+# note, --pass-through can be used multiple times if needed
+COMMON_ARGS+=("--pass-through" "--contain")
+
 # make sure to use the same parent dir for storing tarballs of tmp
 PREVIOUS_TMP_DIR=${PWD}/previous_tmp
 

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -184,6 +184,11 @@ if [[ "${REPOSITORY_NAME}" == "dev.eessi.io" ]]; then
     COMMON_ARGS+=("--repository" "software.eessi.io,access=ro")
 fi
 
+# add $software_layer_dir and /dev as extra bind paths
+#  - $software_layer_dir is needed because it is used as prefix for running scripts
+#  - /dev is needed to access /dev/fuse
+COMMON_ARGS+=("--extra-bind-paths" "${software_layer_dir},/dev")
+
 # make sure to use the same parent dir for storing tarballs of tmp
 PREVIOUS_TMP_DIR=${PWD}/previous_tmp
 

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023b.yml
@@ -105,3 +105,41 @@ easyconfigs:
 #      options:
 #        from-pr: 20792
   - Valgrind-3.23.0-gompi-2023b.eb
+# from here on easyconfigs were originally built with EB 4.9.2
+  - IPython-8.17.2-GCCcore-13.2.0.eb
+  - dlb-3.4-gompi-2023b.eb
+# originally built with EB 4.9.2, PR 20889 was included since EB 4.9.3
+#  - pystencils-1.3.4-gfbf-2023b.eb:
+#      options:
+#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20889
+#        from-commit: c66c4788a17f7e4f55aa23f9fdb782aad97c9ce7
+  - pystencils-1.3.4-gfbf-2023b.eb
+# originally built with EB 4.9.2, PR 21017 was included since EB 4.9.3, PR 3393
+#   was included since EB 4.9.3
+#  - Extrae-4.2.0-gompi-2023b.eb:
+#      options:
+#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21017
+#        from-commit: 120f4d56efebd2bc61382db4c84a664a339c66cf
+#        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3393
+#        include-easyblocks-from-commit: c4951c78d62fa5cf8e9f6fe0ead212d2a4d7cb9c
+  - Extrae-4.2.0-gompi-2023b.eb
+# originally built with EB 4.9.2, PR 21034 was included since EB 4.9.3
+#  - pyMBE-0.8.0-foss-2023b.eb:
+#      options:
+#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21034
+#        from-commit: 76e7fc6657bab64bfbec826540a3a8f0040258f2
+  - pyMBE-0.8.0-foss-2023b.eb
+# originally built with EB 4.9.2, PR 21200 was included since EB 4.9.3
+#  - STAR-2.7.11b-GCC-13.2.0.eb:
+#      options:
+#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21200
+#        from-commit: 765ba900daf5953e306c4dad896febe52fdd6c00
+  - STAR-2.7.11b-GCC-13.2.0.eb
+  - HPL-2.3-foss-2023b.eb
+# originally built with EB 4.9.2, PR 21366 was included since EB 4.9.3
+#  - R-bundle-CRAN-2024.06-foss-2023b.eb:
+#      options:
+#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21366
+#        # we use a commit from the Brunsli PR here to get rid of the Highway dependency
+#        from-commit: 1736a123b1685836452587a5c51793257570bb2d
+  - R-bundle-CRAN-2024.06-foss-2023b.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023b.yml
@@ -123,6 +123,12 @@ easyconfigs:
 #        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3393
 #        include-easyblocks-from-commit: c4951c78d62fa5cf8e9f6fe0ead212d2a4d7cb9c
   - Extrae-4.2.0-gompi-2023b.eb
+  - Boost.MPI-1.83.0-gompi-2023b.eb:
+      options:
+        # source URLs for Boost.* have changed, corresponding PR is
+        # https://github.com/easybuilders/easybuild-easyconfigs/pull/22240
+        # Boost.MPI is a dependency of pyMBE
+        from-commit: e610fe1ac5393d1de668a466fdaaea74c580ee03
 # originally built with EB 4.9.2, PR 21034 was included since EB 4.9.3
 #  - pyMBE-0.8.0-foss-2023b.eb:
 #      options:

--- a/eessi_container.sh
+++ b/eessi_container.sh
@@ -89,6 +89,8 @@ display_help() {
   echo "  -n | --nvidia MODE      - configure the container to work with NVIDIA GPUs,"
   echo "                            MODE==install for a CUDA installation, MODE==run to"
   echo "                            attach a GPU, MODE==all for both [default: false]"
+  echo "  -p | --pass-through ARG - argument to pass through to the launch of the"
+  echo "                            container; can be given multiple times [default: not set]"
   echo "  -r | --repository CFG   - configuration file or identifier defining the"
   echo "                            repository to use; can be given multiple times;"
   echo "                            CFG may include a suffix ',access={ro,rw}' to"
@@ -126,6 +128,7 @@ VERBOSE=0
 STORAGE=
 LIST_REPOS=0
 MODE="shell"
+PASS_THROUGH=()
 SETUP_NVIDIA=0
 REPOSITORIES=()
 RESUME=
@@ -180,6 +183,10 @@ while [[ $# -gt 0 ]]; do
     -n|--nvidia)
       SETUP_NVIDIA=1
       NVIDIA_MODE="$2"
+      shift 2
+      ;;
+    -p|--pass-through)
+      PASS_THROUGH+=("$2")
       shift 2
       ;;
     -r|--repository)
@@ -841,6 +848,11 @@ if [ ! -z ${EESSI_SOFTWARE_SUBDIR_OVERRIDE} ]; then
     # also specify via $APPTAINERENV_* (future proof, cfr. https://apptainer.org/docs/user/latest/singularity_compatibility.html#singularity-environment-variable-compatibility)
     export APPTAINERENV_EESSI_SOFTWARE_SUBDIR_OVERRIDE=${EESSI_SOFTWARE_SUBDIR_OVERRIDE}
 fi
+
+# add pass through arguments
+for arg in "${PASS_THROUGH[@]}"; do
+    ADDITIONAL_CONTAINER_OPTIONS+=(${arg})
+done
 
 echo "Launching container with command (next line):"
 echo "singularity ${RUN_QUIET} ${MODE} ${ADDITIONAL_CONTAINER_OPTIONS[@]} ${EESSI_FUSE_MOUNTS[@]} ${CONTAINER} $@"


### PR DESCRIPTION
**This PR needs to be reviewed carefully.**

It contains three changes:

1. Adds the capability to pass through arguments to the launch of the container (new arg `--pass-through` for `eessi_container.sh`)
2. Adds extra bind paths for `$software_layer_dir` and `/dev` when running `eessi_container.sh`. Also makes use of `--pass-through` to run the container with `--contain`. The latter is needed to prevent system level scripts from the host to be executed when the container is launched.
3. Adds easyconfigs originally built with EB 4.9.2 with the tool chain foss/2023b (see #939). Then used `[include-easyblocks-]from-{pr,commit}` have been removed since all of them were included in EB 4.9.3

**IMPORTANT** The (ReFrame) test step is not functioning as expected. Even after some changes to the bot configuration (adding 'processor' information to `reframe_config.py` to work around non working CPU auto-detection) and using of `--contain` the test step seems to block/stall. Thus, for the time being, we skip the test step by using `exportvariable:SKIP_TESTS=yes` for bot build commands.