### PR TITLE
{2023.06}[2023a,grace] add Siesta/5.2.2 in 2023a easystack

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-5.0.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-5.0.0-2023a.yml
@@ -1,0 +1,6 @@
+easyconfigs:
+  - Siesta-5.2.2-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22292
+        # and https://github.com/easybuilders/easybuild-easyconfigs/pull/22646
+        from-commit: b212c00fdc3983678037429719f1b210cb978b42


### PR DESCRIPTION
Packages added:
```
flook/0.8.4-GCC-12.3.0
json-fortran/9.0.2-GCC-12.3.0
libfdf/0.5.1-GCC-12.3.0
libGridXC/2.0.2-gompi-2023a
libPSML/2.1.0-GCC-12.3.0
mctc-lib/0.3.1-GCC-12.3.0
mstore/0.3.0-GCC-12.3.0
PnetCDF/1.12.3-gompi-2023a
ruamel.yaml/0.17.32-GCCcore-12.3.0
Siesta/5.2.2-foss-2023a
Simple-DFTD3/1.2.1-gfbf-2023a
test-drive/0.5.0-GCC-12.3.0
TOML-Fortran/0.4.2-GCC-12.3.0
xmlf90/1.6.3-GCC-12.3.0
```
