### PR TITLE
Rebuild all CUDA software with EB-5.1.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/accel/nvidia/rebuilds/20250805-eb-5.1.1-rebuild-2023a-for-cuda-sanity-check.yml
+++ b/easystacks/software.eessi.io/2023.06/accel/nvidia/rebuilds/20250805-eb-5.1.1-rebuild-2023a-for-cuda-sanity-check.yml
@@ -5,10 +5,6 @@
 # that there are a lot of missing installations https://github.com/EESSI/software-layer/pull/1087 . A rebuild PR like
 # this will have the convenient side effect of filling all those holes
 easyconfigs:
-  - CUDA-12.1.1.eb:
-      options:
-        accept-eula-for: CUDA
-  - cuDNN-8.9.2.26-CUDA-12.1.1.eb
   - LAMMPS-2Aug2023_update2-foss-2023a-kokkos-CUDA-12.1.1.eb
   - ESPResSo-4.2.2-foss-2023a-CUDA-12.1.1.eb
   - LightGBM-4.5.0-foss-2023a-CUDA-12.1.1.eb

--- a/easystacks/software.eessi.io/2023.06/accel/nvidia/rebuilds/20250805-eb-5.1.1-rebuild-2023b-for-cuda-sanity-check.yml
+++ b/easystacks/software.eessi.io/2023.06/accel/nvidia/rebuilds/20250805-eb-5.1.1-rebuild-2023b-for-cuda-sanity-check.yml
@@ -5,9 +5,6 @@
 # that there are a lot of missing installations https://github.com/EESSI/software-layer/pull/1087 . A rebuild PR like
 # this will have the convenient side effect of filling all those holes
 easyconfigs:
-  - CUDA-12.4.0.eb:
-      options:
-        accept-eula-for: CUDA
   - UCX-CUDA-1.15.0-GCCcore-13.2.0-CUDA-12.4.0.eb
   - UCC-CUDA-1.2.0-GCCcore-13.2.0-CUDA-12.4.0.eb
   - OSU-Micro-Benchmarks-7.5-gompi-2023b-CUDA-12.4.0.eb


### PR DESCRIPTION
There are two reasons for this:

1. Now that we have a CUDA sanity check, this allows us to see if anything is 'broken'. 
2. The PR that enables CI to check for differences between CUDA stacks at https://github.com/EESSI/software-layer/pull/1087 shows there are many differences between the architectures. In fact, there are so many holes that a rebuild PR for _all_ architectures is probably the easiest way to fill all the gaps (much easier that figuring out what's missing for which of the 37 combinations of CPU+GPU).