### PR TITLE
{2023.06}[2023b,a64fx] Qt5 5.15.13

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023b.yml
@@ -80,12 +80,10 @@ easyconfigs:
   - OpenJPEG-2.5.0-GCCcore-13.2.0.eb
   - libwebp-1.3.2-GCCcore-13.2.0.eb
   - Wayland-1.22.0-GCCcore-13.2.0.eb
-# building nodejs (dependency of Qt5) failed in a first attempt, so we build the
-# other packages and pick that up later
-## originally built with EB 4.9.0, PR was included since EB 4.9.1
-##  - Qt5-5.15.13-GCCcore-13.2.0.eb:
-##      options:
-##        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20201
-##        from-pr: 20201
-#  - Qt5-5.15.13-GCCcore-13.2.0.eb
   - OSU-Micro-Benchmarks-7.2-gompi-2023b.eb
+# originally built with EB 4.9.0, PR was included since EB 4.9.1
+#  - Qt5-5.15.13-GCCcore-13.2.0.eb:
+#      options:
+#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20201
+#        from-pr: 20201
+  - Qt5-5.15.13-GCCcore-13.2.0.eb

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -1269,6 +1269,9 @@ PARALLELISM_LIMITS = {
         '*': (divide_by_factor, 2),
         CPU_TARGET_A64FX: (set_maximum, 12),
     },
+    'nodejs': {
+        CPU_TARGET_A64FX: (divide_by_factor, 2),
+    },
     'MBX': {
         '*': (divide_by_factor, 2),
     },

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -1280,7 +1280,7 @@ PARALLELISM_LIMITS = {
         CPU_TARGET_A64FX: (set_maximum, 8),
     },
     'Qt5': {
-        CPU_TARGET_A64FX: (divide_by_factor, 2),
+        CPU_TARGET_A64FX: (set_maximum, 8),
     },
     'ROOT': {
         CPU_TARGET_A64FX: (divide_by_factor, 2),


### PR DESCRIPTION
In #1050 building nodejs (dependency of Qt5) failed. We try first to build Qt5 and all its dependencies. If that fails again, we may build first all dependencies of nodejs and then try the remaining ones.