### PR TITLE
{2023.06}[2023a,grace] Remaining apps from EB 4.9.0 2023a easystack

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -74,6 +74,12 @@ easyconfigs:
         # possible change in gitlabs tarball packaging, affected by .gitattributes
         # https://github.com/easybuilders/easybuild-easyconfigs/pull/22580
         from-commit: 456d64bbeacf465e8f7e7ff378864e26352d045d
+  - ParMETIS-4.0.3-gompi-2023a.eb: 
+      options:
+        # source URLs for ParMETIS-4.0.3 have changed, corresponding PR is
+        # https://github.com/easybuilders/easybuild-easyconfigs/pull/22579
+        # ParMETIS-4.0.3 is a dependency of SuperLU_DIST-8.1.2
+        from-commit: 977e5208a720f23ace41b83b84da8b717d0aeada
   - SuperLU_DIST-8.1.2-foss-2023a.eb
   - PETSc-3.20.3-foss-2023a.eb
   - MODFLOW-6.4.4-foss-2023a.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -67,3 +67,16 @@ easyconfigs:
   - Z3-4.12.2-GCCcore-12.3.0.eb
   - PyOpenGL-3.1.7-GCCcore-12.3.0.eb
   - OpenJPEG-2.5.0-GCCcore-12.3.0.eb
+  - Highway-1.0.4-GCCcore-12.3.0.eb
+  - ELPA-2023.05.001-foss-2023a.eb
+  - libxc-6.2.2-GCC-12.3.0.eb
+  - SuperLU_DIST-8.1.2-foss-2023a.eb
+  - PETSc-3.20.3-foss-2023a.eb
+  - MODFLOW-6.4.4-foss-2023a.eb
+  - NLopt-2.7.1-GCCcore-12.3.0.eb
+  - nettle-3.9.1-GCCcore-12.3.0.eb
+  - Xvfb-21.1.8-GCCcore-12.3.0.eb
+  - libsndfile-1.2.2-GCCcore-12.3.0.eb
+  - PostgreSQL-16.1-GCCcore-12.3.0.eb
+  - ImageMagick-7.1.1-15-GCCcore-12.3.0.eb
+  - GDAL-3.7.1-foss-2023a.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -70,6 +70,10 @@ easyconfigs:
   - Highway-1.0.4-GCCcore-12.3.0.eb
   - ELPA-2023.05.001-foss-2023a.eb
   - libxc-6.2.2-GCC-12.3.0.eb
+      options:
+        # possible change in gitlabs tarball packaging, affected by .gitattributes
+        # https://github.com/easybuilders/easybuild-easyconfigs/pull/22580
+        from-commit: 456d64bbeacf465e8f7e7ff378864e26352d045d
   - SuperLU_DIST-8.1.2-foss-2023a.eb
   - PETSc-3.20.3-foss-2023a.eb
   - MODFLOW-6.4.4-foss-2023a.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -69,7 +69,7 @@ easyconfigs:
   - OpenJPEG-2.5.0-GCCcore-12.3.0.eb
   - Highway-1.0.4-GCCcore-12.3.0.eb
   - ELPA-2023.05.001-foss-2023a.eb
-  - libxc-6.2.2-GCC-12.3.0.eb
+  - libxc-6.2.2-GCC-12.3.0.eb:
       options:
         # possible change in gitlabs tarball packaging, affected by .gitattributes
         # https://github.com/easybuilders/easybuild-easyconfigs/pull/22580

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -502,7 +502,7 @@ def pre_prepare_hook_highway_handle_test_compilation_issues(self, *args, **kwarg
         # note: keep condition in sync with the one used in
         # post_prepare_hook_highway_handle_test_compilation_issues
         if self.version in ['1.0.4'] and tcname == 'GCCcore' and tcversion == '12.3.0':
-            if cpu_target in [CPU_TARGET_A64FX, CPU_TARGET_NEOVERSE_V1]:
+            if cpu_target in [CPU_TARGET_A64FX, CPU_TARGET_NEOVERSE_V1, CPU_TARGET_NVIDIA_GRACE]:
                 self.cfg.update('configopts', '-DHWY_ENABLE_TESTS=OFF')
             if cpu_target == CPU_TARGET_NEOVERSE_N1:
                 self.orig_optarch = build_option('optarch')


### PR DESCRIPTION
This PR also addresses the failure seen during building Highway-1.0.4 in #991, also added ParMETIS-4.0.3 which is a dependency of SuperLU_DIST-8.1.2 because couldn't download file parmetis-4.0.3.tar.gz

Packages added:
```
Armadillo/12.6.2-foss-2023a
arpack-ng/3.9.0-foss-2023a
Brunsli/0.1-GCCcore-12.3.0
CFITSIO/4.3.0-GCCcore-12.3.0
ELPA/2023.05.001-foss-2023a
FLAC/1.4.2-GCCcore-12.3.0
GDAL/3.7.1-foss-2023a
GEOS/3.12.0-GCC-12.3.0
HDF/4.2.16-2-GCCcore-12.3.0
Highway/1.0.4-GCCcore-12.3.0
Hypre/2.29.0-foss-2023a
Imath/3.1.7-GCCcore-12.3.0
json-c/0.16-GCCcore-12.3.0
LERC/4.0.0-GCCcore-12.3.0
libgeotiff/1.7.1-GCCcore-12.3.0
libogg/1.3.5-GCCcore-12.3.0
libopus/1.4-GCCcore-12.3.0
libsndfile/1.2.2-GCCcore-12.3.0
libtirpc/1.3.3-GCCcore-12.3.0
libvorbis/1.3.7-GCCcore-12.3.0
libxc/6.2.2-GCC-12.3.0
MODFLOW/6.4.4-foss-2023a
netCDF-Fortran/4.6.1-gompi-2023a
nettle/3.9.1-GCCcore-12.3.0
NLopt/2.7.1-GCCcore-12.3.0
OpenEXR/3.1.7-GCCcore-12.3.0
ParMETIS/4.0.3-gompi-2023a
PETSc/3.20.3-foss-2023a
PostgreSQL/16.1-GCCcore-12.3.0
SuiteSparse/7.1.0-foss-2023a
SuperLU_DIST/8.1.2-foss-2023a
SWIG/4.1.1-GCCcore-12.3.0
Xerces-C++/3.2.4-GCCcore-12.3.0
Xvfb/21.1.8-GCCcore-12.3.0
```