### PR TITLE
{2023.06}[2022b,a64fx] QuantumESPRESSO 7.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -13,3 +13,4 @@ easyconfigs:
   - libglvnd-1.6.0-GCCcore-12.2.0.eb
   - nodejs-18.12.1-GCCcore-12.2.0.eb
   - libunwind-1.6.2-GCCcore-12.2.0.eb
+  - QuantumESPRESSO-7.2-foss-2022b.eb


### PR DESCRIPTION
Build failed in https://github.com/EESSI/software-layer/pull/1177 due to missing libxc sources, I've uploaded those to the bot account.