### PR TITLE
{2023.06}[2023b,CUDA,grace] CUDA/12.4, UCX-CUDA/1.15.0, UCC-CUDA/1.2.0, OSU-Micro-Benchmarks-7.5 w/ CUDA

### DIFF
--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -271,6 +271,7 @@ fi
 
 # Install NVIDIA drivers in host_injections (if they exist)
 if command_exists "nvidia-smi"; then
+    export LD_LIBRARY_PATH="/.singularity.d/libs:${LD_LIBRARY_PATH}"
     nvidia-smi --version
     ec=$?
     if [ ${ec} -eq 0 ]; then 

--- a/easystacks/software.eessi.io/2023.06/grace/accel/nvidia/eessi-2023.06-eb-4.9.4-2023b-CUDA.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/accel/nvidia/eessi-2023.06-eb-4.9.4-2023b-CUDA.yml
@@ -2,6 +2,8 @@ easyconfigs:
   - CUDA-12.4.0.eb:
       options:
         accept-eula-for: CUDA
+        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3516
+        include-easyblocks-from-commit: 3469151ce7e4f85415c877dee555aeea7691c757
   - UCX-CUDA-1.15.0-GCCcore-13.2.0-CUDA-12.4.0.eb
   - UCC-CUDA-1.2.0-GCCcore-13.2.0-CUDA-12.4.0.eb:
       options:
@@ -10,4 +12,6 @@ easyconfigs:
   - OSU-Micro-Benchmarks-7.5-gompi-2023b-CUDA-12.4.0.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21926
-        from-commit: de79ec74eb076e1aceda5e21235a73c05ed6764c
+        # from-commit: de79ec74eb076e1aceda5e21235a73c05ed6764c
+        # use merge commit
+        from-commit: f3bd10b19f7caf4de3302bc7a73749341db9c7d8

--- a/easystacks/software.eessi.io/2023.06/grace/accel/nvidia/eessi-2023.06-eb-4.9.4-2023b-CUDA.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/accel/nvidia/eessi-2023.06-eb-4.9.4-2023b-CUDA.yml
@@ -1,0 +1,13 @@
+easyconfigs:
+  - CUDA-12.4.0.eb:
+      options:
+        accept-eula-for: CUDA
+  - UCX-CUDA-1.15.0-GCCcore-13.2.0-CUDA-12.4.0.eb
+  - UCC-CUDA-1.2.0-GCCcore-13.2.0-CUDA-12.4.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21565
+        from-commit: 46141a3f40e699433fac03af2d3ed81bd5a62da7
+  - OSU-Micro-Benchmarks-7.5-gompi-2023b-CUDA-12.4.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21926
+        from-commit: de79ec74eb076e1aceda5e21235a73c05ed6764c


### PR DESCRIPTION
Add CUDA and a first set of CUDA-enabled packages. Build for `nvidia/cc90`.

PR includes a small fix to ensure that `nvidia-smi` finds needed NVIDIA libraries when running the `EESSI-install-software.sh` script inside a Gentoo Prefix shell.

Need to make sure to build the CUDA module correctly. See https://github.com/EESSI/software-layer/pull/919/files#diff-847943558c26638b42bfbce28fc8c19778e137289eefa374c811a75225169e8d