### PR TITLE
{2023.06}[2022b,a64fx] remaining apps originally built with EB 4.9.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2022b.yml
@@ -36,23 +36,23 @@ easyconfigs:
 ##  - Qt5-5.15.7-GCCcore-12.2.0.eb
 ##  - QuantumESPRESSO-7.2-foss-2022b.eb
 # Apps originaly added from gracehopper on https://github.com/EESSI/software-layer/pull/1031
-  - MUMPS-5.6.1-foss-2022b-metis.eb
-  - GL2PS-1.4.2-GCCcore-12.2.0.eb
-  - GST-plugins-base-1.22.1-GCC-12.2.0.eb
-  - wxWidgets-3.2.2.1-GCC-12.2.0.eb
+  - MUMPS-5.6.1-foss-2022b-metis.eb 
+  # - GL2PS-1.4.2-GCCcore-12.2.0.eb 
+  # - GST-plugins-base-1.22.1-GCC-12.2.0.eb
+  # - wxWidgets-3.2.2.1-GCC-12.2.0.eb
   - Archive-Zip-1.68-GCCcore-12.2.0.eb
   - jemalloc-5.3.0-GCCcore-12.2.0.eb
   - Judy-1.0.5-GCCcore-12.2.0.eb
   - libaio-0.3.113-GCCcore-12.2.0.eb
   - Z3-4.12.2-GCCcore-12.2.0.eb
   - tbb-2021.10.0-GCCcore-12.2.0.eb
-  - dask-2023.7.1-foss-2022b.eb
-  - netcdf4-python-1.6.3-foss-2022b.eb
+  # - dask-2023.7.1-foss-2022b.eb
+  # - netcdf4-python-1.6.3-foss-2022b.eb
   - Ruby-3.2.2-GCCcore-12.2.0.eb
 # originally built with EB 4.9.2; PR 21526 and PR 3467 included since EB 5.0.0, thus need to use *from-commit
-  - ROOT-6.26.10-foss-2022b.eb:
-      options:
-        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21526
-        from-commit: 6cbfbd7d7a55dc7243f46d0beea510278f4718df
-        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3467
-        include-easyblocks-from-commit: c3aebe1f133d064a228c5d6c282e898b83d74601
+  # - ROOT-6.26.10-foss-2022b.eb:
+  #     options:
+  #      # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21526
+  #      from-commit: 6cbfbd7d7a55dc7243f46d0beea510278f4718df
+  #      # see https://github.com/easybuilders/easybuild-easyblocks/pull/3467
+  #      include-easyblocks-from-commit: c3aebe1f133d064a228c5d6c282e898b83d74601

--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2022b.yml
@@ -35,3 +35,24 @@ easyconfigs:
 #  - HarfBuzz-5.3.1-GCCcore-12.2.0.eb
 ##  - Qt5-5.15.7-GCCcore-12.2.0.eb
 ##  - QuantumESPRESSO-7.2-foss-2022b.eb
+# Apps originaly added from gracehopper on https://github.com/EESSI/software-layer/pull/1031
+  - MUMPS-5.6.1-foss-2022b-metis.eb
+  - GL2PS-1.4.2-GCCcore-12.2.0.eb
+  - GST-plugins-base-1.22.1-GCC-12.2.0.eb
+  - wxWidgets-3.2.2.1-GCC-12.2.0.eb
+  - Archive-Zip-1.68-GCCcore-12.2.0.eb
+  - jemalloc-5.3.0-GCCcore-12.2.0.eb
+  - Judy-1.0.5-GCCcore-12.2.0.eb
+  - libaio-0.3.113-GCCcore-12.2.0.eb
+  - Z3-4.12.2-GCCcore-12.2.0.eb
+  - tbb-2021.10.0-GCCcore-12.2.0.eb
+  - dask-2023.7.1-foss-2022b.eb
+  - netcdf4-python-1.6.3-foss-2022b.eb
+  - Ruby-3.2.2-GCCcore-12.2.0.eb
+# originally built with EB 4.9.2; PR 21526 and PR 3467 included since EB 5.0.0, thus need to use *from-commit
+  - ROOT-6.26.10-foss-2022b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21526
+        from-commit: 6cbfbd7d7a55dc7243f46d0beea510278f4718df
+        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3467
+        include-easyblocks-from-commit: c3aebe1f133d064a228c5d6c282e898b83d74601


### PR DESCRIPTION
By mapping https://github.com/EESSI/software-layer/pull/1031 into a64fx