### PR TITLE
{2023.06}[foss/2023a] WebKitGTK+ v2.41.4

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.1-2023a.yml
@@ -17,3 +17,4 @@ easyconfigs:
         from-commit: daa610c5b3aaf43b80779805d85f13a1d5a8734e
   - MLflow-2.10.2-gfbf-2023a.eb
   - Salmon-1.10.3-GCC-12.3.0.eb
+  - WebKitGTK+-2.41.4-foss-2023a.eb


### PR DESCRIPTION
missing packages:
```
c-ares/1.19.1-GCCcore-12.3.0
CUnit/2.1-3-GCCcore-12.3.0
enchant-2/2.6.5-GCCcore-12.3.0
gc/8.2.4-GCCcore-12.3.0
glew/2.2.0-GCCcore-12.3.0-osmesa
glib-networking/2.72.1-GCCcore-12.3.0
GnuTLS/3.7.8-GCCcore-12.3.0
Guile/3.0.9-GCCcore-12.3.0
hunspell/1.7.2-GCCcore-12.3.0
Jansson/2.14-GCC-12.3.0
libavif/1.0.4-GCCcore-12.3.0
libev/4.33-GCC-12.3.0
libpsl/0.21.5-GCCcore-12.3.0
LibSoup/3.6.1-GCC-12.3.0
libtasn1/4.19.0-GCCcore-12.3.0
libunistring/1.1-GCCcore-12.3.0
libwpe/1.16.0-GCCcore-12.3.0
nghttp2/1.58.0-GCC-12.3.0
nghttp3/1.3.0-GCCcore-12.3.0
ngtcp2/1.2.0-GCC-12.3.0
p11-kit/0.25.3-GCCcore-12.3.0
pkg-config/0.29.2-GCCcore-12.3.0
pugixml/1.14-GCCcore-12.3.0
unifdef/2.12-GCCcore-12.3.0
Waylandpp/1.0.0-GCCcore-12.3.0
WebKitGTK+/2.41.4-foss-2023a
wpebackend-fdo/1.15.90-GCCcore-12.3.0
```