### PR TITLE
{2023.06}[2023a,a64fx] apps originally built with EB 4.9.1

### DIFF
--- a/det_submit_opts.py
+++ b/det_submit_opts.py
@@ -1,0 +1,45 @@
+import os
+import subprocess
+
+from easybuild.framework.easystack import EasyStackParser
+
+CPU_TARGET_A64FX = 'aarch64/a64fx'
+
+
+def get_orig_easystack(easystack, repo_path):
+    """ write the original easystack file (before the diff was applied) """
+    orig_easystack = f'{easystack}.orig'
+    git_cmd = f'git -C {repo_path} show HEAD:{easystack}'.split()
+    with open(os.path.join(repo_path, orig_easystack), 'w', encoding='utf-8') as outfile:
+        subprocess.run(git_cmd, check=True, stdout=outfile)
+    return orig_easystack
+
+
+def det_submit_opts(job):
+    """
+    determine submit options from added easyconfigs
+    Args:
+        job (Job): namedtuple containing all information about job to be submitted
+
+    Returns:
+        (string): string containing extra submit options
+    """
+    easystack = 'easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml'
+    repo_path = job.working_dir
+    orig_easystack = get_orig_easystack(easystack, repo_path)
+
+    esp = EasyStackParser()
+    orig_ecs = {x[0] for x in esp.parse(os.path.join(repo_path, orig_easystack)).ec_opt_tuples}
+    pr_ecs = {x[0] for x in esp.parse(os.path.join(repo_path, easystack)).ec_opt_tuples}
+    added_ecs = pr_ecs - orig_ecs
+    print(f'added easyconfigs: {added_ecs}')
+
+    submit_opts = [job.slurm_opts]
+    for ec in added_ecs:
+        # remove OS part from arch_target
+        arch_name = '/'.join(job.arch_target.split('/')[1:])
+        # set walltime limit to 2 days when R-bundle-CRAN should be built on a64fx
+        if ec.startswith('R-bundle-CRAN-2023.12-foss-2023a') and arch_name == CPU_TARGET_A64FX:
+            submit_opts.append('--time=2-00:00:00')
+
+    return ' '.join(submit_opts)

--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -263,34 +263,37 @@ easyconfigs:
   - ncdu-1.18-GCC-12.3.0.eb
   - SAMtools-1.18-GCC-12.3.0.eb
   - R-bundle-CRAN-2023.12-foss-2023a.eb
-# while PR 20379 is included since EB 4.9.2, we need to use a commit to avoid
-# rebuilding R-bundle-Bioconductor due to the later PR 21948 which was only made
-# available with EB 5.0.0
+# R-bundle-CRAN requires a lot of time. We first build that one and afterwards
+# continue with the ones below.
+#
+## while PR 20379 is included since EB 4.9.2, we need to use a commit to avoid
+## rebuilding R-bundle-Bioconductor due to the later PR 21948 which was only made
+## available with EB 5.0.0
+##  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
+##      options:
+##        from-pr: 20379
 #  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
 #      options:
-#        from-pr: 20379
-  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
-      options:
-        # (additional extensions have been added)
-        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21948
-        from-commit: f9cfe6ac7d9019970c2be3e8b09db4d846cf005a
-# PR 18852 is included since EB 4.9.2
-#  - ipympl-0.9.3-gfbf-2023a.eb:
-#      options:
-#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/18852
-#        from-pr: 18852
-  - ipympl-0.9.3-gfbf-2023a.eb
-# PR 20595 is included since EB 4.9.2
-#  - ESPResSo-4.2.2-foss-2023a.eb:
-#      options:
-#        from-pr: 20595
-  - ESPResSo-4.2.2-foss-2023a.eb
-  - GATK-4.5.0.0-GCCcore-12.3.0-Java-17.eb
-  - WhatsHap-2.2-foss-2023a.eb
-# PR 20784 is included since EB 4.9.2
-#  - BLAST+-2.14.1-gompi-2023a.eb:
-#      options:
-#        from-pr: 20784
-  - BLAST+-2.14.1-gompi-2023a.eb
-  - Valgrind-3.21.0-gompi-2023a.eb
-  - OrthoFinder-2.5.5-foss-2023a.eb
+#        # (additional extensions have been added)
+#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21948
+#        from-commit: f9cfe6ac7d9019970c2be3e8b09db4d846cf005a
+## PR 18852 is included since EB 4.9.2
+##  - ipympl-0.9.3-gfbf-2023a.eb:
+##      options:
+##        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/18852
+##        from-pr: 18852
+#  - ipympl-0.9.3-gfbf-2023a.eb
+## PR 20595 is included since EB 4.9.2
+##  - ESPResSo-4.2.2-foss-2023a.eb:
+##      options:
+##        from-pr: 20595
+#  - ESPResSo-4.2.2-foss-2023a.eb
+#  - GATK-4.5.0.0-GCCcore-12.3.0-Java-17.eb
+#  - WhatsHap-2.2-foss-2023a.eb
+## PR 20784 is included since EB 4.9.2
+##  - BLAST+-2.14.1-gompi-2023a.eb:
+##      options:
+##        from-pr: 20784
+#  - BLAST+-2.14.1-gompi-2023a.eb
+#  - Valgrind-3.21.0-gompi-2023a.eb
+#  - OrthoFinder-2.5.5-foss-2023a.eb

--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -258,3 +258,39 @@ easyconfigs:
   - PostgreSQL-16.1-GCCcore-12.3.0.eb
   - ImageMagick-7.1.1-15-GCCcore-12.3.0.eb
   - GDAL-3.7.1-foss-2023a.eb
+# from here on apps were originally built with EB 4.9.1 (except for
+# R-bundle-CRAN-2023.12-foss-2023a, which was originally built with 4.9.4)
+  - ncdu-1.18-GCC-12.3.0.eb
+  - SAMtools-1.18-GCC-12.3.0.eb
+  - R-bundle-CRAN-2023.12-foss-2023a.eb
+# while PR 20379 is included since EB 4.9.2, we need to use a commit to avoid
+# rebuilding R-bundle-Bioconductor due to the later PR 21948 which was only made
+# available with EB 5.0.0
+#  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
+#      options:
+#        from-pr: 20379
+  - R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
+      options:
+        # (additional extensions have been added)
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21948
+        from-commit: f9cfe6ac7d9019970c2be3e8b09db4d846cf005a
+# PR 18852 is included since EB 4.9.2
+#  - ipympl-0.9.3-gfbf-2023a.eb:
+#      options:
+#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/18852
+#        from-pr: 18852
+  - ipympl-0.9.3-gfbf-2023a.eb
+# PR 20595 is included since EB 4.9.2
+#  - ESPResSo-4.2.2-foss-2023a.eb:
+#      options:
+#        from-pr: 20595
+  - ESPResSo-4.2.2-foss-2023a.eb
+  - GATK-4.5.0.0-GCCcore-12.3.0-Java-17.eb
+  - WhatsHap-2.2-foss-2023a.eb
+# PR 20784 is included since EB 4.9.2
+#  - BLAST+-2.14.1-gompi-2023a.eb:
+#      options:
+#        from-pr: 20784
+  - BLAST+-2.14.1-gompi-2023a.eb
+  - Valgrind-3.21.0-gompi-2023a.eb
+  - OrthoFinder-2.5.5-foss-2023a.eb


### PR DESCRIPTION
Apps built originally with EB 4.9.1 plus two exceptions:
- R-bundle-CRAN seems to have been built originally with EB 4.9.4
- ~R-bundle-Bioconductor needs to use a commit from a PR that was only made available with EB 5.0.0 (we use the commit to avoid rebuilding the package later; currently, rebuilding doesn't work on a64fx)~
  - will build R-bundle-Bioconductor in a follow-up PR