### PR TITLE
make sure that Lmod cache file is present for all supported CPU targets

### DIFF
--- a/.github/workflows/test-software.eessi.io.yml
+++ b/.github/workflows/test-software.eessi.io.yml
@@ -118,6 +118,9 @@ jobs:
                   done
               fi
 
+              # make sure that Lmod cache file is present
+              ls -l ${EESSI_SOFTWARE_PATH}/.lmod/cache/spiderT.lua
+
         - name: Test check_missing_installations.sh with missing package (GCC/8.3.0)
           run: |
               export EESSI_SOFTWARE_SUBDIR_OVERRIDE=${{matrix.EESSI_SOFTWARE_SUBDIR_OVERRIDE}}


### PR DESCRIPTION
This would've helped to catch missing cache files (like in https://gitlab.com/eessi/support/-/issues/167) a lot earlier