### PR TITLE
Fix condition of if statement in GROMACS hook

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -615,7 +615,7 @@ def pre_configure_hook_gromacs(self, *args, **kwargs):
     """
     if self.name == 'GROMACS':
         cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
-        if LooseVersion(self.version) <= LooseVersion('2024.1') and cpu_target == CPU_TARGET_NEOVERSE_V1 or LooseVersion(self.version) <= LooseVersion('2024.4') and CPU_TARGET_NVIDIA_GRACE:
+        if (LooseVersion(self.version) <= LooseVersion('2024.1') and cpu_target == CPU_TARGET_NEOVERSE_V1) or (LooseVersion(self.version) <= LooseVersion('2024.4') and CPU_TARGET_NVIDIA_GRACE):
             self.cfg.update('configopts', '-DGMX_SIMD=ARM_NEON_ASIMD')
             print_msg(
                 "Avoiding use of SVE instructions for GROMACS %s by using ARM_NEON_ASIMD as GMX_SIMD value",

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -615,7 +615,10 @@ def pre_configure_hook_gromacs(self, *args, **kwargs):
     """
     if self.name == 'GROMACS':
         cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
-        if (LooseVersion(self.version) <= LooseVersion('2024.1') and cpu_target == CPU_TARGET_NEOVERSE_V1) or (LooseVersion(self.version) <= LooseVersion('2024.4') and CPU_TARGET_NVIDIA_GRACE):
+        if (
+            (LooseVersion(self.version) <= LooseVersion('2024.1') and cpu_target == CPU_TARGET_NEOVERSE_V1) or
+            (LooseVersion(self.version) <= LooseVersion('2024.4') and CPU_TARGET_NVIDIA_GRACE)
+        ):
             self.cfg.update('configopts', '-DGMX_SIMD=ARM_NEON_ASIMD')
             print_msg(
                 "Avoiding use of SVE instructions for GROMACS %s by using ARM_NEON_ASIMD as GMX_SIMD value",

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -617,7 +617,7 @@ def pre_configure_hook_gromacs(self, *args, **kwargs):
         cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
         if (
             (LooseVersion(self.version) <= LooseVersion('2024.1') and cpu_target == CPU_TARGET_NEOVERSE_V1) or
-            (LooseVersion(self.version) <= LooseVersion('2024.4') and CPU_TARGET_NVIDIA_GRACE)
+            (LooseVersion(self.version) <= LooseVersion('2024.4') and cpu_target == CPU_TARGET_NVIDIA_GRACE)
         ):
             self.cfg.update('configopts', '-DGMX_SIMD=ARM_NEON_ASIMD')
             print_msg(


### PR DESCRIPTION
GROMACS build for Icelake failed due to:
```
== Avoiding use of SVE instructions for GROMACS 2024.1 by using ARM_NEON_ASIMD as GMX_SIMD value
```
See https://github.com/EESSI/software-layer/pull/1069.