### PR TITLE
{2023.06}[system,a64fx] circumvent fusemount issue, improve module use, and add some packages

### DIFF
--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -53,6 +53,23 @@ function copy_build_log() {
     fi
 }
 
+function safe_module_use {
+    # add a given non-empty directory to $MODULEPATH if and only if it is not yet in
+    directory=${1}
+
+    if [[ -z ${directory+x} ]]; then
+        echo "safe_module_use: given directory unset or empty; not adding it to \$MODULEPATH (${MODULEPATH})"
+        return
+    fi
+    if [[ ":${MODULEPATH}:" == *":${directory}:"* ]]; then
+        echo "safe_module_use: directory '${directory}' is already in \$MODULEPATH (${MODULEPATH}); not adding it again"
+        return
+    else
+        echo "safe_module_use: directory '${directory}' is not yet in \$MODULEPATH (${MODULEPATH}); adding it"
+        module use ${directory}
+    fi
+}
+
 POSITIONAL_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -308,7 +325,8 @@ if [[ "${EESSI_CVMFS_REPO}" == /cvmfs/dev.eessi.io ]]; then
 fi
 
 echo "DEBUG: adding path '$EASYBUILD_INSTALLPATH/modules/all' to MODULEPATH='${MODULEPATH}'"
-module use $EASYBUILD_INSTALLPATH/modules/all
+#module use $EASYBUILD_INSTALLPATH/modules/all
+safe_module_use $EASYBUILD_INSTALLPATH/modules/all
 echo "DEBUG: after adding module path // MODULEPATH='${MODULEPATH}'"
 
 if [[ -z ${MODULEPATH} ]]; then

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -251,7 +251,9 @@ export EESSI_CVMFS_INSTALL=1
 # NOTE 3, we have to set a default for EASYBUILD_INSTALLPATH here in cases the
 #   EESSI-extend module itself needs to be installed.
 export EASYBUILD_INSTALLPATH=${EESSI_PREFIX}/software/${EESSI_OS_TYPE}/${EESSI_SOFTWARE_SUBDIR_OVERRIDE}
+echo "DEBUG: before loading EESSI-extend // EASYBUILD_INSTALLPATH='${EASYBUILD_INSTALLPATH}'"
 source load_eessi_extend_module.sh ${EESSI_VERSION}
+echo "DEBUG: after loading EESSI-extend //  EASYBUILD_INSTALLPATH='${EASYBUILD_INSTALLPATH}'"
 
 # Install full CUDA SDK and cu* libraries in host_injections
 # Hardcode this for now, see if it works
@@ -305,7 +307,9 @@ if [[ "${EESSI_CVMFS_REPO}" == /cvmfs/dev.eessi.io ]]; then
     module use /cvmfs/software.eessi.io/versions/$EESSI_VERSION/software/${EESSI_OS_TYPE}/${EESSI_SOFTWARE_SUBDIR_OVERRIDE}/modules/all
 fi
 
+echo "DEBUG: adding path '$EASYBUILD_INSTALLPATH/modules/all' to MODULEPATH='${MODULEPATH}'"
 module use $EASYBUILD_INSTALLPATH/modules/all
+echo "DEBUG: after adding module path // MODULEPATH='${MODULEPATH}'"
 
 if [[ -z ${MODULEPATH} ]]; then
     fatal_error "Failed to set up \$MODULEPATH?!"
@@ -373,8 +377,10 @@ else
     done
 fi
 
+echo "DEBUG: before creating/updating lmod config files // EASYBUILD_INSTALLPATH='${EASYBUILD_INSTALLPATH}'"
 export LMOD_CONFIG_DIR="${EASYBUILD_INSTALLPATH}/.lmod"
 lmod_rc_file="$LMOD_CONFIG_DIR/lmodrc.lua"
+echo "DEBUG: lmod_rc_file='${lmod_rc_file}'"
 if [[ ! -z ${EESSI_ACCELERATOR_TARGET} ]]; then
     # EESSI_ACCELERATOR_TARGET is set, so let's remove the accelerator path from $lmod_rc_file
     lmod_rc_file=$(echo ${lmod_rc_file} | sed "s@/accel/${EESSI_ACCELERATOR_TARGET}@@")

--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-001-system.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-001-system.yml
@@ -1,0 +1,20 @@
+easyconfigs:
+  - EasyBuild-4.8.2.eb
+  - EasyBuild-4.9.0.eb
+  - EasyBuild-4.9.1.eb
+  - EasyBuild-4.9.2.eb
+  - EasyBuild-4.9.3.eb
+  - EasyBuild-4.9.4.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21465
+        from-commit: 39cdebd7bd2cb4a9c170ee22439401316b2e7a25
+  - Nextflow-23.10.0.eb
+  - ReFrame-4.3.3.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22183
+        from-commit: 2b2fe53c885799cbf13b77ddfa9532c48b296e9d  
+  - ReFrame-4.6.2.eb
+  - Pandoc-3.6.2.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22493
+        from-commit: da8ed20bad0dd1c6533c568f6c4fbb7c3d15342e

--- a/eessi_container.sh
+++ b/eessi_container.sh
@@ -735,8 +735,12 @@ fi
 
 declare -a EESSI_FUSE_MOUNTS=()
 
-# always mount cvmfs-config repo (to get access to EESSI repositories such as software.eessi.io)
-EESSI_FUSE_MOUNTS+=("--fusemount" "container:cvmfs2 cvmfs-config.cern.ch /cvmfs/cvmfs-config.cern.ch")
+# mount cvmfs-config repo (to get access to EESSI repositories such as software.eessi.io) unless env var
+# EESSI_DO_NOT_MOUNT_CVMFS_CONFIG_CERN_CH is defined
+if [ -z ${EESSI_DO_NOT_MOUNT_CVMFS_CONFIG_CERN_CH+x} ]; then
+    EESSI_FUSE_MOUNTS+=("--fusemount" "container:cvmfs2 cvmfs-config.cern.ch /cvmfs/cvmfs-config.cern.ch")
+fi
+
 
 # iterate over REPOSITORIES and either use repository-specific access mode or global setting (possibly a global default)
 for cvmfs_repo in "${REPOSITORIES[@]}"


### PR DESCRIPTION
This PR provides three things:
1. Solves the issue that the build container could not _fusemount_ software.eessi.io
2. Solves the issue that `$EASYBUILD_INSTALLPATH` got reset by some `module use ...` statement (just before creating/updating Lmod configuration files)
3. Adds a few basic packages installed with the toolchain `system`.

## Fusemount issue
Hit a strange issue on Deucalion. The CernVM-FS repository for software.eessi.io could not be mounted. It resulted in the error
```
CernVM-FS: loading Fuse module... Failed to initialize root file catalog (16 - file catalog failure)
```
When the mounting of `cvmfs-config.cern.ch` was disabled, it worked again. Also multiple `eessi.io` repositories could be mounted.

This PR opens the possibility to not mount `cvmfs-config.cern.ch` when the environment variable `$EESSI_DO_NOT_MOUNT_CVMFS_CONFIG_CERN_CH` is set. Setting this variable can be done in a site script (see `app.cfg` setting `site_config_script`).

## Empty `$EASYBUILD_INSTALLPATH` issue
For details see comments https://github.com/EESSI/software-layer/pull/1025#issuecomment-2799123582 and https://github.com/EESSI/software-layer/pull/1025#issuecomment-2799955283

## Adds the following packages
```
EasyBuild/4.8.2
EasyBuild/4.9.0
EasyBuild/4.9.1
EasyBuild/5.0.0
EESSI-extend/2023.06-easybuild
Nextflow/23.10.0
Pandoc/3.6.2
ReFrame/4.3.3
ReFrame/4.6.2
```