### PR TITLE
 {2023.06}[2023a,a64fx] apps originally built with EB 4.9.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -392,7 +392,7 @@ easyconfigs:
 #      options:
 #        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21155
 #        from-commit: 6929a67401f2a2ec58f91fb306332a77497d73ff
-  - MBX-1.1.0-foss-2023a.eb
+#  - MBX-1.1.0-foss-2023a.eb
 # PRs 20964 and 3381 are included since EB 4.9.3
 #  - Transrate-1.0.3-GCC-12.3.0.eb:
 #      options:
@@ -400,22 +400,22 @@ easyconfigs:
 #        include-easyblocks-from-commit: bb86f05d4917b29e022023f152efdf0ca5c14ded
 #        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20964
 #        from-commit: 7d539a9e599d8bc5ac2bda6ee9587ef62351ee03
-  - Transrate-1.0.3-GCC-12.3.0.eb
+#  - Transrate-1.0.3-GCC-12.3.0.eb
 # PR 20833 is included since EB 4.9.3
 #  - Critic2-1.2-foss-2023a.eb:
 #      options:
 #        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20833
 #        from-commit: 78426c2383fc7e4b9b9e77d7a77f336e1bee3843
-  - Critic2-1.2-foss-2023a.eb
+#  - Critic2-1.2-foss-2023a.eb
 # PR 21310 is included since EB 4.9.3
 #  - LRBinner-0.1-foss-2023a.eb:
 #      options:
 #        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21310
 #        from-commit: 799d9101df2cf81aabe252f00cc82a7246363f53
-  - LRBinner-0.1-foss-2023a.eb
+#  - LRBinner-0.1-foss-2023a.eb
 # PR 21227 is included since EB 4.9.3
 #  - Redland-1.0.17-GCC-12.3.0.eb:
 #      options:
 #        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21227
 #        from-commit: 4c5e3455dec31e68e8383c7fd86d1f80c434676d
-  - Redland-1.0.17-GCC-12.3.0.eb
+#  - Redland-1.0.17-GCC-12.3.0.eb


### PR DESCRIPTION
Split off from https://github.com/EESSI/software-layer/pull/1091.