### PR TITLE
{2023.06}[2023a,grace] add GDRCopy/2.3.1 in 2023a easystack

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -197,3 +197,4 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22235
         from-commit: 01dd97ea62fe4d7d0df040ede3af03eb2f1b8641
+  - GDRCopy-2.3.1-GCCcore-12.3.0.eb 


### PR DESCRIPTION
Packages added:
```
GDRCopy/2.3.1-GCCcore-12.3.0
```