### PR TITLE
{2023.06}[2022b,a64fx] R-bundle-Bioconductor 3.16

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2022b.yml
@@ -107,3 +107,11 @@ easyconfigs:
 #      options:
 #        from-pr: 20238
   - R-4.2.2-foss-2022b.eb
+# from here on built originally with EB 4.9.1
+# originally built with EB 4.9.1, PR 20379 was included since 4.9.2; no more
+# updates to the easyconfig since then
+#  - R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb:
+#      options:
+#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20379
+#        from-pr: 20379
+  - R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb


### PR DESCRIPTION
Based on how it was done for Grace: https://github.com/EESSI/software-layer/pull/1026

```
6 out of 147 required modules missing:

* RapidJSON/1.1.0-GCCcore-12.2.0 (RapidJSON-1.1.0-GCCcore-12.2.0.eb)
* RE2/2023-03-01-GCCcore-12.2.0 (RE2-2023-03-01-GCCcore-12.2.0.eb)
* utf8proc/2.8.0-GCCcore-12.2.0 (utf8proc-2.8.0-GCCcore-12.2.0.eb)
* Arrow/11.0.0-gfbf-2022b (Arrow-11.0.0-gfbf-2022b.eb)
* arrow-R/11.0.0.3-foss-2022b-R-4.2.2 (arrow-R-11.0.0.3-foss-2022b-R-4.2.2.eb)
* R-bundle-Bioconductor/3.16-foss-2022b-R-4.2.2 (R-bundle-Bioconductor-3.16-foss-2022b-R-4.2.2.eb)
```