### PR TITLE
{2023.06}[2022b,grace] Qt5 5.15.7

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -1,0 +1,5 @@
+easyconfigs:
+# from here on built originally with EB 4.8.2
+# need to keep building Qt5 with 4.8.2 because more recent versions include an
+# updated easyblock for python which doesn't work correctly for Python-2.7.18
+  - Qt5-5.15.7-GCCcore-12.2.0.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2022b.yml
@@ -33,4 +33,4 @@ easyconfigs:
 # moved Qt5 to easystack file used with EB 4.8.2 because it needs an older
 # version of the python easyblock
 #  - Qt5-5.15.7-GCCcore-12.2.0.eb
-  - QuantumESPRESSO-7.2-foss-2022b.eb
+#  - QuantumESPRESSO-7.2-foss-2022b.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2022b.yml
@@ -30,5 +30,7 @@ easyconfigs:
 #      options:
 #        from-pr: 19339
   - HarfBuzz-5.3.1-GCCcore-12.2.0.eb
+# moved Qt5 to easystack file used with EB 4.8.2 because it needs an older
+# version of the python easyblock
 #  - Qt5-5.15.7-GCCcore-12.2.0.eb
-#  - QuantumESPRESSO-7.2-foss-2022b.eb
+  - QuantumESPRESSO-7.2-foss-2022b.eb


### PR DESCRIPTION
Qt5 has a dependency for Python-2.7.18 which doesn't build with a recent version of the python easyblock (see #1003). Hence, we use version 4.8.2, that is the version we used originally.

~For QuantumESPRESSO, we use EB 4.9.4~ we will build QuantumESPRESSO in a separate PR