### PR TITLE
{2023.06}[2023b,a64fx] Rebuild openCARP 17.0 and some of its dependencies for A64FX to disable ParMETIS support

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20251008-eb-5.1.1-openCARP-17.0-and-deps-without-ParMETIS-a64fx.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20251008-eb-5.1.1-openCARP-17.0-and-deps-without-ParMETIS-a64fx.yml
@@ -1,0 +1,10 @@
+# 2025.10.08
+# 
+# The openCARP 17.0 installation for A64FX was built with ParMETIS support (because it had an outdated EESSI-extend at the time of building),
+# while it was disabled for the other targets.
+# This rebuild will make sure that openCARP and its dependencies PETSc and SuperLU_DIST  get built without ParMETIS support,
+# and will allow us to remove ParMETIS from the A64FX stack.
+easyconfigs:
+  - SuperLU_DIST-8.2.1-foss-2023b.eb
+  - PETSc-3.22.5-foss-2023b.eb
+  - openCARP-17.0-foss-2023b.eb


### PR DESCRIPTION
This was built with ParMETIS support due to an outdated EESSI-extend, see https://github.com/EESSI/software-layer/pull/1118#issuecomment-3053946045.