### PR TITLE
Create first builds for icelake and cascadelake (EasyBuild 4.8.2 + EESSI-extend)

### DIFF
--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -354,7 +354,7 @@ else
         echo -e "Processing easystack file ${easystack_file}...\n\n"
 
         # determine version of EasyBuild module to load based on EasyBuild version included in name of easystack file
-        eb_version=$(echo ${easystack_file} | sed 's/.*eb-\([0-9.]*\).*/\1/g')
+        eb_version=$(echo ${easystack_file} | sed 's/.*eb-\([0-9.]*\).*.yml/\1/g')
 
         # load EasyBuild module (will be installed if it's not available yet)
         source ${TOPDIR}/load_easybuild_module.sh ${eb_version}

--- a/EESSI-remove-software.sh
+++ b/EESSI-remove-software.sh
@@ -108,7 +108,7 @@ if [ $EUID -eq 0 ]; then
     else
         for easystack_file in ${changed_easystacks_rebuilds}; do
             # determine version of EasyBuild module to load based on EasyBuild version included in name of easystack file
-            eb_version=$(echo ${easystack_file} | sed 's/.*eb-\([0-9.]*\).*/\1/g')
+            eb_version=$(echo ${easystack_file} | sed 's/.*eb-\([0-9.]*\).*.yml/\1/g')
 
             # load EasyBuild module (will be installed if it's not available yet)
             source ${TOPDIR}/load_easybuild_module.sh ${eb_version}

--- a/easystacks/software.eessi.io/2023.06/icelake_cclake/000-eb-4.8.2.yml
+++ b/easystacks/software.eessi.io/2023.06/icelake_cclake/000-eb-4.8.2.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/EasyBuild/4.8.2/easybuild/reprod/EasyBuild-4.8.2.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/EasyBuild/4.8.2/easybuild/reprod/easyblocks/*.py

--- a/load_easybuild_module.sh
+++ b/load_easybuild_module.sh
@@ -67,8 +67,11 @@ else
     eb_install_out=${TMPDIR}/eb_install.out
     ok_msg="Latest EasyBuild release installed, let's go!"
     fail_msg="Installing latest EasyBuild release failed, that's not good... (output: ${eb_install_out})"
-    ${EB} --install-latest-eb-release 2>&1 | tee ${eb_install_out}
+    # Install in a temporary prefix, and disable read-only-installdir, so that we don't get errors when TMPDIR is cleaned up
+    ${EB} --install-latest-eb-release --installpath ${TMPDIR}/eb_tmp_installpath --disable-read-only-installdir 2>&1 | tee ${eb_install_out}
     check_exit_code $? "${ok_msg}" "${fail_msg}"
+    # Make sure the temporary module prefix is on the MODULEPATH
+    module use ${TMPDIR}/eb_tmp_installpath/modules/all
 
     # maybe the module obtained with --install-latest-eb-release is exactly the EasyBuild version we wanted?
     IGNORE_CACHE=''
@@ -93,6 +96,8 @@ else
             else
                 fatal_error "No easyconfig found for EasyBuild v${EB_VERSION}"
             fi
+            # Since we now reinstalled the EasyBuild we REALLY needed, we can unuse the tempdir from the MODULEPATH
+            module unuse ${TMPDIR}/eb_tmp_installpath/modules/all
         fi
     fi
 

--- a/load_eessi_extend_module.sh
+++ b/load_eessi_extend_module.sh
@@ -88,12 +88,21 @@ else
         echo ">> Final installation in ${EASYBUILD_INSTALLPATH}..."
         export PATH=${EB_TMPDIR}/bin:${PATH}
         export PYTHONPATH=$(ls -d ${EB_TMPDIR}/lib/python*/site-packages):${PYTHONPATH}
+        # EESSI-extend DOES need some EasyBuild module to be available. However, we don't install that here
+        # anymore. It is up to the person deploying a stack in a new prefix to make sure that at least a single
+        # EasyBuild version is available - but that is normally the first thing you deploy anyway, since we need
+        # it to deploy anything else anyway
+        # By NOT installing it here, the person installing the new stack has control over WHICH EasyBuild version is
+        # Installed first
+        # Note that in the build pipeline, load_easybuild_module.sh will simply install an EasyBuild version in a
+        # temporary prefix in order to be used by EESSI-extend to install the FIRST EasyBuild version in a new prefix
+        # That is, thus, the bootstrap procedure.
         # EESSI-extend also needs EasyBuild to be installed as a module, so install the latest release
-        eb_install_out=${TMPDIR}/eb_install.out
-        ok_msg="Latest EasyBuild installed, let's go!"
-        fail_msg="Installing latest EasyBuild failed, that's not good... (output: ${eb_install_out})"
-        ${EB} --install-latest-eb-release 2>&1 | tee ${eb_install_out}
-        check_exit_code $? "${ok_msg}" "${fail_msg}"
+        # eb_install_out=${TMPDIR}/eb_install.out
+        # ok_msg="Latest EasyBuild installed, let's go!"
+        # fail_msg="Installing latest EasyBuild failed, that's not good... (output: ${eb_install_out})"
+        # ${EB} --install-latest-eb-release 2>&1 | tee ${eb_install_out}
+        # check_exit_code $? "${ok_msg}" "${fail_msg}"
         # Now install EESSI-extend
         eessi_install_out=${TMPDIR}/eessi_install.out
         ok_msg="EESSI-extend/${EESSI_EXTEND_VERSION} installed, let's go!"

--- a/load_eessi_extend_module.sh
+++ b/load_eessi_extend_module.sh
@@ -106,7 +106,7 @@ else
         # Add this temp installpath to the modulepath. This is needed for the EESSI-extend sanity check step to succeed
         # As loading the EESSI-extend module requires loading the 'latest' EasyBuild module - which means there should
         # be at least one on the MODULEPATH
-        module use ${TMPDIR}/eb_tmp_installpath
+        module use ${TMPDIR}/eb_tmp_installpath/modules/all
         # Now install EESSI-extend
         eessi_install_out=${TMPDIR}/eessi_install.out
         ok_msg="EESSI-extend/${EESSI_EXTEND_VERSION} installed, let's go!"
@@ -115,7 +115,7 @@ else
         # an attempt to figure out if it is needed, e.g., when we are rebuilding
         ${EB} "EESSI-extend-easybuild.eb" --try-amend=keeppreviousinstall=True 2>&1 | tee ${eessi_install_out}
         check_exit_code $? "${ok_msg}" "${fail_msg}"
-        module unuse ${TMPDIR}/eb_tmp_installpath
+        module unuse ${TMPDIR}/eb_tmp_installpath/modules/all
     )
 
     # restore origin $PATH and $PYTHONPATH values, and clean up environment variables that are no longer needed

--- a/load_eessi_extend_module.sh
+++ b/load_eessi_extend_module.sh
@@ -101,7 +101,8 @@ else
         eb_install_out=${TMPDIR}/eb_install.out
         ok_msg="Latest EasyBuild installed, let's go!"
         fail_msg="Installing latest EasyBuild failed, that's not good... (output: ${eb_install_out})"
-        ${EB} --install-latest-eb-release --installpath ${TMPDIR}/eb_tmp_installpath 2>&1 | tee ${eb_install_out}
+        # Install in a temporary prefix, and disable read-only-installdir, so that we don't get errors when TMPDIR is cleaned up
+        ${EB} --install-latest-eb-release --installpath ${TMPDIR}/eb_tmp_installpath --disable-read-only-installdir 2>&1 | tee ${eb_install_out}
         check_exit_code $? "${ok_msg}" "${fail_msg}"
         # Add this temp installpath to the modulepath. This is needed for the EESSI-extend sanity check step to succeed
         # As loading the EESSI-extend module requires loading the 'latest' EasyBuild module - which means there should

--- a/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
+++ b/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
@@ -96,7 +96,7 @@ for EASYSTACK_FILE in ${TOPDIR}/easystacks/eessi-*CUDA*.yml; do
     echo -e "Processing easystack file ${easystack_file}...\n\n"
 
     # determine version of EasyBuild module to load based on EasyBuild version included in name of easystack file
-    eb_version=$(echo ${EASYSTACK_FILE} | sed 's/.*eb-\([0-9.]*\).*/\1/g')
+    eb_version=$(echo ${EASYSTACK_FILE} | sed 's/.*eb-\([0-9.]*\).*.yml/\1/g')
 
     # Load EasyBuild version for this easystack file _before_ loading EESSI-extend
     module_avail_out=${tmpdir}/ml.out


### PR DESCRIPTION
Installing the stack for icelake & cascadelake, based on the approach outlined in https://gitlab.com/eessi/support/-/issues/145

I've used the scripts from https://github.com/EESSI/software-layer/pull/1035/commits/84817f0b10e7722f30958910f03c1fdab471e14d to create the EasyStack files, then split of the very first EasyBuild install into it's own EasyStack file, so that we can first (separately) try to install an initial EESSI-extend and EasyBuild version. If that works, we take things from there.