### PR TITLE
{2023.06}[foss/2023b] snakemake v8.28.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023b.yml
@@ -4,7 +4,7 @@ easyconfigs:
   - Subread-2.1.1-GCC-13.2.0.eb
   - Flye-2.9.4-GCC-13.2.0.eb
   - MLflow-2.18.0-gfbf-2023b.eb
-  - snakemake-8.28.0-foss-2023b.eb
+  - snakemake-8.28.0-foss-2023b.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22371
         from-commit: 29f82e43229663c22f0c76cb3fc7b6dd5c407cd7


### PR DESCRIPTION
missing packages:
```
Cbc/2.10.11-foss-2023b
Cgl/0.60.8-foss-2023b
Clp/1.17.9-foss-2023b
CoinUtils/2.11.10-GCC-13.2.0
Osi/0.108.9-GCC-13.2.0
PuLP/2.8.0-foss-2023b
snakemake/8.28.0-foss-2023b
```