### PR TITLE
{2023.06}[2022b,a64fx] Dependencies of Qt5

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -1,0 +1,16 @@
+easyconfigs:
+  # dependencies of Qt5
+  - re2c-3.0-GCCcore-12.2.0.eb
+  - Python-2.7.18-GCCcore-12.2.0-bare.eb
+  - graphite2-1.3.14-GCCcore-12.2.0.eb
+  - double-conversion-3.2.1-GCCcore-12.2.0.eb
+  - Mako-1.2.4-GCCcore-12.2.0.eb
+  - libjpeg-turbo-2.1.4-GCCcore-12.2.0.eb
+  - snappy-1.1.9-GCCcore-12.2.0.eb
+  - libdrm-2.4.114-GCCcore-12.2.0.eb
+  - NSS-3.85-GCCcore-12.2.0.eb
+  - JasPer-4.0.0-GCCcore-12.2.0.eb
+  - libglvnd-1.6.0-GCCcore-12.2.0.eb
+  - nodejs-18.12.1-GCCcore-12.2.0.eb
+  - libunwind-1.6.2-GCCcore-12.2.0.eb
+  - lit-18.1.7-GCCcore-12.2.0.eb

--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -13,4 +13,3 @@ easyconfigs:
   - libglvnd-1.6.0-GCCcore-12.2.0.eb
   - nodejs-18.12.1-GCCcore-12.2.0.eb
   - libunwind-1.6.2-GCCcore-12.2.0.eb
-  - lit-18.1.7-GCCcore-12.2.0.eb


### PR DESCRIPTION
Forked off from #1177. LLVM has build issues, but the dependencies in this PR should build without issues.