### PR TITLE
{2023.06}[2023a,a64fx] PyTorch 2.1.2 originally built with EB 4.9.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -170,12 +170,12 @@ easyconfigs:
 #        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3036
 #        include-easyblocks-from-pr: 3036
   - LAMMPS-2Aug2023_update2-foss-2023a-kokkos.eb
-## PR 19573 was included since EB 4.9.1
-##  - PyTorch-2.1.2-foss-2023a.eb:
-##      options:
-##        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19573
-##        from-pr: 19573
-#  - PyTorch-2.1.2-foss-2023a.eb
+# PR 19573 was included since EB 4.9.1
+#  - PyTorch-2.1.2-foss-2023a.eb:
+#      options:
+#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/19573
+#        from-pr: 19573
+  - PyTorch-2.1.2-foss-2023a.eb
   - matplotlib-3.7.2-gfbf-2023a.eb
 # PR 19554 was included since EB 4.9.1
 #  - PyQt5-5.15.10-GCCcore-12.3.0.eb:


### PR DESCRIPTION
Adds remaining app - PyTorch - that was originally built with EB 4.9.0

Other apps originally built with EB 4.9.0 were added via #1038 and #1040