### PR TITLE
{2023.06}[icelake,cascadelake] EasyStacks batch 14b: 057 - QuantumESPRESSO 7.3.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/icelake_cclake/057-eb-4.9.2.yml
+++ b/easystacks/software.eessi.io/2023.06/icelake_cclake/057-eb-4.9.2.yml
@@ -1,0 +1,6 @@
+# 057-eb-4.9.2.yml: total build duration = 357 minutes
+easyconfigs:
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/QuantumESPRESSO/7.3.1-foss-2023a/easybuild/QuantumESPRESSO-7.3.1-foss-2023a.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/QuantumESPRESSO/7.3.1-foss-2023a/easybuild/reprod/easyblocks/*.py
+


### PR DESCRIPTION
QuantumESPRESSO failed in #1070. The very first error in the test step was:
```
     file /tmp/bot/easybuild/build/QuantumESPRESSO/7.3.1/foss-2023a/qe-7.3.1/pseudo/O.blyp-mt.UPF not found
```

Perhaps it ran out of disk space, so let's try it again with only QuantumESPRESSO. All dependencies should be in place:
```
$ export EESSI_SOFTWARE_SUBDIR_OVERRIDE=x86_64/intel/icelake
$ source /cvmfs/software.eessi.io/versions/2023.06/init/bash
$ ml EasyBuild/4.9.2
$ ml EESSI-extend
$ eb -M /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/QuantumESPRESSO/7.3.1-foss-2023a/easybuild/QuantumESPRESSO-7.3.1-foss-2023a.eb

No missing modules!
```
