### PR TITLE
Debug Rust 1.65.0 issue on a64fx

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2022b.yml
@@ -35,3 +35,6 @@ easyconfigs:
 #  - HarfBuzz-5.3.1-GCCcore-12.2.0.eb
 ##  - Qt5-5.15.7-GCCcore-12.2.0.eb
 ##  - QuantumESPRESSO-7.2-foss-2022b.eb
+- Rust-1.65.0-GCCcore-12.2.0.eb:
+    options:
+      try-software-version: 1.70.0


### PR DESCRIPTION
Doing some tests to debug the issue observed in https://github.com/EESSI/software-layer/pull/1098#issuecomment-3051687490. First trying to build Rust 1.70.0 with the same toolchain to find out if it's a problem with Rust itself, since 1.70.0 was successfully built with GCC 12.3.0.