### PR TITLE
{2023.06}[foss/2023b] HeFFTe 2.4.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.0-2023b.yml
@@ -8,3 +8,4 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22719
         # and https://github.com/easybuilders/easybuild-easyconfigs/pull/23078
         from-commit: bd408e638bdd0d0ef7d80d92b6d3e2ceb8d0893d
+  - HeFFTe-2.4.1-foss-2023b.eb


### PR DESCRIPTION
This is, among other things, a dependency of multixscale/dev.eessi.io-espresso#1

```
 1 out of 35 required modules missing:

* HeFFTe/2.4.1-foss-2023b (HeFFTe-2.4.1-foss-2023b.eb)
```