### PR TITLE
{2023.06}[2023a,a64fx] add TensorFlow 2.13

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -45,13 +45,13 @@ easyconfigs:
   - nsync-1.26.0-GCCcore-12.3.0.eb
   - RE2-2023-08-01-GCCcore-12.3.0.eb
   - protobuf-python-4.24.0-GCCcore-12.3.0.eb
-## originally built with EB 4.8.2; PR 19268 included since EB 4.9.0
-##  - TensorFlow-2.13.0-foss-2023a.eb:
-##      # patch setup.py for grpcio extension in TensorFlow 2.13.0 easyconfigs to take into account alternate sysroot;
-##      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19268
-##      options:
-##        from-pr: 19268
-#  - TensorFlow-2.13.0-foss-2023a.eb
+# originally built with EB 4.8.2; PR 19268 included since EB 4.9.0
+#  - TensorFlow-2.13.0-foss-2023a.eb:
+#      # patch setup.py for grpcio extension in TensorFlow 2.13.0 easyconfigs to take into account alternate sysroot;
+#      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19268
+#      options:
+#        from-pr: 19268
+  - TensorFlow-2.13.0-foss-2023a.eb
 #  - X11-20230603-GCCcore-12.3.0.eb
 ## originally built with EB 4.8.2; PR 19339 included since EB 4.9.0
 ## - HarfBuzz-5.3.1-GCCcore-12.3.0.eb:

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -132,7 +132,12 @@ def post_ready_hook(self, *args, **kwargs):
     memory_hungry_build_a64fx = cpu_target == CPU_TARGET_A64FX and self.name in ['Qt5', 'ROOT']
     if memory_hungry_build or memory_hungry_build_a64fx:
         parallel = self.cfg['parallel']
-        if parallel > 1:
+        if cpu_target == CPU_TARGET_A64FX and self.name in ['TensorFlow']:
+            if parallel > 1:
+                self.cfg['parallel'] = 2
+                msg = "limiting parallelism to %s (was %s) for %s on %s to avoid out-of-memory failures during building/testing"
+                print_msg(msg % (self.cfg['parallel'], parallel, self.name, cpu_target), log=self.log)
+        elif parallel > 1:
             self.cfg['parallel'] = parallel // 2
             msg = "limiting parallelism to %s (was %s) for %s to avoid out-of-memory failures during building/testing"
             print_msg(msg % (self.cfg['parallel'], parallel, self.name), log=self.log)

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -134,7 +134,7 @@ def post_ready_hook(self, *args, **kwargs):
         parallel = self.cfg['parallel']
         if cpu_target == CPU_TARGET_A64FX and self.name in ['TensorFlow']:
             if parallel > 1:
-                self.cfg['parallel'] = 8
+                self.cfg['parallel'] = 12
                 msg = "limiting parallelism to %s (was %s) for %s on %s to avoid out-of-memory failures during building/testing"
                 print_msg(msg % (self.cfg['parallel'], parallel, self.name, cpu_target), log=self.log)
         elif parallel > 1:

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -134,7 +134,7 @@ def post_ready_hook(self, *args, **kwargs):
         parallel = self.cfg['parallel']
         if cpu_target == CPU_TARGET_A64FX and self.name in ['TensorFlow']:
             if parallel > 1:
-                self.cfg['parallel'] = 12
+                self.cfg['parallel'] = 16
                 msg = "limiting parallelism to %s (was %s) for %s on %s to avoid out-of-memory failures during building/testing"
                 print_msg(msg % (self.cfg['parallel'], parallel, self.name, cpu_target), log=self.log)
         elif parallel > 1:

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -134,7 +134,7 @@ def post_ready_hook(self, *args, **kwargs):
         parallel = self.cfg['parallel']
         if cpu_target == CPU_TARGET_A64FX and self.name in ['TensorFlow']:
             if parallel > 1:
-                self.cfg['parallel'] = 2
+                self.cfg['parallel'] = 8
                 msg = "limiting parallelism to %s (was %s) for %s on %s to avoid out-of-memory failures during building/testing"
                 print_msg(msg % (self.cfg['parallel'], parallel, self.name, cpu_target), log=self.log)
         elif parallel > 1:

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -133,8 +133,9 @@ def post_ready_hook(self, *args, **kwargs):
     if memory_hungry_build or memory_hungry_build_a64fx:
         parallel = self.cfg['parallel']
         if cpu_target == CPU_TARGET_A64FX and self.name in ['TensorFlow']:
-            if parallel > 1:
-                self.cfg['parallel'] = 16
+            # limit parallelism to 8, builds with 12 and 16 failed on Deucalion
+            if parallel > 8:
+                self.cfg['parallel'] = 8
                 msg = "limiting parallelism to %s (was %s) for %s on %s to avoid out-of-memory failures during building/testing"
                 print_msg(msg % (self.cfg['parallel'], parallel, self.name, cpu_target), log=self.log)
         elif parallel > 1:


### PR DESCRIPTION
Adds TensorFlow 2.13. Limits parallelism to 8 (via `eb_hooks.py`) in order to work around out-of-memory issue.