### PR TITLE
fix issue that parallel gets set to None with EB 5+

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -133,10 +133,11 @@ def post_ready_hook(self, *args, **kwargs):
     # Check whether we have EasyBuild 4 or 5
     parallel_param = 'parallel'
     if EASYBUILD_VERSION >= '5':
-        # parallel_param = 'max_parallel'  # EasyBlock.set_parallel sets 'parallel'
-        parallel_param = 'parallel'
+        parallel_param = 'max_parallel'
     # get current parallelism setting
     parallel = self.cfg[parallel_param]
+    if parallel == None:
+        return  # self.cfg doesn't contain 'parallel' or 'max_parallel'
     if parallel == 1:
         return  # no need to limit if already using 1 core
 

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -133,7 +133,8 @@ def post_ready_hook(self, *args, **kwargs):
     # Check whether we have EasyBuild 4 or 5
     parallel_param = 'parallel'
     if EASYBUILD_VERSION >= '5':
-        parallel_param = 'max_parallel'
+        # parallel_param = 'max_parallel'  # EasyBlock.set_parallel sets 'parallel'
+        parallel_param = 'parallel'
     # get current parallelism setting
     parallel = self.cfg[parallel_param]
     if parallel == 1:


### PR DESCRIPTION
Fixes an issue caused by the post_ready_hook trying to obtain the parallelism via

```
self.cfg['max_parallel'] 
```

which is not set by `EasyBlock.set_parallel`. The latter always (for EB 4 and EB 5) sets

```
self.cfg['parallel'] 
```
_or_
```
self.cfg.parallel 
```
