### PR TITLE
{2023.06}[2023a,CUDA,grace] CUDA/12.1.1, cuDNN/8.9.2.26, CUDA-Samples/12.1 + apps with CUDA

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/accel/nvidia/eessi-2023.06-eb-4.9.4-2023a-CUDA.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/accel/nvidia/eessi-2023.06-eb-4.9.4-2023a-CUDA.yml
@@ -5,6 +5,8 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyblocks/pull/3516
         include-easyblocks-from-commit: 3469151ce7e4f85415c877dee555aeea7691c757
   - CUDA-Samples-12.1-GCC-12.3.0-CUDA-12.1.1.eb
+  - UCX-CUDA-1.14.1-GCCcore-12.3.0-CUDA-12.1.1.eb
+  - UCC-CUDA-1.2.0-GCCcore-12.3.0-CUDA-12.1.1.eb
   - OSU-Micro-Benchmarks-7.2-gompi-2023a-CUDA-12.1.1.eb
   - LAMMPS-2Aug2023_update2-foss-2023a-kokkos-CUDA-12.1.1.eb
   - ESPResSo-4.2.2-foss-2023a-CUDA-12.1.1.eb:

--- a/easystacks/software.eessi.io/2023.06/grace/accel/nvidia/eessi-2023.06-eb-4.9.4-2023a-CUDA.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/accel/nvidia/eessi-2023.06-eb-4.9.4-2023a-CUDA.yml
@@ -17,3 +17,4 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21699
         from-commit: e3407bd127d248c08960f6b09c973da0fdecc2c3
+  - NCCL-2.18.3-GCCcore-12.3.0-CUDA-12.1.1.eb 

--- a/easystacks/software.eessi.io/2023.06/grace/accel/nvidia/eessi-2023.06-eb-4.9.4-2023a-CUDA.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/accel/nvidia/eessi-2023.06-eb-4.9.4-2023a-CUDA.yml
@@ -1,0 +1,18 @@
+easyconfigs:
+  - CUDA-12.1.1.eb:
+      options:
+        accept-eula-for: CUDA
+        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3516
+        include-easyblocks-from-commit: 3469151ce7e4f85415c877dee555aeea7691c757
+  - CUDA-Samples-12.1-GCC-12.3.0-CUDA-12.1.1.eb
+  - OSU-Micro-Benchmarks-7.2-gompi-2023a-CUDA-12.1.1.eb
+  - LAMMPS-2Aug2023_update2-foss-2023a-kokkos-CUDA-12.1.1.eb
+  - ESPResSo-4.2.2-foss-2023a-CUDA-12.1.1.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21440
+        from-commit: 5525968921d7b5eae54f7d16391201e17ffae13c
+  - cuDNN-8.9.2.26-CUDA-12.1.1.eb
+  - LightGBM-4.5.0-foss-2023a-CUDA-12.1.1.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21699
+        from-commit: e3407bd127d248c08960f6b09c973da0fdecc2c3

--- a/easystacks/software.eessi.io/2023.06/grace/accel/nvidia/eessi-2023.06-eb-4.9.4-2023a-CUDA.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/accel/nvidia/eessi-2023.06-eb-4.9.4-2023a-CUDA.yml
@@ -8,7 +8,6 @@ easyconfigs:
   - UCX-CUDA-1.14.1-GCCcore-12.3.0-CUDA-12.1.1.eb
   - UCC-CUDA-1.2.0-GCCcore-12.3.0-CUDA-12.1.1.eb
   - OSU-Micro-Benchmarks-7.2-gompi-2023a-CUDA-12.1.1.eb
-  - LAMMPS-2Aug2023_update2-foss-2023a-kokkos-CUDA-12.1.1.eb
   - ESPResSo-4.2.2-foss-2023a-CUDA-12.1.1.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21440


### PR DESCRIPTION
LAMMPS-2Aug2023_update2-foss-2023a-kokkos-CUDA-12.1.1 fails to build, this PR could highlight the failure we see: https://github.com/kokkos/kokkos/pull/7158, skipping it for now 

Packages added:
```
CUDA/12.1.1
CUDA-Samples/12.1-GCC-12.3.0-CUDA-12.1.1
cuDNN/8.9.2.26-CUDA-12.1.1
ESPResSo/4.2.2-foss-2023a-CUDA-12.1.1
LightGBM/4.5.0-foss-2023a-CUDA-12.1.1
NCCL/2.18.3-GCCcore-12.3.0-CUDA-12.1.1
OSU-Micro-Benchmarks/7.2-gompi-2023a-CUDA-12.1.1
UCC-CUDA/1.2.0-GCCcore-12.3.0-CUDA-12.1.1
UCX-CUDA/1.14.1-GCCcore-12.3.0-CUDA-12.1.1
```