### PR TITLE
{2023.06}[2022b,grace] apps originally built with EB 4.9.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2022b.yml
@@ -37,3 +37,53 @@ easyconfigs:
 # easyconfigs (via EB 4.9.4) didn't work, and wasn't done for any of the other
 # supported CPU microarchitectures. Hence, we build QE with 4.8.2
 #  - QuantumESPRESSO-7.2-foss-2022b.eb
+#
+# from here on built originally with EB 4.9.0
+# includes dependencies Boost/1.81.0 and Boost.MPI/1.81.0 for which we have to
+# use updated easyconfigs (via from-commit) because the download URLs have
+# changed
+#
+# originally built with EB 4.9.0, PR 20298 was included since 4.9.2 and no more
+# updates to it since then
+#  - Highway-1.0.3-GCCcore-12.2.0.eb:
+#      options:
+#        from-pr: 20298
+  - Highway-1.0.3-GCCcore-12.2.0.eb
+  - SciPy-bundle-2023.02-gfbf-2022b.eb
+# Boost-1.81.0-GCC-12.2.0.eb is a dependency for GDAL and the sources URL for Boost
+# has recently changed by PR 22157
+# see https://github.com/easybuilders/easybuild-easyconfigs/pull/22157
+  - Boost-1.81.0-GCC-12.2.0.eb:
+      options:
+        from-commit: 5bebccf792ccf35a8ee3250bc8fed86dff5d5df9
+  - GDAL-3.6.2-foss-2022b.eb
+# originally built with EB 4.9.0, PR 19324 was included since 4.9.1; there were a
+# few additional changes to the easyconfig, hence we use the merge commit for 19324
+#  - waLBerla-6.1-foss-2022b.eb:
+#      options:
+#        from-pr: 19324
+# Boost.MPI-1.81.0-gompi-2022b.eb is a dependency for waLBerla and the sources URL for
+# Boost.MPI has recently changed by PR 22240
+# see https://github.com/easybuilders/easybuild-easyconfigs/pull/22240
+  - Boost.MPI-1.81.0-gompi-2022b.eb:
+      options:
+        from-commit: e610fe1ac5393d1de668a466fdaaea74c580ee03
+  - waLBerla-6.1-foss-2022b.eb:
+      options:
+        from-commit: 11daa230014b22387c28712d2ce93c45618058f6
+  - WRF-4.4.1-foss-2022b-dmpar.eb
+# originally built with EB 4.9.0, PR 20086 was included since 4.9.1; there were a
+# few additional changes to the easyconfig, hence we use the merge commit for 20086
+#  - ImageMagick-7.1.0-53-GCCcore-12.2.0.eb:
+#      options:
+#        from-pr: 20086
+  - ImageMagick-7.1.0-53-GCCcore-12.2.0.eb:
+      options:
+        from-commit: a0eff4515ecad4fe37d7c018c95526ad4a777de7
+# originally built with EB 4.9.0, PR 20238 was included since 4.9.1; there were
+# additional changes, particularly addressing CVE 2024-27322 that was included
+# since EB 4.9.2, hence we simply use the easyconfig available with EB 4.9.4
+#  - R-4.2.2-foss-2022b.eb:
+#      options:
+#        from-pr: 20238
+  - R-4.2.2-foss-2022b.eb


### PR DESCRIPTION
Several apps that were originally built with EB 4.9.0. We need to use `from-commit` for `Boost` and `Boost.MPI` because their sources URLs have changed and the corresponding changes were only merged after EB 4.9.4 was released. For `ImageMagick` we use `from-commit` to avoid using more recent changes. We don't do that for `R` because more recently a patch was added to fix a CVE.