### PR TITLE
{2023.06}[2023a,a64fx] rebuild SciPy-bundle 2023.07

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20250414-eb-4.9.4-SciPy-bundle-2023.07-a64fx.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20250414-eb-4.9.4-SciPy-bundle-2023.07-a64fx.yml
@@ -1,0 +1,14 @@
+# 2025.04.14
+# While adding support for Intel Sapphire Rapids, additional patches applied to the
+# original easyconfig were required to successfully build SciPy-bundle 2023.07.
+# In order to keep the stack consistent across the different CPUs,
+# a rebuild was done for all CPU targets - except a64fx.
+# See:
+# - https://github.com/easybuilders/easybuild-easyconfigs/pull/19419
+# - https://github.com/easybuilders/easybuild-easyconfigs/pull/20817
+# - https://github.com/easybuilders/easybuild-easyconfigs/pull/21693
+easyconfigs:
+  - SciPy-bundle-2023.07-gfbf-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21693
+        from-commit: 7c5144d2c1a061cd9f08b5901970b7f6ec5eb5c0


### PR DESCRIPTION
Need to rebuild SciPy-bundle 2023.07 to keep stack for `aarch64/a64fx` consistent with the other CPU targets.

See #866