### PR TITLE
{2023.06}[2023a,grace] Apps from EB 4.9.0 2023a easystack

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -51,32 +51,9 @@ easyconfigs:
   - scikit-learn-1.3.1-gfbf-2023a.eb
   - MUMPS-5.6.1-foss-2023a-metis.eb:
       options:
-        # source URLs for MUMP Shave changed, corresponding PR is
+        # source URLs for MUMPS have changed, corresponding PR is
         # https://github.com/easybuilders/easybuild-easyconfigs/pull/22582
         # MUMPS is a dependency of snakemake
         from-commit: 0437ff1ad34283398f55d4a6e01e6540b1ae9688
   - snakemake-8.4.2-foss-2023a.eb
   - LAMMPS-2Aug2023_update2-foss-2023a-kokkos.eb
-  - PyTorch-2.1.2-foss-2023a.eb
-  - matplotlib-3.7.2-gfbf-2023a.eb
-  - PyQt5-5.15.10-GCCcore-12.3.0.eb
-  - Pillow-SIMD-9.5.0-GCCcore-12.3.0.eb
-  - dask-2023.9.2-foss-2023a.eb
-  - JupyterNotebook-7.0.2-GCCcore-12.3.0.eb
-  - ImageMagick-7.1.1-15-GCCcore-12.3.0.eb
-  - Z3-4.12.2-GCCcore-12.3.0.eb
-  - PyOpenGL-3.1.7-GCCcore-12.3.0.eb
-  - OpenJPEG-2.5.0-GCCcore-12.3.0.eb
-  - Highway-1.0.4-GCCcore-12.3.0.eb
-  - ELPA-2023.05.001-foss-2023a.eb
-  - libxc-6.2.2-GCC-12.3.0.eb
-  - SuperLU_DIST-8.1.2-foss-2023a.eb
-  - PETSc-3.20.3-foss-2023a.eb
-  - MODFLOW-6.4.4-foss-2023a.eb
-  - NLopt-2.7.1-GCCcore-12.3.0.eb
-  - nettle-3.9.1-GCCcore-12.3.0.eb
-  - Xvfb-21.1.8-GCCcore-12.3.0.eb
-  - libsndfile-1.2.2-GCCcore-12.3.0.eb
-  - PostgreSQL-16.1-GCCcore-12.3.0.eb
-  - ImageMagick-7.1.1-15-GCCcore-12.3.0.eb
-  - GDAL-3.7.1-foss-2023a.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -49,6 +49,12 @@ easyconfigs:
   - pytest-rerunfailures-12.0-GCCcore-12.3.0.eb
   - pytest-shard-0.1.2-GCCcore-12.3.0.eb
   - scikit-learn-1.3.1-gfbf-2023a.eb
+  - MUMPS-5.6.1-foss-2023a-metis.eb:
+      options:
+        # source URLs for MUMP Shave changed, corresponding PR is
+        # https://github.com/easybuilders/easybuild-easyconfigs/pull/22582
+        # MUMPS is a dependency of snakemake
+        from-commit: 0437ff1ad34283398f55d4a6e01e6540b1ae9688
   - snakemake-8.4.2-foss-2023a.eb
   - LAMMPS-2Aug2023_update2-foss-2023a-kokkos.eb
   - PyTorch-2.1.2-foss-2023a.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -27,3 +27,44 @@ easyconfigs:
   - ALL-0.9.2-foss-2023a.eb
   - CDO-2.2.2-gompi-2023a.eb
   - BWA-0.7.17-20220923-GCCcore-12.3.0.eb
+  - METIS-5.1.0-GCCcore-12.3.0.eb
+  - SCOTCH-7.0.3-gompi-2023a.eb
+  - CGAL-5.6-GCCcore-12.3.0.eb
+  - ParaView-5.11.2-foss-2023a.eb
+  - gnuplot-5.4.8-GCCcore-12.3.0.eb
+  - ESPResSo-4.2.1-foss-2023a.eb
+  - Rivet-3.1.9-gompi-2023a-HepMC3-3.2.6.eb
+  - Pillow-10.0.0-GCCcore-12.3.0.eb
+  - sympy-1.12-gfbf-2023a.eb
+  - networkx-3.1-gfbf-2023a.eb
+  - expecttest-0.1.5-GCCcore-12.3.0.eb
+  - PyYAML-6.0-GCCcore-12.3.0.eb
+  - pytest-flakefinder-1.1.0-GCCcore-12.3.0.eb
+  - pytest-rerunfailures-12.0-GCCcore-12.3.0.eb
+  - pytest-shard-0.1.2-GCCcore-12.3.0.eb
+  - scikit-learn-1.3.1-gfbf-2023a.eb
+  - snakemake-8.4.2-foss-2023a.eb
+  - LAMMPS-2Aug2023_update2-foss-2023a-kokkos.eb
+  - PyTorch-2.1.2-foss-2023a.eb
+  - matplotlib-3.7.2-gfbf-2023a.eb
+  - PyQt5-5.15.10-GCCcore-12.3.0.eb
+  - Pillow-SIMD-9.5.0-GCCcore-12.3.0.eb
+  - dask-2023.9.2-foss-2023a.eb
+  - JupyterNotebook-7.0.2-GCCcore-12.3.0.eb
+  - ImageMagick-7.1.1-15-GCCcore-12.3.0.eb
+  - Z3-4.12.2-GCCcore-12.3.0.eb
+  - PyOpenGL-3.1.7-GCCcore-12.3.0.eb
+  - OpenJPEG-2.5.0-GCCcore-12.3.0.eb
+  - Highway-1.0.4-GCCcore-12.3.0.eb
+  - ELPA-2023.05.001-foss-2023a.eb
+  - libxc-6.2.2-GCC-12.3.0.eb
+  - SuperLU_DIST-8.1.2-foss-2023a.eb
+  - PETSc-3.20.3-foss-2023a.eb
+  - MODFLOW-6.4.4-foss-2023a.eb
+  - NLopt-2.7.1-GCCcore-12.3.0.eb
+  - nettle-3.9.1-GCCcore-12.3.0.eb
+  - Xvfb-21.1.8-GCCcore-12.3.0.eb
+  - libsndfile-1.2.2-GCCcore-12.3.0.eb
+  - PostgreSQL-16.1-GCCcore-12.3.0.eb
+  - ImageMagick-7.1.1-15-GCCcore-12.3.0.eb
+  - GDAL-3.7.1-foss-2023a.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -32,6 +32,12 @@ easyconfigs:
   - CGAL-5.6-GCCcore-12.3.0.eb
   - ParaView-5.11.2-foss-2023a.eb
   - gnuplot-5.4.8-GCCcore-12.3.0.eb
+  - Boost.MPI-1.82.0-gompi-2023a.eb: 
+      options:
+        # source URLs for Boost.MPI have changed, corresponding PR is
+        # https://github.com/easybuilders/easybuild-easyconfigs/pull/22240
+        # Boost.MPI is a dependency of ESPResSo
+        from-commit: e610fe1ac5393d1de668a466fdaaea74c580ee03
   - ESPResSo-4.2.1-foss-2023a.eb
   - Rivet-3.1.9-gompi-2023a-HepMC3-3.2.6.eb
   - Pillow-10.0.0-GCCcore-12.3.0.eb


### PR DESCRIPTION
Packages added:
```
archspec/0.2.1-GCCcore-12.3.0
Boost.MPI/1.82.0-gompi-2023a
Cbc/2.10.11-foss-2023a
CGAL/5.6-GCCcore-12.3.0
Cgl/0.60.8-foss-2023a
Clp/1.17.9-foss-2023a
CoinUtils/2.11.10-GCC-12.3.0
ESPResSo/4.2.1-foss-2023a
expecttest/0.1.5-GCCcore-12.3.0
fastjet/3.4.2-gompi-2023a
fastjet-contrib/1.053-gompi-2023a
GitPython/3.1.40-GCCcore-12.3.0
GLPK/5.0-GCCcore-12.3.0
GMP/6.2.1-GCCcore-12.3.0
gmpy2/2.1.5-GCC-12.3.0
gnuplot/5.4.8-GCCcore-12.3.0
GSL/2.7-GCC-12.3.0
HepMC3/3.2.6-GCC-12.3.0
IPython/8.14.0-GCCcore-12.3.0
kim-api/2.3.0-GCC-12.3.0
LAMMPS/2Aug2023_update2-foss-2023a-kokkos
libcerf/2.3-GCCcore-12.3.0
libgd/2.3.3-GCCcore-12.3.0
libsodium/1.0.18-GCCcore-12.3.0
libwebp/1.3.1-GCCcore-12.3.0
libxslt/1.1.38-GCCcore-12.3.0
libyaml/0.2.5-GCCcore-12.3.0
LittleCMS/2.15-GCCcore-12.3.0
Lua/5.4.6-GCCcore-12.3.0
lxml/4.9.2-GCCcore-12.3.0
MDI/1.4.26-gompi-2023a
METIS/5.1.0-GCCcore-12.3.0
MPC/1.3.1-GCCcore-12.3.0
MPFR/4.2.0-GCCcore-12.3.0
MUMPS/5.6.1-foss-2023a-metis
networkx/3.1-gfbf-2023a
OpenJPEG/2.5.0-GCCcore-12.3.0
OpenPGM/5.2.122-GCCcore-12.3.0
Osi/0.108.9-GCC-12.3.0
Pango/1.50.14-GCCcore-12.3.0
ParaView/5.11.2-foss-2023a
Pillow/10.0.0-GCCcore-12.3.0
Pint/0.23-GCCcore-12.3.0
PLUMED/2.9.0-foss-2023a
PuLP/2.8.0-foss-2023a
pytest-flakefinder/1.1.0-GCCcore-12.3.0
pytest-rerunfailures/12.0-GCCcore-12.3.0
pytest-shard/0.1.2-GCCcore-12.3.0
PyYAML/6.0-GCCcore-12.3.0
Rivet/3.1.9-gompi-2023a-HepMC3-3.2.6
scikit-learn/1.3.1-gfbf-2023a
SCOTCH/7.0.3-gompi-2023a
siscone/3.0.6-GCCcore-12.3.0
snakemake/8.4.2-foss-2023a
sympy/1.12-gfbf-2023a
typing-extensions/4.9.0-GCCcore-12.3.0
Voro++/0.4.6-GCCcore-12.3.0
wrapt/1.15.0-gfbf-2023a
xxd/9.0.2112-GCCcore-12.3.0
YODA/1.9.9-GCC-12.3.0
ZeroMQ/4.3.4-GCCcore-12.3.0
```