### PR TITLE
{2023.06}[2023b] RAxML 8.2.13

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023b.yml
@@ -8,8 +8,3 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22371
         from-commit: 29f82e43229663c22f0c76cb3fc7b6dd5c407cd7
-  - RAxML-8.2.13-gompi-2023b.eb:
-      options:
-        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/23975
-        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24627
-        from-commit: b1f428cb3d93eb8be2f6dce1494b23713daa3ecd

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023b.yml
@@ -51,3 +51,8 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24490
         from-commit: c9c20b479dc9220724f0c38f980a372413d0c5ed
+  - RAxML-8.2.13-gompi-2023b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/23975
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24627
+        from-commit: b1f428cb3d93eb8be2f6dce1494b23713daa3ecd


### PR DESCRIPTION
```
1 out of 19 required modules missing:

* RAxML/8.2.13-gompi-2023b-avx2 (RAxML-8.2.13-gompi-2023b-avx2.eb)
```