### PR TITLE
{2023.06}[2022b,grace] remaining apps originally built with EB 4.9.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2022b.yml
@@ -134,23 +134,23 @@ easyconfigs:
   - CGAL-5.5.2-GCCcore-12.2.0.eb
   - KaHIP-3.14-gompi-2022b.eb
   - MPC-1.3.1-GCCcore-12.2.0.eb
-#  - MUMPS-5.6.1-foss-2022b-metis.eb
-#  - GL2PS-1.4.2-GCCcore-12.2.0.eb
-#  - GST-plugins-base-1.22.1-GCC-12.2.0.eb
-#  - wxWidgets-3.2.2.1-GCC-12.2.0.eb
-#  - Archive-Zip-1.68-GCCcore-12.2.0.eb
-#  - jemalloc-5.3.0-GCCcore-12.2.0.eb
-#  - Judy-1.0.5-GCCcore-12.2.0.eb
-#  - libaio-0.3.113-GCCcore-12.2.0.eb
-#  - Z3-4.12.2-GCCcore-12.2.0.eb
-#  - tbb-2021.10.0-GCCcore-12.2.0.eb
-#  - dask-2023.7.1-foss-2022b.eb
-#  - netcdf4-python-1.6.3-foss-2022b.eb
-#  - Ruby-3.2.2-GCCcore-12.2.0.eb
-## originally built with EB 4.9.2; PR 21526 and PR 3467 included since EB 5.0.0, thus need to use *from-commit
-#  - ROOT-6.26.10-foss-2022b.eb:
-#      options:
-#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21526
-#        from-commit: 6cbfbd7d7a55dc7243f46d0beea510278f4718df
-#        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3467
-#        include-easyblocks-from-commit: c3aebe1f133d064a228c5d6c282e898b83d74601
+  - MUMPS-5.6.1-foss-2022b-metis.eb
+  - GL2PS-1.4.2-GCCcore-12.2.0.eb
+  - GST-plugins-base-1.22.1-GCC-12.2.0.eb
+  - wxWidgets-3.2.2.1-GCC-12.2.0.eb
+  - Archive-Zip-1.68-GCCcore-12.2.0.eb
+  - jemalloc-5.3.0-GCCcore-12.2.0.eb
+  - Judy-1.0.5-GCCcore-12.2.0.eb
+  - libaio-0.3.113-GCCcore-12.2.0.eb
+  - Z3-4.12.2-GCCcore-12.2.0.eb
+  - tbb-2021.10.0-GCCcore-12.2.0.eb
+  - dask-2023.7.1-foss-2022b.eb
+  - netcdf4-python-1.6.3-foss-2022b.eb
+  - Ruby-3.2.2-GCCcore-12.2.0.eb
+# originally built with EB 4.9.2; PR 21526 and PR 3467 included since EB 5.0.0, thus need to use *from-commit
+  - ROOT-6.26.10-foss-2022b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21526
+        from-commit: 6cbfbd7d7a55dc7243f46d0beea510278f4718df
+        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3467
+        include-easyblocks-from-commit: c3aebe1f133d064a228c5d6c282e898b83d74601


### PR DESCRIPTION
<details><summary>Adds ~ 23 remaining apps out of 70 apps originally planned in #1029</summary>

```
* Archive-Zip/1.68-GCCcore-12.2.0 (Archive-Zip-1.68-GCCcore-12.2.0.eb)
* BCFtools/1.17-GCC-12.2.0 (BCFtools-1.17-GCC-12.2.0.eb)
* BLAST+/2.14.0-gompi-2022b (BLAST+-2.14.0-gompi-2022b.eb)
* BamTools/2.5.2-GCC-12.2.0 (BamTools-2.5.2-GCC-12.2.0.eb)
* Bio-DB-HTS/3.01-GCC-12.2.0 (Bio-DB-HTS-3.01-GCC-12.2.0.eb)
* Bio-SearchIO-hmmer/1.7.3-GCC-12.2.0 (Bio-SearchIO-hmmer-1.7.3-GCC-12.2.0.eb)
* BioPerl/1.7.8-GCCcore-12.2.0 (BioPerl-1.7.8-GCCcore-12.2.0.eb)
* Biopython/1.81-foss-2022b (Biopython-1.81-foss-2022b.eb)
* Bowtie2/2.5.1-GCC-12.2.0 (Bowtie2-2.5.1-GCC-12.2.0.eb)
* CD-HIT/4.8.1-GCC-12.2.0 (CD-HIT-4.8.1-GCC-12.2.0.eb)
* CGAL/5.5.2-GCCcore-12.2.0 (CGAL-5.5.2-GCCcore-12.2.0.eb)
* CapnProto/0.10.3-GCCcore-12.2.0 (CapnProto-0.10.3-GCCcore-12.2.0.eb)
* GL2PS/1.4.2-GCCcore-12.2.0 (GL2PS-1.4.2-GCCcore-12.2.0.eb)
* GST-plugins-base/1.22.1-GCC-12.2.0 (GST-plugins-base-1.22.1-GCC-12.2.0.eb)
* GStreamer/1.22.1-GCC-12.2.0 (GStreamer-1.22.1-GCC-12.2.0.eb)
* GenomeTools/1.6.2-GCC-12.2.0 (GenomeTools-1.6.2-GCC-12.2.0.eb)
* Graphene/1.10.8-GCCcore-12.2.0 (Graphene-1.10.8-GCCcore-12.2.0.eb)
* HTSlib/1.17-GCC-12.2.0 (HTSlib-1.17-GCC-12.2.0.eb)
* ISA-L/2.30.0-GCCcore-12.2.0 (ISA-L-2.30.0-GCCcore-12.2.0.eb)
* Judy/1.0.5-GCCcore-12.2.0 (Judy-1.0.5-GCCcore-12.2.0.eb)
* KaHIP/3.14-gompi-2022b (KaHIP-3.14-gompi-2022b.eb)
* KronaTools/2.8.1-GCCcore-12.2.0 (KronaTools-2.8.1-GCCcore-12.2.0.eb)
* LMDB/0.9.29-GCCcore-12.2.0 (LMDB-0.9.29-GCCcore-12.2.0.eb)
* Lua/5.4.4-GCCcore-12.2.0 (Lua-5.4.4-GCCcore-12.2.0.eb)
* MAFFT/7.505-GCC-12.2.0-with-extensions (MAFFT-7.505-GCC-12.2.0-with-extensions.eb)
* MDAnalysis/2.4.2-foss-2022b (MDAnalysis-2.4.2-foss-2022b.eb)
* METIS/5.1.0-GCCcore-12.2.0 (METIS-5.1.0-GCCcore-12.2.0.eb)
* MPC/1.3.1-GCCcore-12.2.0 (MPC-1.3.1-GCCcore-12.2.0.eb)
* MUMPS/5.6.1-foss-2022b-metis (MUMPS-5.6.1-foss-2022b-metis.eb)
* Mash/2.3-GCC-12.2.0 (Mash-2.3-GCC-12.2.0.eb)
* MetaEuk/6-GCC-12.2.0 (MetaEuk-6-GCC-12.2.0.eb)
* MultiQC/1.14-foss-2022b (MultiQC-1.14-foss-2022b.eb)
* Perl/5.36.0-GCCcore-12.2.0-minimal (Perl-5.36.0-GCCcore-12.2.0-minimal.eb)
* PyYAML/6.0-GCCcore-12.2.0 (PyYAML-6.0-GCCcore-12.2.0.eb)
* Pysam/0.21.0-GCC-12.2.0 (Pysam-0.21.0-GCC-12.2.0.eb)
* ROOT/6.26.10-foss-2022b (ROOT-6.26.10-foss-2022b.eb)
* Ruby/3.2.2-GCCcore-12.2.0 (Ruby-3.2.2-GCCcore-12.2.0.eb)
* SAMtools/1.17-GCC-12.2.0 (SAMtools-1.17-GCC-12.2.0.eb)
* SCOTCH/7.0.3-gompi-2022b (SCOTCH-7.0.3-gompi-2022b.eb)
* VCFtools/0.1.16-GCC-12.2.0 (VCFtools-0.1.16-GCC-12.2.0.eb)
* WhatsHap/2.1-foss-2022b (WhatsHap-2.1-foss-2022b.eb)
* XML-LibXML/2.0208-GCCcore-12.2.0 (XML-LibXML-2.0208-GCCcore-12.2.0.eb)
* Z3/4.12.2-GCCcore-12.2.0 (Z3-4.12.2-GCCcore-12.2.0.eb)
* Zip/3.0-GCCcore-12.2.0 (Zip-3.0-GCCcore-12.2.0.eb)
* bokeh/3.2.1-foss-2022b (bokeh-3.2.1-foss-2022b.eb)
* cpio/2.15-GCCcore-12.2.0 (cpio-2.15-GCCcore-12.2.0.eb)
* dask/2023.7.1-foss-2022b (dask-2023.7.1-foss-2022b.eb)
* elfutils/0.189-GCCcore-12.2.0 (elfutils-0.189-GCCcore-12.2.0.eb)
* fastp/0.23.4-GCC-12.2.0 (fastp-0.23.4-GCC-12.2.0.eb)
* freeglut/3.4.0-GCCcore-12.2.0 (freeglut-3.4.0-GCCcore-12.2.0.eb)
* gnuplot/5.4.6-GCCcore-12.2.0 (gnuplot-5.4.6-GCCcore-12.2.0.eb)
* h5py/3.8.0-foss-2022b (h5py-3.8.0-foss-2022b.eb)
* jemalloc/5.3.0-GCCcore-12.2.0 (jemalloc-5.3.0-GCCcore-12.2.0.eb)
* libaio/0.3.113-GCCcore-12.2.0 (libaio-0.3.113-GCCcore-12.2.0.eb)
* libcerf/2.3-GCCcore-12.2.0 (libcerf-2.3-GCCcore-12.2.0.eb)
* libgd/2.3.3-GCCcore-12.2.0 (libgd-2.3.3-GCCcore-12.2.0.eb)
* libyaml/0.2.5-GCCcore-12.2.0 (libyaml-0.2.5-GCCcore-12.2.0.eb)
* lpsolve/5.5.2.11-GCC-12.2.0 (lpsolve-5.5.2.11-GCC-12.2.0.eb)
* meson-python/0.11.0-GCCcore-12.2.0 (meson-python-0.11.0-GCCcore-12.2.0.eb)
* mpi4py/3.1.4-gompi-2022b (mpi4py-3.1.4-gompi-2022b.eb)
* ncbi-vdb/3.0.5-gompi-2022b (ncbi-vdb-3.0.5-gompi-2022b.eb)
* netcdf4-python/1.6.3-foss-2022b (netcdf4-python-1.6.3-foss-2022b.eb)
* networkx/3.0-gfbf-2022b (networkx-3.0-gfbf-2022b.eb)
* parallel/20230722-GCCcore-12.2.0 (parallel-20230722-GCCcore-12.2.0.eb)
* pkgconfig/1.5.5-GCCcore-12.2.0-python (pkgconfig-1.5.5-GCCcore-12.2.0-python.eb)
* pyfaidx/0.7.2.1-GCCcore-12.2.0 (pyfaidx-0.7.2.1-GCCcore-12.2.0.eb)
* python-isal/1.1.0-GCCcore-12.2.0 (python-isal-1.1.0-GCCcore-12.2.0.eb)
* setuptools/64.0.3-GCCcore-12.2.0 (setuptools-64.0.3-GCCcore-12.2.0.eb)
* tbb/2021.10.0-GCCcore-12.2.0 (tbb-2021.10.0-GCCcore-12.2.0.eb)
* tqdm/4.64.1-GCCcore-12.2.0 (tqdm-4.64.1-GCCcore-12.2.0.eb)
* wxWidgets/3.2.2.1-GCC-12.2.0 (wxWidgets-3.2.2.1-GCC-12.2.0.eb)
```
</details>