### PR TITLE
{2023.06}[2023a,a64fx] Rebuild Perl-bundle-CPAN 5.36.1 for A64FX

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20251009-eb-4.9.2-Perl-bundle-CPAN-5.36.1-sync-exts-a64fx.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20251009-eb-4.9.2-Perl-bundle-CPAN-5.36.1-sync-exts-a64fx.yml
@@ -1,0 +1,6 @@
+# 2025.10.08
+# Rebuild Perl-bundle-CPAN 5.36.1 with the same EB version
+# that was used for other CPU targets. The currently installed version
+# is built with EB 5.1.2 and includes more extensions.
+easyconfigs:
+  - Perl-bundle-CPAN-5.36.1-GCCcore-12.3.0.eb


### PR DESCRIPTION
The currently installed version for A64FX includes more extensions than the ones installed for the other targets.