### PR TITLE
{2025.06}[2024a] MetaBAT 2.17

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.1-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.1-2024a.yml
@@ -5,3 +5,5 @@ easyconfigs:
   - OpenMPI-5.0.3-GCC-13.3.0.eb
   - foss-2024a.eb
   - ollama-0.6.0-GCCcore-13.3.0.eb
+  - MetaBAT-2.17-GCC-13.3.0.eb
+


### PR DESCRIPTION
```
7 out of 23 required modules missing:

* gzip/1.13-GCCcore-13.3.0 (gzip-1.13-GCCcore-13.3.0.eb)
* HTSlib/1.21-GCC-13.3.0 (HTSlib-1.21-GCC-13.3.0.eb)
* lz4/1.9.4-GCCcore-13.3.0 (lz4-1.9.4-GCCcore-13.3.0.eb)
* zstd/1.5.6-GCCcore-13.3.0 (zstd-1.5.6-GCCcore-13.3.0.eb)
* ICU/75.1-GCCcore-13.3.0 (ICU-75.1-GCCcore-13.3.0.eb)
* Boost/1.85.0-GCC-13.3.0 (Boost-1.85.0-GCC-13.3.0.eb)
* MetaBAT/2.17-GCC-13.3.0 (MetaBAT-2.17-GCC-13.3.0.eb)
```