### PR TITLE
{2023.06}[foss/2023a] GRASS v8.4.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - GRASS-8.4.0-foss-2023a.eb


### PR DESCRIPTION
missing packages:
```
minizip/1.1-GCCcore-12.3.0 
FreeXL/2.0.0-GCCcore-12.3.0 
librttopo/1.1.0-GCC-12.3.0 
libspatialite/5.1.0-GCC-12.3.0 
attrdict3/2.0.2-GCCcore-12.3.0 
PDAL/2.8.2-foss-2023a 
wxPython/4.2.1-foss-2023a
GRASS/8.4.0-foss-2023a 
```