### PR TITLE
Remove eessi startup hook that errors on CUDA being moved from CPU prefixes

### DIFF
--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -231,23 +231,6 @@ function eessi_load_hook(t)
     end
 end
 
-local function using_eessi_accel_stack ()
-    local modulepath = os.getenv("MODULEPATH") or ""
-    local accel_stack_in_modulepath = false
-
-    -- Check if we are using an EESSI version 2023 accelerator stack by checking if the $MODULEPATH contains
-    -- a path that starts with /cvmfs/software.eessi.io and contains accel/nvidia/ccNN
-    for path in string.gmatch(modulepath, '(.-):') do
-        if string.sub(path, 1, 41) == "/cvmfs/software.eessi.io/versions/2023.06" then
-            if string.find(path, "accel/nvidia/cc%d%d") then
-                accel_stack_in_modulepath = true
-                break
-            end
-        end
-    end
-    return accel_stack_in_modulepath
-end
-
 hook.register("load", eessi_load_hook)
 
 """

--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -248,56 +248,6 @@ local function using_eessi_accel_stack ()
     return accel_stack_in_modulepath
 end
 
-local function eessi_removed_module_warning_startup_hook(usrCmd)
-    if usrCmd == 'load' and not os.getenv("EESSI_SKIP_REMOVED_MODULES_CHECK") then
-        local CUDA_RELOCATION_MSG = [[All CUDA installations and modules depending on CUDA have been relocated to GPU-specific stacks.
-        Please see https://www.eessi.io/docs/site_specific_config/gpu/ for more information.]]
-
-        local RELOCATED_CUDA_MODULES = {
-            ['NCCL'] = CUDA_RELOCATION_MSG,
-            ['NCCL/2.18.3-GCCcore-12.3.0-CUDA-12.1.1'] = CUDA_RELOCATION_MSG,
-            ['UCX-CUDA'] = CUDA_RELOCATION_MSG,
-            ['UCX-CUDA/1.14.1-GCCcore-12.3.0-CUDA-12.1.1'] = CUDA_RELOCATION_MSG,
-            -- we also have non-CUDA versions of OSU Micro Benchmarks, so only match the CUDA version
-            ['OSU-Micro-Benchmarks/7.2-gompi-2023a-CUDA-12.1.1'] = CUDA_RELOCATION_MSG,
-            ['UCC-CUDA'] = CUDA_RELOCATION_MSG,
-            ['UCC-CUDA/1.2.0-GCCcore-12.3.0-CUDA-12.1.1'] = CUDA_RELOCATION_MSG,
-            ['CUDA'] = CUDA_RELOCATION_MSG,
-            ['CUDA/12.1.1'] = CUDA_RELOCATION_MSG,
-            ['CUDA-Samples'] = CUDA_RELOCATION_MSG,
-            ['CUDA-Samples/12.1-GCC-12.3.0-CUDA-12.1.1'] = CUDA_RELOCATION_MSG,
-        }
-
-        local REMOVED_MODULES = {
-            ['ipympl/0.9.3-foss-2023a'] = 'This module has been replaced by ipympl/0.9.3-gfbf-2023a',
-        }
-
-        local masterTbl = masterTbl()
-        local error_msg = ""
-        -- The CUDA messages should only be shown if the accelerator stack is NOT being used
-        if not using_eessi_accel_stack() then
-            for _, module in pairs(masterTbl.pargs) do
-                if RELOCATED_CUDA_MODULES[module] ~= nil then
-                    error_msg = error_msg .. module .. ': ' .. RELOCATED_CUDA_MODULES[module] .. '\\n\\n'
-                end
-            end
-        end
-        for _, module in pairs(masterTbl.pargs) do
-            if REMOVED_MODULES[module] ~= nil then
-                error_msg = error_msg .. module .. ': ' .. REMOVED_MODULES[module] .. '\\n\\n'
-            end
-        end
-        if error_msg ~= "" then
-            LmodError('\\n' .. error_msg .. 'If you know what you are doing and you want to ignore this check for removed/relocated modules, set $EESSI_SKIP_REMOVED_MODULES_CHECK to any value.')
-        end
-    end
-end
-
-function eessi_startup_hook(usrCmd)
-    eessi_removed_module_warning_startup_hook(usrCmd)
-end
-
-hook.register("startup", eessi_startup_hook)
 hook.register("load", eessi_load_hook)
 
 """
@@ -320,7 +270,7 @@ local function hide_2022b_modules(modT)
                   modT.fullName:match("GCC%-([0-9]*.[0-9]*.[0-9]*)") or
                   modT.fullName:match("GCCcore%-([0-9]*.[0-9]*.[0-9]*)")
 
-    -- if nothing matches, return              
+    -- if nothing matches, return
     if tcver == nil then return end
 
     -- if we have matches, check if the toolchain version is either 2022b or 12.2.0

--- a/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
+++ b/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
@@ -92,10 +92,6 @@ echo "Created temporary directory '${tmpdir}'"
 # Store MODULEPATH so it can be restored at the end of each loop iteration
 SAVE_MODULEPATH=${MODULEPATH}
 
-# THIS EXPORT SHOULD NEVER MAKE IT INTO THE REPO, it's just used temporarily to make host-injections
-# install for icelake in https://github.com/EESSI/software-layer/pull/1044
-export EESSI_SKIP_REMOVED_MODULES_CHECK=1
-
 for EASYSTACK_FILE in ${TOPDIR}/easystacks/eessi-*CUDA*.yml; do
     echo -e "Processing easystack file ${easystack_file}...\n\n"
 

--- a/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
+++ b/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
@@ -92,6 +92,10 @@ echo "Created temporary directory '${tmpdir}'"
 # Store MODULEPATH so it can be restored at the end of each loop iteration
 SAVE_MODULEPATH=${MODULEPATH}
 
+# THIS EXPORT SHOULD NEVER MAKE IT INTO THE REPO, it's just used temporarily to make host-injections
+# install for icelake in https://github.com/EESSI/software-layer/pull/1044
+export EESSI_SKIP_REMOVED_MODULES_CHECK=1
+
 for EASYSTACK_FILE in ${TOPDIR}/easystacks/eessi-*CUDA*.yml; do
     echo -e "Processing easystack file ${easystack_file}...\n\n"
 


### PR DESCRIPTION
This hook has caused more issues than it's worth, and the warning has been there for a long time now, so people should know by now.