### PR TITLE
{2023.06}[2023a,a64fx} lit 18.1.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -298,3 +298,8 @@ easyconfigs:
   - Valgrind-3.21.0-gompi-2023a.eb
   - OrthoFinder-2.5.5-foss-2023a.eb
   - BWA-0.7.18-GCCcore-12.3.0.eb
+  - lit-18.1.2-GCCcore-12.3.0.eb
+      # needed due to changed/new dependencies for R-bundle-CRAN-2023.12-foss-2023a.eb
+      # without any from-commit this will use a version from April 6, 2024
+      # https://github.com/easybuilders/easybuild-easyconfigs/blob/88f6f9c7439c535e62461e6e71b1961c7be118b8/easybuild/easyconfigs/l/lit/lit-18.1.2-GCCcore-12.3.0.eb
+      # EB 5.0.0 has a few changes to that


### PR DESCRIPTION
Built in the same way as for the other targets, see https://github.com/EESSI/software-layer/blob/main/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-2023a.yml#L57.

Many other builds are failing in the check missing installations step, because this dependency is missing, e.g. the Flye build in #1179:
```
1 out of 61 required modules missing:

* lit/18.1.2-GCCcore-12.3.0 (lit-18.1.2-GCCcore-12.3.0.eb)
```