### PR TITLE
{2025.06} gfbf/2025a + FFTW 3.3.10

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.1-gfbf-2025a-FFTW.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.1-gfbf-2025a-FFTW.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - GCC-14.2.0.eb
+  - gfbf-2025a.eb
+  - FFTW-3.3.10-GCC-14.2.0


### PR DESCRIPTION
One step closer to `foss/2025a`.

Not including `OpenMPI` yet, because that build failed in https://github.com/EESSI/software-layer/pull/1159, need to figure out what the problem is...

Will need merge conflict fix after merging of https://github.com/EESSI/software-layer/pull/1146