### PR TITLE
{2025.06}[system] M4 1.4.19

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.1-001-system.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.1-001-system.yml
@@ -1,0 +1,7 @@
+easyconfigs:
+  # note: M4 is only listed here because it's a build dependency for GCCcore,
+  #       but it was still filtered out as dependency when GCCcore/13.3.0 and GCCcore/14.2.0 got built;
+  #       now Autotools/Automake/libtool/M4 are retained as (build) dependency because the newer versions
+  #       in EESSI 2025.06 compat layer can cause problems with some installations (like OpenMPI);
+  #       see also https://github.com/EESSI/software-layer-scripts/pull/74
+  - M4-1.4.19.eb


### PR DESCRIPTION
To unbreak CI because `M4/1.4.19` (build) dependency for GCCcore installations is missing.

Required because of changes in:
- https://github.com/EESSI/software-layer-scripts/pull/74