### PR TITLE
{2023.06}[foss/2023a] Octave 10.1.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023a.yml
@@ -1,0 +1,5 @@
+easyconfigs:
+  - Octave-10.1.0-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22932
+        from-commit: 3211d34eb16ff31b8de3dfef55ecaaf1ec205c6f


### PR DESCRIPTION
Added installation of `Octave-10.1.0` with `EB-5.1.1` and `foss-2023a`