### PR TITLE
{2023.06}[2023a,grace] Z3 v4.12.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -1,3 +1,4 @@
 easyconfigs:
 #This is an outdated version of the Z3-4.12.2-GCCcore-12.3.0 easyconfig, adding it to keep sync with the other stacks
+#see https://github.com/easybuilders/easybuild-easyconfigs/pull/20050
   - Z3-4.12.2-GCCcore-12.3.0-Python-3.11.3.eb

--- a/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.0-2023a.yml
@@ -1,0 +1,3 @@
+easyconfigs:
+#This is an outdated version of the Z3-4.12.2-GCCcore-12.3.0 easyconfig, adding it to keep sync with the other stacks
+  - Z3-4.12.2-GCCcore-12.3.0-Python-3.11.3.eb


### PR DESCRIPTION
This is an outdated version of the Z3-4.12.2-GCCcore-12.3.0 easyconfig, before unifying Z3 4.12.2 easyconfigs into a single one with Python bindings in https://github.com/easybuilders/easybuild-easyconfigs/pull/20050/files , adding it to keep sync with the other stacks