### PR TITLE
{2023.06}[2023a] bcgTree 1.2.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.0.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.0.0-2023a.yml
@@ -12,4 +12,5 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22707
         # and https://github.com/easybuilders/easybuild-easyconfigs/pull/22540
+        # and https://github.com/easybuilders/easybuild-easyconfigs/pull/22781
         from-commit: 720c5b5b8280bf342d827617ee14738f3d231097

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.0.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.0.0-2023a.yml
@@ -7,9 +7,9 @@ easyconfigs:
   - MUSCLE-5.1.0-GCCcore-12.3.0.eb:
       options:
         # See https://github.com/easybuilders/easybuild-easyconfigs/pull/22780
-        from-commit: b3ebae089935d4e71fa96f449d150f91402d1faf
+        from-commit: c18be9031082633f22e1e0eed86f5eb110565e61
   - bcgTree-1.2.1-foss-2023a.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22707
         # and https://github.com/easybuilders/easybuild-easyconfigs/pull/22540
-        from-commit: 608956e04994b97114af69ff370532a4386ae3d6
+        from-commit: 99e573396fb566985f67315e66db5bb45e59979c

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.0.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.0.0-2023a.yml
@@ -4,3 +4,8 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22292
         # and https://github.com/easybuilders/easybuild-easyconfigs/pull/22646
         from-commit: b212c00fdc3983678037429719f1b210cb978b42
+  - bcgTree-1.2.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22707
+        # and https://github.com/easybuilders/easybuild-easyconfigs/pull/22540
+        from-commit: 608956e04994b97114af69ff370532a4386ae3d6

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.0.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.0.0-2023a.yml
@@ -4,6 +4,10 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22292
         # and https://github.com/easybuilders/easybuild-easyconfigs/pull/22646
         from-commit: b212c00fdc3983678037429719f1b210cb978b42
+  - MUSCLE-5.1.0-GCCcore-12.3.0.eb:
+      options:
+        # See https://github.com/easybuilders/easybuild-easyconfigs/pull/22780
+        from-commit: b3ebae089935d4e71fa96f449d150f91402d1faf
   - bcgTree-1.2.1-foss-2023a.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22707

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.0.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.0.0-2023a.yml
@@ -7,9 +7,9 @@ easyconfigs:
   - MUSCLE-5.1.0-GCCcore-12.3.0.eb:
       options:
         # See https://github.com/easybuilders/easybuild-easyconfigs/pull/22780
-        from-commit: c18be9031082633f22e1e0eed86f5eb110565e61
+        from-commit: ff159780fbaa881fb442b0ee1b37cd9e3d981ca9
   - bcgTree-1.2.1-foss-2023a.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22707
         # and https://github.com/easybuilders/easybuild-easyconfigs/pull/22540
-        from-commit: 99e573396fb566985f67315e66db5bb45e59979c
+        from-commit: 720c5b5b8280bf342d827617ee14738f3d231097


### PR DESCRIPTION
4 out of 39 required modules missing:

* MUSCLE/5.1.0-GCCcore-12.3.0 (MUSCLE-5.1.0-GCCcore-12.3.0.eb)
* Gblocks/0.91b (Gblocks-0.91b.eb)
* RAxML/8.2.13-gompi-2023a-avx2 (RAxML-8.2.13-gompi-2023a-avx2.eb)
* bcgTree/1.2.1-foss-2023a (bcgTree-1.2.1-foss-2023a.eb)