### PR TITLE
{2023.06}[gfbf/2023a] websockify 0.13.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023a.yml
@@ -10,7 +10,7 @@ easyconfigs:
         # See https://github.com/easybuilders/easybuild-easyconfigs/pull/22932
         from-commit: 3211d34eb16ff31b8de3dfef55ecaaf1ec205c6f
   - MrBayes-3.2.7-gompi-2023a.eb
-  - websockify-0.13.0-gfbf-2023a.eb
+  - websockify-0.13.0-gfbf-2023a.eb:
       options:
         # See https://github.com/easybuilders/easybuild-easyconfigs/pull/23596
         from-commit: daa610c5b3aaf43b80779805d85f13a1d5a8734e

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023a.yml
@@ -10,3 +10,7 @@ easyconfigs:
         # See https://github.com/easybuilders/easybuild-easyconfigs/pull/22932
         from-commit: 3211d34eb16ff31b8de3dfef55ecaaf1ec205c6f
   - MrBayes-3.2.7-gompi-2023a.eb
+  - websockify-0.13.0-gfbf-2023a.eb
+      options:
+        # See https://github.com/easybuilders/easybuild-easyconfigs/pull/23596
+        from-commit: daa610c5b3aaf43b80779805d85f13a1d5a8734e


### PR DESCRIPTION
```
3 out of 45 required modules missing:

* Redis/7.2.3-GCCcore-12.3.0 (Redis-7.2.3-GCCcore-12.3.0.eb)
* redis-py/5.0.1-GCCcore-12.3.0 (redis-py-5.0.1-GCCcore-12.3.0.eb)
* websockify/0.13.0-gfbf-2023a (websockify-0.13.0-gfbf-2023a.eb)
```