### PR TITLE
{2023.06}[2023a,grace] rebuild R-bundle-Bioconductor-3.18 in 2023a easystack

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -92,7 +92,11 @@ easyconfigs:
   - GDAL-3.7.1-foss-2023a.eb
   - ncdu-1.18-GCC-12.3.0.eb
   - SAMtools-1.18-GCC-12.3.0.eb
-  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb
+  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
+      options:
+        # (additional extensions have been added)
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21948
+        from-commit: f9cfe6ac7d9019970c2be3e8b09db4d846cf005a
   - ipympl-0.9.3-gfbf-2023a.eb
   - ESPResSo-4.2.2-foss-2023a.eb
   - GATK-4.5.0.0-GCCcore-12.3.0-Java-17.eb


### PR DESCRIPTION
The latest changes for `R-bundle-Bioconductor-3.18` were not introduced in #998, this PR addresses those changes 
Packages added:
```
R-bundle-Bioconductor/3.18-foss-2023a-R-4.3.2
```