### PR TITLE
{2023.06}[a64fx,2022b] Rust 1.65.0 

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2022b.yml
@@ -56,3 +56,4 @@ easyconfigs:
   #      from-commit: 6cbfbd7d7a55dc7243f46d0beea510278f4718df
   #      # see https://github.com/easybuilders/easybuild-easyblocks/pull/3467
   #      include-easyblocks-from-commit: c3aebe1f133d064a228c5d6c282e898b83d74601
+  - Rust-1.65.0-GCCcore-12.2.0.eb


### PR DESCRIPTION
This should just build a module file with an LmodError (see https://github.com/EESSI/software-layer-scripts/pull/91), as we implemented a hook that will replace dependencies on this version by 1.75.0. 