### PR TITLE
{2025.06}[2024a] TurboVNC 3.1.2

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
@@ -17,4 +17,4 @@ easyconfigs:
   - TurboVNC-3.1.2-GCCcore-13.3.0.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24254
-        from-commit: 40e90f63163a40c8695160f7c5b79a107a176630
+        from-commit: d71be56f713ea6434fecca5caee3c43443d05b93


### PR DESCRIPTION
This is not so useful until we have a window manager that we can start up for vnc