### PR TITLE
{2023.06}[2022b, a64fx] LLVM 15.0.5

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -13,3 +13,4 @@ easyconfigs:
   - libglvnd-1.6.0-GCCcore-12.2.0.eb
   - nodejs-18.12.1-GCCcore-12.2.0.eb
   - libunwind-1.6.2-GCCcore-12.2.0.eb
+  - LLVM-15.0.5-GCCcore-12.2.0.eb


### PR DESCRIPTION
Required https://github.com/EESSI/software-layer-scripts/pull/97 to be ingested.