### PR TITLE
Rebuild R 4.2.2 and 4.3.2 to include patch for CVE

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20250501-eb-4.9.4-R-4.2.2-and-4.3.2-fix-CVE.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20250501-eb-4.9.4-R-4.2.2-and-4.3.2-fix-CVE.yml
@@ -1,5 +1,6 @@
 # 2025.05.01
-# Rebuild of R 4.2.2 to include patch for CVE,
+# Rebuild of R 4.2.2 and 4.3.2 to include patch for CVE,
 # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20462 
 easyconfigs:
   - R-4.2.2-foss-2022b.eb
+  - R-4.3.2-gfbf-2023a.eb

--- a/easystacks/software.eessi.io/2023.06/rebuilds/20250501-eb-4.9.4-R-4.2.2-fix-CVE.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20250501-eb-4.9.4-R-4.2.2-fix-CVE.yml
@@ -1,0 +1,5 @@
+# 2025.05.01
+# Rebuild of R 4.2.2 to include patch for CVE,
+# see https://github.com/easybuilders/easybuild-easyconfigs/pull/20462 
+easyconfigs:
+  - R-4.2.2-foss-2022b.eb


### PR DESCRIPTION
This ensures that all stacks/targets have the same version (some may already have the patch, e.g. Sapphire Rapids and Grace).

Edit:
```
$ grep CVE /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/*/*/software/R/4.2.2-foss-2022b/easybuild/R-4.2.2-foss-2022b.eb 
/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4/software/R/4.2.2-foss-2022b/easybuild/R-4.2.2-foss-2022b.eb:patches = ['R-4.x_fix-CVE-2024-27322.patch']
/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4/software/R/4.2.2-foss-2022b/easybuild/R-4.2.2-foss-2022b.eb:    {'R-4.x_fix-CVE-2024-27322.patch': 'd8560e15c3c5716f99e852541901014d406f2a73136b0b74f11ba529f7a7b00d'},
/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/sapphirerapids/software/R/4.2.2-foss-2022b/easybuild/R-4.2.2-foss-2022b.eb:patches = ['R-4.x_fix-CVE-2024-27322.patch']
/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/sapphirerapids/software/R/4.2.2-foss-2022b/easybuild/R-4.2.2-foss-2022b.eb:    {'R-4.x_fix-CVE-2024-27322.patch': 'd8560e15c3c5716f99e852541901014d406f2a73136b0b74f11ba529f7a7b00d'},

$ grep CVE /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/generic/software/R/4.2.2-foss-2022b/easybuild/R-4.2.2-foss-2022b.eb 

$ grep CVE /cvmfs/software.eessi.io/versions/2023.06/software/linux/aarch64/*/software/R/4.2.2-foss-2022b/easybuild/R-4.2.2-foss-2022b.eb 

$ grep CVE /cvmfs/software.eessi.io/versions/2023.06/software/linux/aarch64/*/*/software/R/4.2.2-foss-2022b/easybuild/R-4.2.2-foss-2022b.eb 
patches = ['R-4.x_fix-CVE-2024-27322.patch']
    {'R-4.x_fix-CVE-2024-27322.patch': 'd8560e15c3c5716f99e852541901014d406f2a73136b0b74f11ba529f7a7b00d'},
```
So, also `zen4` already has the fix.

Edit 2: I'm doing the same kind of rebuild for version 4.3.2, which has the same issue and also already includes the fix for the aforementioned targets.

For `a64fx`, version 4.3.2 is already available and includes the fix. Version 4.2.2 has not been built yet, but assuming @trz42 will do the build in the same way as he has done for `grace`, it will automatically get the fix.