### PR TITLE
{2023.06}[2023a,grace] Apps from EB 4.9.2 2023a easystack

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -100,3 +100,37 @@ easyconfigs:
   - BLAST+-2.14.1-gompi-2023a.eb
   - Valgrind-3.21.0-gompi-2023a.eb
   - OrthoFinder-2.5.5-foss-2023a.eb
+  - OpenFOAM-10-foss-2023a.eb
+  - OpenFOAM-11-foss-2023a.eb
+  - BCFtools-1.18-GCC-12.3.0.eb
+  - BWA-0.7.18-GCCcore-12.3.0.eb
+  - CapnProto-1.0.1-GCCcore-12.3.0.eb
+  - DendroPy-4.6.1-GCCcore-12.3.0.eb
+  - DIAMOND-2.1.8-GCC-12.3.0.eb
+  - FastME-2.1.6.3-GCC-12.3.0.eb
+  - fastp-0.23.4-GCC-12.3.0.eb
+  - HMMER-3.4-gompi-2023a.eb
+  - IQ-TREE-2.3.5-gompi-2023a.eb
+  - KronaTools-2.8.1-GCCcore-12.3.0.eb
+  - LSD2-2.4.1-GCCcore-12.3.0.eb
+  - MAFFT-7.520-GCC-12.3.0-with-extensions.eb
+  - ncbi-vdb-3.0.10-gompi-2023a.eb
+  - MetalWalls-21.06.1-foss-2023a.eb
+  - QuantumESPRESSO-7.3.1-foss-2023a.eb
+  - CP2K-2023.1-foss-2023a.eb
+  - amdahl-0.3.1-gompi-2023a.eb
+  - LLVM-14.0.6-GCCcore-12.3.0-llvmlite.eb
+  - numba-0.58.1-foss-2023a.eb
+  - librosa-0.10.1-foss-2023a.eb
+  - xarray-2023.9.0-gfbf-2023a.eb
+  - SciTools-Iris-3.9.0-foss-2023a.eb
+  - OpenFOAM-v2312-foss-2023a.eb
+  - BioPerl-1.7.8-GCCcore-12.3.0.eb
+  - grpcio-1.57.0-GCCcore-12.3.0.eb
+  - orjson-3.9.15-GCCcore-12.3.0.eb
+  - wradlib-2.0.3-foss-2023a.eb
+  - MBX-1.1.0-foss-2023a.eb
+  - Transrate-1.0.3-GCC-12.3.0.eb
+  - Critic2-1.2-foss-2023a.eb
+  - LRBinner-0.1-foss-2023a.eb
+  - Redland-1.0.17-GCC-12.3.0.eb


### PR DESCRIPTION
Packages added:
```
amdahl/0.3.1-gompi-2023a
BCFtools/1.18-GCC-12.3.0
BioPerl/1.7.8-GCCcore-12.3.0
BWA/0.7.18-GCCcore-12.3.0
CapnProto/1.0.1-GCCcore-12.3.0
Cartopy/0.22.0-foss-2023a
colorize/0.7.7-GCC-12.3.0
CP2K/2023.1-foss-2023a
crb-blast/0.6.9-GCC-12.3.0
Critic2/1.2-foss-2023a
DB/18.1.40-GCCcore-12.3.0
DB_File/1.859-GCCcore-12.3.0
DendroPy/4.6.1-GCCcore-12.3.0
f90wrap/0.2.13-foss-2023a
fastp/0.23.4-GCC-12.3.0
Fiona/1.9.5-foss-2023a
FragGeneScan/1.31-GCCcore-12.3.0
geopandas/0.14.2-foss-2023a
groff/1.22.4-GCCcore-12.3.0
grpcio/1.57.0-GCCcore-12.3.0
gtk-doc/1.34.0-GCCcore-12.3.0
h5netcdf/1.2.0-foss-2023a
HDBSCAN/0.8.38.post1-foss-2023a
HMMER/3.4-gompi-2023a
HTSlib/1.18-GCC-12.3.0
IQ-TREE/2.3.5-gompi-2023a
ITSTool/2.0.7-GCCcore-12.3.0
jemalloc/5.3.0-GCCcore-12.3.0
Judy/1.0.5-GCCcore-12.3.0
KaHIP/3.16-gompi-2023a
KronaTools/2.8.1-GCCcore-12.3.0
libaio/0.3.113-GCCcore-12.3.0
libcint/5.4.0-gfbf-2023a
libgcrypt/1.10.3-GCCcore-12.3.0
libgpg-error/1.48-GCCcore-12.3.0
Libint/2.7.2-GCC-12.3.0-lmax-6-cp2k
librosa/0.10.1-foss-2023a
libvori/220621-GCCcore-12.3.0
libxml2-python/2.11.4-GCCcore-12.3.0
LLVM/14.0.6-GCCcore-12.3.0-llvmlite
LRBinner/0.1-foss-2023a
LSD2/2.4.1-GCCcore-12.3.0
LZO/2.10-GCCcore-12.3.0
MAFFT/7.520-GCC-12.3.0-with-extensions
mallard-ducktype/1.0.2-GCCcore-12.3.0
MariaDB/11.6.0-GCC-12.3.0
maturin/1.4.0-GCCcore-12.3.0-Rust-1.75.0
MBX/1.1.0-foss-2023a
Meson/1.3.1-GCCcore-12.3.0
meson-python/0.15.0-GCCcore-12.3.0
MetalWalls/21.06.1-foss-2023a
ncbi-vdb/3.0.10-gompi-2023a
netcdf4-python/1.6.4-foss-2023a
numba/0.58.1-foss-2023a
OpenFOAM/10-foss-2023a
OpenFOAM/11-foss-2023a
OpenFOAM/v2312-foss-2023a
orjson/3.9.15-GCCcore-12.3.0
Perl-bundle-CPAN/5.36.1-GCCcore-12.3.0
psycopg2/2.9.9-GCCcore-12.3.0
Pygments/2.18.0-GCCcore-12.3.0
pyproj/3.6.0-GCCcore-12.3.0
python-xxhash/3.4.1-GCCcore-12.3.0
QuantumESPRESSO/7.3.1-foss-2023a
Raptor/2.0.16-GCCcore-12.3.0
Rasqal/0.9.33-GCCcore-12.3.0
Redland/1.0.17-GCC-12.3.0
Ruby/3.3.0-GCCcore-12.3.0
Rust/1.75.0-GCCcore-12.3.0
SciTools-Iris/3.9.0-foss-2023a
Seaborn/0.13.2-gfbf-2023a
Shapely/2.0.1-gfbf-2023a
SQLAlchemy/2.0.25-GCCcore-12.3.0
tqdm/4.66.1-GCCcore-12.3.0
Transrate/1.0.3-GCC-12.3.0
unixODBC/2.3.12-GCCcore-12.3.0
wradlib/2.0.3-foss-2023a
xarray/2023.9.0-gfbf-2023a
XML-LibXML/2.0209-GCCcore-12.3.0
xxHash/0.8.2-GCCcore-12.3.0
yell/2.2.2-GCC-12.3.0
yelp-tools/42.1-GCCcore-12.3.0
yelp-xsl/42.1-GCCcore-12.3.0
```