### PR TITLE
{2025.06}[2024a] ollama 0.6.0

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.1-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.1-2024a.yml
@@ -2,3 +2,4 @@ easyconfigs:
   - GCC-13.3.0.eb
   - gfbf-2024a.eb
   - FFTW-3.3.10-GCC-13.3.0
+  - ollama-0.6.0-GCCcore-13.3.0.eb


### PR DESCRIPTION
```
2 out of 10 required modules missing:

* Go/1.23.6 (Go-1.23.6.eb)
* ollama/0.6.0-GCCcore-13.3.0 (ollama-0.6.0-GCCcore-13.3.0.eb)
```