### PR TITLE
{2023.06}[gfbf/2023a,gfbf/2023b] MLflow 2.10.2, MLflow 2.18.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023a.yml
@@ -15,3 +15,4 @@ easyconfigs:
       options:
         # See https://github.com/easybuilders/easybuild-easyconfigs/pull/23596
         from-commit: daa610c5b3aaf43b80779805d85f13a1d5a8734e
+  - MLflow-2.10.2-gfbf-2023a.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023b.yml
@@ -3,3 +3,4 @@ easyconfigs:
   - libheif-1.19.5-GCCcore-13.2.0.eb
   - Subread-2.1.1-GCC-13.2.0.eb
   - Flye-2.9.4-GCC-13.2.0.eb
+  - MLflow-2.18.0-gfbf-2023b.eb


### PR DESCRIPTION
```
2 out of 90 required modules missing:

* Flask/2.3.3-GCCcore-12.3.0 (Flask-2.3.3-GCCcore-12.3.0.eb)
* MLflow/2.10.2-gfbf-2023a (MLflow-2.10.2-gfbf-2023a.eb)
```
```
11 out of 94 required modules missing:

* GitPython/3.1.42-GCCcore-13.2.0 (GitPython-3.1.42-GCCcore-13.2.0.eb)
* Greenlet/3.0.3-GCCcore-13.2.0 (Greenlet-3.0.3-GCCcore-13.2.0.eb)
* Flask/3.0.0-GCCcore-13.2.0 (Flask-3.0.0-GCCcore-13.2.0.eb)
* protobuf/25.3-GCCcore-13.2.0 (protobuf-25.3-GCCcore-13.2.0.eb)
* protobuf-python/4.25.3-GCCcore-13.2.0 (protobuf-python-4.25.3-GCCcore-13.2.0.eb)
* Markdown/3.6-GCCcore-13.2.0 (Markdown-3.6-GCCcore-13.2.0.eb)
* psycopg/3.1.18-GCCcore-13.2.0 (psycopg-3.1.18-GCCcore-13.2.0.eb)
* SQLAlchemy/2.0.29-GCCcore-13.2.0 (SQLAlchemy-2.0.29-GCCcore-13.2.0.eb)
* wrapt/1.16.0-GCCcore-13.2.0 (wrapt-1.16.0-GCCcore-13.2.0.eb)
* Deprecated/1.2.14-GCCcore-13.2.0 (Deprecated-1.2.14-GCCcore-13.2.0.eb)
* MLflow/2.18.0-gfbf-2023b (MLflow-2.18.0-gfbf-2023b.eb)
```