### PR TITLE
run the `check_missing_installations.sh` script with the EB version from the easystack filename

### DIFF
--- a/.github/workflows/test-software.eessi.io.yml
+++ b/.github/workflows/test-software.eessi.io.yml
@@ -74,7 +74,7 @@ jobs:
               env | grep ^EESSI | sort
 
               # first check the CPU-only builds for this CPU target
-              echo "just run check_missing_installations.sh (should use easystacks/software.eessi.io/${EESSI_VERSION}/eessi-${EESSI_VERSION}-*.yml with latest EasyBuild release)"
+              echo "first run check_missing_installations.sh for CPU-only builds"
               for easystack_file in $(EESSI_VERSION=${EESSI_VERSION} .github/workflows/scripts/only_latest_easystacks.sh); do
                   eb_version=$(echo ${easystack_file} | sed 's/.*eb-\([0-9.]*\).*.yml/\1/g')
                   echo "check missing installations for ${easystack_file} with EasyBuild ${eb_version}..."

--- a/.github/workflows/test-software.eessi.io.yml
+++ b/.github/workflows/test-software.eessi.io.yml
@@ -69,9 +69,6 @@ jobs:
               # set $EESSI_CPU_FAMILY to the CPU architecture that corresponds to $EESSI_SOFTWARE_SUBDIR_OVERRIDE (part before the first slash),
               # to prevent issues with checks in the Easybuild configuration that use this variable
               export EESSI_CPU_FAMILY=${EESSI_SOFTWARE_SUBDIR_OVERRIDE%%/*}
-              module load EasyBuild
-              which eb
-              eb --version
               export EESSI_PREFIX=/cvmfs/software.eessi.io/versions/${EESSI_VERSION}
               export EESSI_OS_TYPE=linux
               env | grep ^EESSI | sort
@@ -79,7 +76,12 @@ jobs:
               # first check the CPU-only builds for this CPU target
               echo "just run check_missing_installations.sh (should use easystacks/software.eessi.io/${EESSI_VERSION}/eessi-${EESSI_VERSION}-*.yml with latest EasyBuild release)"
               for easystack_file in $(EESSI_VERSION=${EESSI_VERSION} .github/workflows/scripts/only_latest_easystacks.sh); do
-                  echo "check missing installations for ${easystack_file}..."
+                  eb_version=$(echo ${easystack_file} | sed 's/.*eb-\([0-9.]*\).*.yml/\1/g')
+                  echo "check missing installations for ${easystack_file} with EasyBuild ${eb_version}..."
+                  module purge
+                  module load EasyBuild/${eb_version}
+                  which eb
+                  eb --version
                   ./check_missing_installations.sh ${easystack_file}
                   ec=$?
                   if [[ ${ec} -ne 0 ]]; then echo "missing installations found for ${easystack_file}!" >&2; exit ${ec}; fi
@@ -94,7 +96,12 @@ jobs:
                       module use ${EESSI_SOFTWARE_PATH}/accel/${accel}/modules/all
                       echo "checking missing installations for accelerator ${accel} using modulepath: ${MODULEPATH}"
                       for easystack_file in $(EESSI_VERSION=${EESSI_VERSION} ACCEL_EASYSTACKS=1 .github/workflows/scripts/only_latest_easystacks.sh); do
-                          echo "check missing installations for ${easystack_file}..."
+                          eb_version=$(echo ${easystack_file} | sed 's/.*eb-\([0-9.]*\).*.yml/\1/g')
+                          echo "check missing installations for ${easystack_file} with EasyBuild ${eb_version}..."
+                          module purge
+                          module load EasyBuild/${eb_version}
+                          which eb
+                          eb --version
                           ./check_missing_installations.sh ${easystack_file}
                           ec=$?
                           if [[ ${ec} -ne 0 ]]; then echo "missing installations found for ${easystack_file}!" >&2; exit ${ec}; fi


### PR DESCRIPTION
By not specifying the version, it would always use the latest EB version. That could lead to annoying issues, for instance the issue observed in #1086: it started running the checks for some targets with EB 5.1.0 (which just got ingested), and in this version Java 21 was updated to point to Java 21.0.7 instead of 21.0.5. By always sticking to the EB version that's encoded in the easystack filename, this should not happen. We already do the same in `EESSI-installsoftware.sh`, see https://github.com/EESSI/software-layer/blob/2023.06-software.eessi.io/EESSI-install-software.sh#L362.