### PR TITLE
{2023.06}[2022] Rust 1.75.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2022b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - Rust-1.75.0-GCCcore-12.2.0.eb


### PR DESCRIPTION
This adds Rust 1.75.0 for the 2022b toolchain. We already have 1.65.0, but that version does not build on A64FX. https://github.com/EESSI/software-layer-scripts/pull/86 adds a hook that will bump any build dependency on 1.65.0 to 1.75.0 for A64FX builds.