### PR TITLE
{2023.06}[foss/2023a] GetOrganelle 1.7.7.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023a.yml
@@ -10,3 +10,4 @@ easyconfigs:
         # See https://github.com/easybuilders/easybuild-easyconfigs/pull/22932
         from-commit: 3211d34eb16ff31b8de3dfef55ecaaf1ec205c6f
   - MrBayes-3.2.7-gompi-2023a.eb
+  - GetOrganelle-1.7.7.1-foss-2023a.eb


### PR DESCRIPTION
```
4 out of 126 required modules missing:

* Bowtie2/2.5.1-GCC-12.3.0 (Bowtie2-2.5.1-GCC-12.3.0.eb)
* SPAdes/3.15.4-GCC-12.3.0 (SPAdes-3.15.4-GCC-12.3.0.eb)
* Bandage/0.9.0-GCCcore-12.3.0 (Bandage-0.9.0-GCCcore-12.3.0.eb)
* GetOrganelle/1.7.7.1-foss-2023a (GetOrganelle-1.7.7.1-foss-2023a.eb)
```