### PR TITLE
{2023.06}[icelake,cascadelake] EasyStacks batch 18: 072

### DIFF
--- a/072-eb-5.0.0.yml
+++ b/072-eb-5.0.0.yml
@@ -1,0 +1,14 @@
+# 072-eb-5.0.0.yml: total build duration = ?? minutes
+easyconfigs:
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/MUSCLE/5.1.0-GCCcore-12.3.0/easybuild/MUSCLE-5.1.0-GCCcore-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/MUSCLE/5.1.0-GCCcore-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/Gblocks/0.91b/easybuild/Gblocks-0.91b.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/Gblocks/0.91b/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/RAxML/8.2.13-gompi-2023a-avx2/easybuild/RAxML-8.2.13-gompi-2023a-avx2.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/RAxML/8.2.13-gompi-2023a-avx2/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/bcgTree/1.2.1-foss-2023a/easybuild/bcgTree-1.2.1-foss-2023a.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/bcgTree/1.2.1-foss-2023a/easybuild/reprod/easyblocks/*.py

--- a/easystacks/software.eessi.io/2023.06/icelake_cclake/069-eb-4.9.2.yml
+++ b/easystacks/software.eessi.io/2023.06/icelake_cclake/069-eb-4.9.2.yml
@@ -1,0 +1,8 @@
+# 069-eb-4.9.2.yml: total build duration = 3 minutes
+easyconfigs:
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/rpy2/3.5.15-foss-2023a/easybuild/rpy2-3.5.15-foss-2023a.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/rpy2/3.5.15-foss-2023a/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/Tombo/1.5.1-foss-2023a/easybuild/Tombo-1.5.1-foss-2023a.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/Tombo/1.5.1-foss-2023a/easybuild/reprod/easyblocks/*.py

--- a/easystacks/software.eessi.io/2023.06/icelake_cclake/070-eb-4.9.4.yml
+++ b/easystacks/software.eessi.io/2023.06/icelake_cclake/070-eb-4.9.4.yml
@@ -1,0 +1,74 @@
+# 070-eb-4.9.4.yml: total build duration = 325 minutes
+easyconfigs:
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/GStreamer/1.24.8-GCC-13.2.0/easybuild/GStreamer-1.24.8-GCC-13.2.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/GStreamer/1.24.8-GCC-13.2.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/Graphene/1.10.8-GCCcore-13.2.0/easybuild/Graphene-1.10.8-GCCcore-13.2.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/Graphene/1.10.8-GCCcore-13.2.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/GST-plugins-base/1.24.8-GCC-13.2.0/easybuild/GST-plugins-base-1.24.8-GCC-13.2.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/GST-plugins-base/1.24.8-GCC-13.2.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/wxWidgets/3.2.6-GCC-13.2.0/easybuild/wxWidgets-3.2.6-GCC-13.2.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/wxWidgets/3.2.6-GCC-13.2.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/elfx86exts/0.6.2-GCC-12.3.0/easybuild/elfx86exts-0.6.2-GCC-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/elfx86exts/0.6.2-GCC-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/archspec/0.2.5-GCCcore-12.3.0/easybuild/archspec-0.2.5-GCCcore-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/archspec/0.2.5-GCCcore-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/EveryBeam/0.6.1-foss-2023b/easybuild/EveryBeam-0.6.1-foss-2023b.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/EveryBeam/0.6.1-foss-2023b/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/DP3/6.2-foss-2023b/easybuild/DP3-6.2-foss-2023b.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/DP3/6.2-foss-2023b/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/WSClean/3.5-foss-2023b/easybuild/WSClean-3.5-foss-2023b.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/WSClean/3.5-foss-2023b/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/R-bundle-Bioconductor/3.18-foss-2023a-R-4.3.2/easybuild/R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/R-bundle-Bioconductor/3.18-foss-2023a-R-4.3.2/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/ant/1.10.14-Java-11/easybuild/ant-1.10.14-Java-11.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/ant/1.10.14-Java-11/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/GST-plugins-bad/1.22.5-GCC-12.3.0/easybuild/GST-plugins-bad-1.22.5-GCC-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/GST-plugins-bad/1.22.5-GCC-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/PyCairo/1.25.0-GCCcore-12.3.0/easybuild/PyCairo-1.25.0-GCCcore-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/PyCairo/1.25.0-GCCcore-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/PyGObject/3.46.0-GCCcore-12.3.0/easybuild/PyGObject-3.46.0-GCCcore-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/PyGObject/3.46.0-GCCcore-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/GTK4/4.13.1-GCC-12.3.0/easybuild/GTK4-4.13.1-GCC-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/GTK4/4.13.1-GCC-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/OpenCV/4.8.1-foss-2023a-contrib/easybuild/OpenCV-4.8.1-foss-2023a-contrib.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/OpenCV/4.8.1-foss-2023a-contrib/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/coverage/7.4.4-GCCcore-13.2.0/easybuild/coverage-7.4.4-GCCcore-13.2.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/coverage/7.4.4-GCCcore-13.2.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/pre-commit/3.7.0-GCCcore-13.2.0/easybuild/pre-commit-3.7.0-GCCcore-13.2.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/pre-commit/3.7.0-GCCcore-13.2.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/astropy-testing/7.0.0-gfbf-2023b/easybuild/astropy-testing-7.0.0-gfbf-2023b.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/astropy-testing/7.0.0-gfbf-2023b/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/astropy/7.0.0-gfbf-2023b/easybuild/astropy-7.0.0-gfbf-2023b.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/astropy/7.0.0-gfbf-2023b/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/Pandoc/3.6.2/easybuild/Pandoc-3.6.2.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/Pandoc/3.6.2/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/FALL3D/9.0.1-gompi-2023a/easybuild/FALL3D-9.0.1-gompi-2023a.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/FALL3D/9.0.1-gompi-2023a/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/lit/18.1.2-GCCcore-12.3.0/easybuild/lit-18.1.2-GCCcore-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/lit/18.1.2-GCCcore-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/lit/18.1.7-GCCcore-13.2.0/easybuild/lit-18.1.7-GCCcore-13.2.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/lit/18.1.7-GCCcore-13.2.0/easybuild/reprod/easyblocks/*.py

--- a/easystacks/software.eessi.io/2023.06/icelake_cclake/071-eb-5.0.0.yml
+++ b/easystacks/software.eessi.io/2023.06/icelake_cclake/071-eb-5.0.0.yml
@@ -1,0 +1,44 @@
+# 071-eb-5.0.0.yml: total build duration = 32 minutes
+easyconfigs:
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/ruamel.yaml/0.17.32-GCCcore-12.3.0/easybuild/ruamel.yaml-0.17.32-GCCcore-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/ruamel.yaml/0.17.32-GCCcore-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/test-drive/0.5.0-GCC-12.3.0/easybuild/test-drive-0.5.0-GCC-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/test-drive/0.5.0-GCC-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/PnetCDF/1.12.3-gompi-2023a/easybuild/PnetCDF-1.12.3-gompi-2023a.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/PnetCDF/1.12.3-gompi-2023a/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/flook/0.8.4-GCC-12.3.0/easybuild/flook-0.8.4-GCC-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/flook/0.8.4-GCC-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/libfdf/0.5.1-GCC-12.3.0/easybuild/libfdf-0.5.1-GCC-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/libfdf/0.5.1-GCC-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/json-fortran/9.0.2-GCC-12.3.0/easybuild/json-fortran-9.0.2-GCC-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/json-fortran/9.0.2-GCC-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/mctc-lib/0.3.1-GCC-12.3.0/easybuild/mctc-lib-0.3.1-GCC-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/mctc-lib/0.3.1-GCC-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/mstore/0.3.0-GCC-12.3.0/easybuild/mstore-0.3.0-GCC-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/mstore/0.3.0-GCC-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/libGridXC/2.0.2-gompi-2023a/easybuild/libGridXC-2.0.2-gompi-2023a.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/libGridXC/2.0.2-gompi-2023a/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/TOML-Fortran/0.4.2-GCC-12.3.0/easybuild/TOML-Fortran-0.4.2-GCC-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/TOML-Fortran/0.4.2-GCC-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/Simple-DFTD3/1.2.1-gfbf-2023a/easybuild/Simple-DFTD3-1.2.1-gfbf-2023a.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/Simple-DFTD3/1.2.1-gfbf-2023a/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/xmlf90/1.6.3-GCC-12.3.0/easybuild/xmlf90-1.6.3-GCC-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/xmlf90/1.6.3-GCC-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/libPSML/2.1.0-GCC-12.3.0/easybuild/libPSML-2.1.0-GCC-12.3.0.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/libPSML/2.1.0-GCC-12.3.0/easybuild/reprod/easyblocks/*.py
+  - /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/Siesta/5.2.2-foss-2023a/easybuild/Siesta-5.2.2-foss-2023a.eb:
+      options:
+        include-easyblocks: /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell/software/Siesta/5.2.2-foss-2023a/easybuild/reprod/easyblocks/*.py


### PR DESCRIPTION
This contains the software that was installed between us generating the batches of EasyStacks for icelake and cascadelake, and the present day. With this PR, we _should_ also be able to enable the CI.

It does require https://github.com/EESSI/software-layer/pull/1073 to be merged first, and then we should sync this PR with the default branch.