### PR TITLE
Fill holes created by updated dependencies of Qt5 from EB 5.1.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - libheif-1.17.6-GCCcore-12.3.0.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023b.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - openCARP-17.0-foss-2023b.eb
+  - libheif-1.19.5-GCCcore-13.2.0.eb


### PR DESCRIPTION
```
4 out of 131 required modules missing:

* libde265/1.0.15-GCCcore-13.2.0 (libde265-1.0.15-GCCcore-13.2.0.eb)
* libde265/1.0.15-GCCcore-12.3.0 (libde265-1.0.15-GCCcore-12.3.0.eb)
* libheif/1.19.5-GCCcore-13.2.0 (libheif-1.19.5-GCCcore-13.2.0.eb)
* libheif/1.17.6-GCCcore-12.3.0 (libheif-1.17.6-GCCcore-12.3.0.eb)
```