### PR TITLE
enable "compare stacks" CI for A64FX

### DIFF
--- a/.github/workflows/test_compare_stacks.yml
+++ b/.github/workflows/test_compare_stacks.yml
@@ -41,9 +41,10 @@ jobs:
         - x86_64/intel/sapphirerapids
         - x86_64/intel/icelake
         - x86_64/intel/cascadelake
-        exclude:
-        - EESSI_VERSION: 2023.06
-          COMPARISON_ARCH: aarch64/a64fx
+        # Example of how a specific target can be excluded:
+        # exclude:
+        # - EESSI_VERSION: 2023.06
+        #   COMPARISON_ARCH: aarch64/a64fx
     steps:
         - name: Check out software-layer repository
           uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
We're at ~77% now (836/1089). The CI will obviously still fail, but can be used to find out what's still missing/ I've left the original code as comments, figured that they could serve as an example for excluding targets.