### PR TITLE
add Lmod hook that prints warning for SciPy-bundle on NVIDIA Grace

### DIFF
--- a/bot/test.sh
+++ b/bot/test.sh
@@ -192,6 +192,10 @@ COMMON_ARGS+=("--mode" "run")
 [[ ! -z ${HTTPS_PROXY} ]] && COMMON_ARGS+=("--https-proxy" "${HTTPS_PROXY}")
 [[ ! -z ${REPOSITORY} ]] && COMMON_ARGS+=("--repository" "${REPOSITORY}")
 
+# pass through '--contain' to avoid leaking in scripts into the container session
+# note, --pass-through can be used multiple times if needed
+COMMON_ARGS+=("--pass-through" "--contain")
+
 # make sure to use the same parent dir for storing tarballs of tmp
 PREVIOUS_TMP_DIR=${PWD}/previous_tmp
 

--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -209,13 +209,13 @@ local function eessi_scipy_2022b_test_failures_message(t)
     -- test failures and recommend using other versions available via EESSI.
     -- A message and not a warning as the exit code would break CI runs otherwise.
         local simpleName = string.match(t.modFullName, "(.-)/")
-        local advice = 'The module ' .. t.modFullName .. ' will be loaded. However, note that\n'
-        advice = advice .. 'during its building for the CPU microarchitecture ' .. graceArch .. ' from a\n'
-        advice = advice .. 'total of 52.730 unit tests a larger number (46) than usually (2-4) failed. If\n'
-        advice = advice .. 'you encounter issues while using ' .. t.modFullName .. ', please,\n'
-        advice = advice .. 'consider using one of the other versions of ' .. simpleName .. ' that are also provided\n'
-        advice = advice .. 'for the same CPU microarchitecture.\n'
-        LmodMessage("\n", advice)
+        local advice = 'The module ' .. t.modFullName .. ' will be loaded. However, note that\\n'
+        advice = advice .. 'during its building for the CPU microarchitecture ' .. graceArch .. ' from a\\n'
+        advice = advice .. 'total of 52.730 unit tests a larger number (46) than usually (2-4) failed. If\\n'
+        advice = advice .. 'you encounter issues while using ' .. t.modFullName .. ', please,\\n'
+        advice = advice .. 'consider using one of the other versions of ' .. simpleName .. ' that are also provided\\n'
+        advice = advice .. 'for the same CPU microarchitecture.\\n'
+        LmodMessage("\\n", advice)
     end
 end
 

--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -199,10 +199,31 @@ local function eessi_espresso_deprecated_message(t)
     end
 end
 
+local function eessi_scipy_2022b_test_failures_message(t)
+    local cpuArch = os.getenv("EESSI_SOFTWARE_SUBDIR")
+    local graceArch = 'aarch64/nvidia/grace'
+    local fullModuleName = 'SciPy-bundle/2023.02-gfbf-2022b'
+    local moduleVersionArchMatch = t.modFullName == fullModuleName and cpuArch == graceArch
+    if moduleVersionArchMatch and not os.getenv("EESSI_IGNORE_MODULE_WARNINGS") then
+    -- Print a message on loading SciPy-bundle version == 2023.02 informing about the higher number of
+    -- test failures and recommend using other versions available via EESSI.
+    -- A message and not a warning as the exit code would break CI runs otherwise.
+        local simpleName = string.match(t.modFullName, "(.-)/")
+        local advice = 'The module ' .. t.modFullName .. ' will be loaded. However, note that\n'
+        advice = advice .. 'during its building for the CPU microarchitecture ' .. graceArch .. ' from a\n'
+        advice = advice .. 'total of 52.730 unit tests a larger number (46) than usually (2-4) failed. If\n'
+        advice = advice .. 'you encounter issues while using ' .. t.modFullName .. ', please,\n'
+        advice = advice .. 'consider using one of the other versions of ' .. simpleName .. ' that are also provided\n'
+        advice = advice .. 'for the same CPU microarchitecture.\n'
+        LmodMessage("\n", advice)
+    end
+end
+
 -- Combine both functions into a single one, as we can only register one function as load hook in lmod
 -- Also: make it non-local, so it can be imported and extended by other lmodrc files if needed
 function eessi_load_hook(t)
     eessi_espresso_deprecated_message(t)
+    eessi_scipy_2022b_test_failures_message(t)
     -- Only apply CUDA and cu*-library hooks if the loaded module is in the EESSI prefix
     -- This avoids getting an Lmod Error when trying to load a CUDA or cu* module from a local software stack
     if from_eessi_prefix(t) then


### PR DESCRIPTION
During the building of `SciPy-bundle/2023.02-gfbf-2022b` for NVIDIA Grace more unit tests than usually failed (46 vs 2-4 of a total of ~ 52.700) (see PR #1013).

This PR updates the script `create_lmodsitepackage.py` which is run to create the `SitePackage.lua` file. That Lmod configuration file then includes a function `eessi_scipy_2022b_test_failures_message(t)` which is run when a module is loaded. It prints a message when the module being loaded is `SciPy-bundle/2023.02-gfbf-2022b` for the CPU architecture NVIDIA Grace

```
The module SciPy-bundle/2023.02-gfbf-2022b will be loaded. However, note that
during its building for the CPU microarchitecture aarch64/nvidia/grace from a
total of 52.730 unit tests a larger number (46) than usually (2-4) failed. If
you encounter issues while using SciPy-bundle/2023.02-gfbf-2022b, please,
consider using one of the other versions of SciPy-bundle that are also provided
for the same CPU microarchitecture.
```

The printing of the message can be suppressed by
```bash
export EESSI_IGNORE_MODULE_WARNINGS='yes'
```

We have to update the `SitePackage.lua` file for all existing architectures and for `aarch64/nvidia/grace`.

The PR also fixes the issue of the failing test step on NVIDIA Grace nodes by launching the container with `--contain`. It was verified that this additional option does not break the test step on all the other architectures.