### PR TITLE
{2023.06}[a64fx] Rebuild Python with `ctypes` fix

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20250912-eb-4.9.2-Python-ctypes-a64fx.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20250912-eb-4.9.2-Python-ctypes-a64fx.yml
@@ -1,0 +1,20 @@
+# 2025.09.12
+# Python ctypes relies on LD_LIBRARY_PATH and doesn't respect rpath linking. There is a workaround
+# for the EasyBuild context in https://github.com/easybuilders/easybuild-easyblocks/pull/3352.
+#
+# This rebuild ensures this fix is available for all Python versions shipped with EESSI.
+# 
+# See https://gitlab.com/eessi/support/-/issues/77
+easyconfigs:
+  - Python-3.10.8-GCCcore-12.2.0-bare:
+      options:
+        # See https://github.com/easybuilders/easybuild-easyblocks/pull/3352
+        include-easyblocks-from-commit: 1ee17c0f7726c69e97442f53c65c5f041d65c94f
+  - Python-3.11.3-GCCcore-12.3.0:
+      options:
+        # See https://github.com/easybuilders/easybuild-easyblocks/pull/3352
+        include-easyblocks-from-commit: 1ee17c0f7726c69e97442f53c65c5f041d65c94f
+  - Python-3.11.5-GCCcore-13.2.0:
+      options:
+        # See https://github.com/easybuilders/easybuild-easyblocks/pull/3352
+        include-easyblocks-from-commit: 1ee17c0f7726c69e97442f53c65c5f041d65c94f


### PR DESCRIPTION
Based on https://github.com/EESSI/software-layer/pull/655. Should solve the issue observed in https://github.com/EESSI/software-layer/pull/1188#issuecomment-3275422017.