### PR TITLE
Rebuild ESPResSo for CUDA sanity check

### DIFF
--- a/easystacks/software.eessi.io/2023.06/accel/nvidia/rebuilds/20250828-eb-5.1.1-rebuild-ESPResSo-for-cuda-sanity-check.yml
+++ b/easystacks/software.eessi.io/2023.06/accel/nvidia/rebuilds/20250828-eb-5.1.1-rebuild-ESPResSo-for-cuda-sanity-check.yml
@@ -9,4 +9,4 @@ easyconfigs:
       options:
         # need an additional patch to build for the right CUDA architecture,
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/23795
-        from-commit: 7dea219f1e24746528331b8bd5ab2b99ab2cc6d2
+        from-commit: f3940e57527848706505b846ac4f2fce86fd5def


### PR DESCRIPTION
Note: I've seen in an interactive build that this didn't pass the CUDA sanity check. So we may have to investigate why not (i.e. which files don't provide the correct device code, and why), and how to make it pass...