### PR TITLE
{2023.06}[2023b,a64fx] MLflow 2.18.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-5.1.1-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-5.1.1-2023b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - MLflow-2.18.0-gfbf-2023b.eb


### PR DESCRIPTION
This failed to build for a64fx in https://github.com/EESSI/software-layer/pull/1188, but https://github.com/EESSI/software-layer/pull/1191 should have solved the issue.