### PR TITLE
{2023.06}[2023a,grace] Apps from EB 4.9.3 2023a easystack

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -134,3 +134,10 @@ easyconfigs:
   - Critic2-1.2-foss-2023a.eb
   - LRBinner-0.1-foss-2023a.eb
   - Redland-1.0.17-GCC-12.3.0.eb
+  - ccache-4.9-GCCcore-12.3.0.eb
+  - GDB-13.2-GCCcore-12.3.0.eb
+  - tmux-3.3a-GCCcore-12.3.0.eb
+  - Vim-9.1.0004-GCCcore-12.3.0.eb
+  - gmsh-4.12.2-foss-2023a.eb
+  - basemap-1.3.9-foss-2023a.eb
+  - geopandas-0.14.2-foss-2023a.eb


### PR DESCRIPTION
Packages added:
```
basemap/1.3.9-foss-2023a
ccache/4.9-GCCcore-12.3.0
FLTK/1.3.8-GCCcore-12.3.0
FreeImage/3.18.0-GCCcore-12.3.0
GDB/13.2-GCCcore-12.3.0
gmsh/4.12.2-foss-2023a
hiredis/1.2.0-GCCcore-12.3.0
ISL/0.26-GCCcore-12.3.0
occt/7.8.0-GCCcore-12.3.0
SLEPc/3.20.1-foss-2023a
tbb/2021.11.0-GCCcore-12.3.0
tmux/3.3a-GCCcore-12.3.0
Vim/9.1.0004-GCCcore-12.3.0
xprop/1.2.6-GCCcore-12.3.0
```