### PR TITLE
{2023.06}[2022b,grace] apps originally built with EB 4.9.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2022b.yml
@@ -87,3 +87,15 @@ easyconfigs:
 #      options:
 #        from-pr: 20238
   - R-4.2.2-foss-2022b.eb
+# from here on built originally with EB 4.9.0
+# originally built with EB 4.9.1, PR 20379 was included since 4.9.2; no more
+# updates to the easyconfig since then
+#  - R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb:
+#      options:
+#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20379
+#        from-pr: 20379
+  - R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb
+  - ParaView-5.11.1-foss-2022b.eb
+  - ASE-3.22.1-gfbf-2022b.eb
+  - SEPP-4.5.1-foss-2022b.eb
+  - Valgrind-3.21.0-gompi-2022b.eb


### PR DESCRIPTION
Adds a couple of apps (22) to the NVIDIA Grace stack

```
* ASE/3.22.1-gfbf-2022b (ASE-3.22.1-gfbf-2022b.eb)
* Arrow/11.0.0-gfbf-2022b (Arrow-11.0.0-gfbf-2022b.eb)
* DendroPy/4.5.2-GCCcore-12.2.0 (DendroPy-4.5.2-GCCcore-12.2.0.eb)
* FFmpeg/5.1.2-GCCcore-12.2.0 (FFmpeg-5.1.2-GCCcore-12.2.0.eb)
* Flask/2.2.3-GCCcore-12.2.0 (Flask-2.2.3-GCCcore-12.2.0.eb)
* ParaView/5.11.1-foss-2022b (ParaView-5.11.1-foss-2022b.eb)
* Pillow/9.4.0-GCCcore-12.2.0 (Pillow-9.4.0-GCCcore-12.2.0.eb)
* R-bundle-Bioconductor/3.16-foss-2022b-R-4.2.2 (R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb)
* RE2/2023-03-01-GCCcore-12.2.0 (RE2-2023-03-01-GCCcore-12.2.0.eb)
* RapidJSON/1.1.0-GCCcore-12.2.0 (RapidJSON-1.1.0-GCCcore-12.2.0.eb)
* SDL2/2.26.3-GCCcore-12.2.0 (SDL2-2.26.3-GCCcore-12.2.0.eb)
* SEPP/4.5.1-foss-2022b (SEPP-4.5.1-foss-2022b.eb)
* Tkinter/3.10.8-GCCcore-12.2.0 (Tkinter-3.10.8-GCCcore-12.2.0.eb)
* Valgrind/3.21.0-gompi-2022b (Valgrind-3.21.0-gompi-2022b.eb)
* arrow-R/11.0.0.3-foss-2022b-R-4.2.2 (arrow-R-11.0.0.3-foss-2022b-R-4.2.2.eb)
* cppy/1.2.1-GCCcore-12.2.0 (cppy-1.2.1-GCCcore-12.2.0.eb)
* ffnvcodec/11.1.5.2 (ffnvcodec-11.1.5.2.eb)
* matplotlib/3.7.0-gfbf-2022b (matplotlib-3.7.0-gfbf-2022b.eb)
* spglib-python/2.0.2-gfbf-2022b (spglib-python-2.0.2-gfbf-2022b.eb)
* utf8proc/2.8.0-GCCcore-12.2.0 (utf8proc-2.8.0-GCCcore-12.2.0.eb)
* x264/20230226-GCCcore-12.2.0 (x264-20230226-GCCcore-12.2.0.eb)
* x265/3.5-GCCcore-12.2.0 (x265-3.5-GCCcore-12.2.0.eb)
```