### PR TITLE
{2023.06}[system,2023b,grace] a few remaining apps for the system and 2023b toolchains

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-001-system.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-001-system.yml
@@ -14,3 +14,7 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22183
         from-commit: 2b2fe53c885799cbf13b77ddfa9532c48b296e9d  
   - ReFrame-4.6.2.eb
+  - Pandoc-3.6.2.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22493
+        from-commit: da8ed20bad0dd1c6533c568f6c4fbb7c3d15342e

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023b.yml
@@ -213,3 +213,12 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21765
         # NOTE, below commit is the merge commit for PR 21765
         from-commit: c7e4bfe1a57cf9781ce346ba8ae9081644408c23
+# a few apps installed in late march/early april 2025
+  - lit-18.1.7-GCCcore-13.2.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20902
+        from-commit: 79f4cf21490f7f5b187af889be5426c1332a497d
+  - astropy-7.0.0-gfbf-2023b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22469
+        from-commit: fc22841fef99cbb2a221c18029b15e692e78c27c


### PR DESCRIPTION
For the system toolchain there are a few more missing (2 x Java and 1 x ant) which seem to be dependencies of other packages.