### PR TITLE
{2025.06} gfbf/2024a + FFTW 3.3.10

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.1-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.1-2024a.yml
@@ -1,2 +1,4 @@
 easyconfigs:
   - GCC-13.3.0.eb
+  - gfbf-2024a.eb
+  - FFTW-3.3.10-GCC-13.3.0

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.1-gfbf-2024a-FFTW.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.1-gfbf-2024a-FFTW.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - GCC-13.3.0.eb
+  - gfbf-2024a.eb
+  - FFTW-3.3.10-GCC-13.3.0

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.1-gfbf-2024a-FFTW.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.1-gfbf-2024a-FFTW.yml
@@ -1,4 +1,0 @@
-easyconfigs:
-  - GCC-13.3.0.eb
-  - gfbf-2024a.eb
-  - FFTW-3.3.10-GCC-13.3.0


### PR DESCRIPTION
One step closer to `foss/2024a`.

Not including `OpenMPI` yet, because that build failed in https://github.com/EESSI/software-layer/pull/1158, need to figure out what the problem is...

Will need merge conflict fix after merging of https://github.com/EESSI/software-layer/pull/1146