### PR TITLE
{2023.06}[2023a,grace] Apps from EB 4.9.1 2023a easystack

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -90,3 +90,13 @@ easyconfigs:
   - PostgreSQL-16.1-GCCcore-12.3.0.eb
   - ImageMagick-7.1.1-15-GCCcore-12.3.0.eb
   - GDAL-3.7.1-foss-2023a.eb
+  - ncdu-1.18-GCC-12.3.0.eb
+  - SAMtools-1.18-GCC-12.3.0.eb
+  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb
+  - ipympl-0.9.3-gfbf-2023a.eb
+  - ESPResSo-4.2.2-foss-2023a.eb
+  - GATK-4.5.0.0-GCCcore-12.3.0-Java-17.eb
+  - WhatsHap-2.2-foss-2023a.eb
+  - BLAST+-2.14.1-gompi-2023a.eb
+  - Valgrind-3.21.0-gompi-2023a.eb
+  - OrthoFinder-2.5.5-foss-2023a.eb


### PR DESCRIPTION
In this PR, R-bundle-Bioconductor-3.18 and other packages can be used without the `from-commit` as we are using EB 4.9.4

Packages added:
```
Arrow/14.0.1-gfbf-2023a
arrow-R/14.0.1-foss-2023a-R-4.3.2
Biopython/1.83-foss-2023a
BLAST+/2.14.1-gompi-2023a
cimfomfa/22.273-GCCcore-12.3.0
cpio/2.15-GCCcore-12.3.0
DIAMOND/2.1.8-GCC-12.3.0
ESPResSo/4.2.2-foss-2023a
FastME/2.1.6.3-GCC-12.3.0
GATK/4.5.0.0-GCCcore-12.3.0-Java-17
ipympl/0.9.3-gfbf-2023a
ISA-L/2.30.0-GCCcore-12.3.0
Java/17.0.6
LMDB/0.9.31-GCCcore-12.3.0
MCL/22.282-GCCcore-12.3.0
MMseqs2/14-7e284-gompi-2023a
ncdu/1.18-GCC-12.3.0
OrthoFinder/2.5.5-foss-2023a
pyfaidx/0.8.1.1-GCCcore-12.3.0
Pysam/0.22.0-GCC-12.3.0
python-isal/1.1.0-GCCcore-12.3.0
RapidJSON/1.1.0-20230928-GCCcore-12.3.0
R-bundle-Bioconductor/3.18-foss-2023a-R-4.3.2
R-bundle-CRAN/2023.12-foss-2023a
SAMtools/1.18-GCC-12.3.0
utf8proc/2.8.0-GCCcore-12.3.0
Valgrind/3.21.0-gompi-2023a
WhatsHap/2.2-foss-2023a
```