### PR TITLE
{2023.06}[2022b,a64fx] R 4.2.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2022b.yml
@@ -106,4 +106,4 @@ easyconfigs:
 #  - R-4.2.2-foss-2022b.eb:
 #      options:
 #        from-pr: 20238
-#  - R-4.2.2-foss-2022b.eb
+  - R-4.2.2-foss-2022b.eb


### PR DESCRIPTION
This was disabled in https://github.com/EESSI/software-layer/pull/1187 because the build took too long.