### PR TITLE
{2023.06}[2022b,a64fx] SciPy-bundle 2023.02 and Highway 1.0.3

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2022b.yml
@@ -56,4 +56,17 @@ easyconfigs:
   #      from-commit: 6cbfbd7d7a55dc7243f46d0beea510278f4718df
   #      # see https://github.com/easybuilders/easybuild-easyblocks/pull/3467
   #      include-easyblocks-from-commit: c3aebe1f133d064a228c5d6c282e898b83d74601
+
+## from here on built originally with EB 4.9.0
+# includes dependencies Boost/1.81.0 and Boost.MPI/1.81.0 for which we have to
+# use updated easyconfigs (via from-commit) because the download URLs have
+# changed
+#
+# originally built with EB 4.9.0, PR 20298 was included since 4.9.2 and no more
+# updates to it since then
+#  - Highway-1.0.3-GCCcore-12.2.0.eb:
+#      options:
+#        from-pr: 20298
+  - Highway-1.0.3-GCCcore-12.2.0.eb
+  - SciPy-bundle-2023.02-gfbf-2022b.eb
   - Rust-1.65.0-GCCcore-12.2.0.eb


### PR DESCRIPTION
Split off from https://github.com/EESSI/software-layer/pull/1187, shouldn't have any overlapping deps with https://github.com/EESSI/software-layer/pull/1177. SciPy-bundle test issues were fixed in https://github.com/EESSI/software-layer-scripts/pull/100.