### PR TITLE
{2023.06}[2023a,a64fx] apps originally built with EB 4.9.2 - QuantumESPRESSO 7.3.1 and CP2K 2023.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -335,3 +335,17 @@ easyconfigs:
   - MAFFT-7.520-GCC-12.3.0-with-extensions.eb
   - ncbi-vdb-3.0.10-gompi-2023a.eb
   - MetalWalls-21.06.1-foss-2023a.eb
+# PRs 20138 and 3338 were included since EB 4.9.3
+#  - QuantumESPRESSO-7.3.1-foss-2023a.eb:
+#      options:
+#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20138
+#        from-commit: dbdaacc0739fdee91baa9123864ea4428cf21273
+#        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3338
+#        include-easyblocks-from-commit: 32e45bd1f2d916732ca5852d55d17fa4d99e388b
+  - QuantumESPRESSO-7.3.1-foss-2023a.eb
+# PR 20951 is included since EB 4.9.3
+#  - CP2K-2023.1-foss-2023a.eb:
+#      options:
+#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20951
+#        from-commit: a92667fe32396bbd4106243658625f7ff2adcd68
+  - CP2K-2023.1-foss-2023a.eb


### PR DESCRIPTION
Split off from https://github.com/EESSI/software-layer/pull/1091 and https://github.com/EESSI/software-layer/pull/1220. These take almost 20 hours to complete, should work when https://github.com/EESSI/software-layer-scripts/pull/106 is merged.