### PR TITLE
{2023.06}[2022b,grace] QuantumESPRESSO 7.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -3,5 +3,7 @@ easyconfigs:
 # need to keep building Qt5 with 4.8.2 because more recent versions include an
 # updated easyblock for python which doesn't work correctly for Python-2.7.18
   - Qt5-5.15.7-GCCcore-12.2.0.eb
-# try to also build QE with EB 4.8.2
-  - QuantumESPRESSO-7.2-foss-2022b.eb
+# try to also build QE with EB 4.8.2 --> worked but it looks like we may not have
+# used the FoX library, see https://github.com/easybuilders/easybuild-easyconfigs/pull/20070/files#diff-b5e488fd7d21901d2307ed7994868853061fb5c60080e91cb186e2f937e45522
+# so we move building QE 7.2 with EB 4.9.4
+#  - QuantumESPRESSO-7.2-foss-2022b.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -3,3 +3,5 @@ easyconfigs:
 # need to keep building Qt5 with 4.8.2 because more recent versions include an
 # updated easyblock for python which doesn't work correctly for Python-2.7.18
   - Qt5-5.15.7-GCCcore-12.2.0.eb
+# try to also build QE with EB 4.8.2
+  - QuantumESPRESSO-7.2-foss-2022b.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -5,5 +5,7 @@ easyconfigs:
   - Qt5-5.15.7-GCCcore-12.2.0.eb
 # try to also build QE with EB 4.8.2 --> worked but it looks like we may not have
 # used the FoX library, see https://github.com/easybuilders/easybuild-easyconfigs/pull/20070/files#diff-b5e488fd7d21901d2307ed7994868853061fb5c60080e91cb186e2f937e45522
-# so we move building QE 7.2 with EB 4.9.4
-#  - QuantumESPRESSO-7.2-foss-2022b.eb
+# so we move building QE 7.2 with EB 4.9.4; that failed plus QE was not built
+# with the FoX library for any other of the supported CPU microarchitectures,
+# hence we keep building it with EB 4.8.2 (here in this easystack file)
+  - QuantumESPRESSO-7.2-foss-2022b.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2022b.yml
@@ -33,4 +33,5 @@ easyconfigs:
 # moved Qt5 to easystack file used with EB 4.8.2 because it needs an older
 # version of the python easyblock
 #  - Qt5-5.15.7-GCCcore-12.2.0.eb
+# we try to build QE with EB 4.8.2 too
 #  - QuantumESPRESSO-7.2-foss-2022b.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2022b.yml
@@ -33,5 +33,6 @@ easyconfigs:
 # moved Qt5 to easystack file used with EB 4.8.2 because it needs an older
 # version of the python easyblock
 #  - Qt5-5.15.7-GCCcore-12.2.0.eb
-# we try to build QE with EB 4.8.2 too
-#  - QuantumESPRESSO-7.2-foss-2022b.eb
+# we try to build QE with EB 4.8.2 too, that worked; however to ensure the build
+# uses updated easyconfigs we use EB 4.9.4
+  - QuantumESPRESSO-7.2-foss-2022b.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2022b.yml
@@ -33,6 +33,7 @@ easyconfigs:
 # moved Qt5 to easystack file used with EB 4.8.2 because it needs an older
 # version of the python easyblock
 #  - Qt5-5.15.7-GCCcore-12.2.0.eb
-# we try to build QE with EB 4.8.2 too, that worked; however to ensure the build
-# uses updated easyconfigs we use EB 4.9.4
-  - QuantumESPRESSO-7.2-foss-2022b.eb
+# we try to build QE with EB 4.8.2 too, that worked; building with updated
+# easyconfigs (via EB 4.9.4) didn't work, and wasn't done for any of the other
+# supported CPU microarchitectures. Hence, we build QE with 4.8.2
+#  - QuantumESPRESSO-7.2-foss-2022b.eb


### PR DESCRIPTION
QuantumESPRESSO failed to build with EB 4.9.4, so we try first EB 4.8.2 the version that was used to build it originally.