### PR TITLE
{2023.06}[2023a,a64fx] add remaining apps for EB 4.9.4 easystack

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023a.yml
@@ -419,3 +419,72 @@ easyconfigs:
 #        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21227
 #        from-commit: 4c5e3455dec31e68e8383c7fd86d1f80c434676d
   - Redland-1.0.17-GCC-12.3.0.eb
+  - ccache-4.9-GCCcore-12.3.0.eb
+  - GDB-13.2-GCCcore-12.3.0.eb
+  - tmux-3.3a-GCCcore-12.3.0.eb
+  - Vim-9.1.0004-GCCcore-12.3.0.eb
+  - gmsh-4.12.2-foss-2023a.eb
+  - basemap-1.3.9-foss-2023a.eb
+  - geopandas-0.14.2-foss-2023a.eb
+  - archspec-0.2.1-GCCcore-12.3.0.eb
+  - ROOT-6.30.06-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21526
+        from-commit: 6cbfbd7d7a55dc7243f46d0beea510278f4718df
+        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3467
+        include-easyblocks-from-commit: c3aebe1f133d064a228c5d6c282e898b83d74601
+  - waLBerla-6.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21600
+        from-commit: 9b12318bcff1749781d9eb71c23e21bc3a79ed01
+  - mpl-ascii-0.10.0-gfbf-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21679
+        from-commit: 7106f63160b1418d605882dd02ba151d099300bd
+  - jedi-0.19.0-GCCcore-12.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21650
+        from-commit: 109998f6adcda7efb4174b1e5f73b41ee82d1f13
+  - Solids4foam-2.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21606
+        from-commit: 63562c58acf1be64407192b6862c3bd80253d2e0
+  - Cassiopeia-2.0.0-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21657
+        from-commit: 7f1f0e60487e7e1fcb5c4e6bc4fbc4f89994e3fd
+  - LightGBM-4.5.0-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21699
+        from-commit: e3407bd127d248c08960f6b09c973da0fdecc2c3
+  - OpenFOAM-v2406-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyblocks/pull/3519
+        include-easyblocks-from-commit: e4a3ff1932350d575dffc7597435609fad6dd691
+  - Paraver-4.11.4-GCC-12.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20230
+        from-commit: 91c8df6b4c0810061e9f325427c9c79e961bc4b0
+  - Tombo-1.5.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/21925
+        from-commit: 522ca010ab11949ab9594037f72b975cf1cd0d33
+  - elfx86exts-0.6.2-GCC-12.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22145
+        from-commit: 31478e5c9869de3add74d0a02dd5df01ea65b21e
+  - archspec-0.2.5-GCCcore-12.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22235
+        from-commit: 01dd97ea62fe4d7d0df040ede3af03eb2f1b8641
+  - GDRCopy-2.3.1-GCCcore-12.3.0.eb 
+  - OpenCV-4.8.1-foss-2023a-contrib.eb
+  - FALL3D-9.0.1-gompi-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22610
+        from-commit: 10e47e2fdd4f23fd5a52ae167771f8e9c78da411
+  - lit-18.1.2-GCCcore-12.3.0.eb
+      # needed due to changed/new dependencies for R-bundle-CRAN-2023.12-foss-2023a.eb
+      # without any from-commit this will use a version from April 6, 2024
+      # https://github.com/easybuilders/easybuild-easyconfigs/blob/88f6f9c7439c535e62461e6e71b1961c7be118b8/easybuild/easyconfigs/l/lit/lit-18.1.2-GCCcore-12.3.0.eb
+      # EB 5.0.0 has a few changes to that


### PR DESCRIPTION
Based on the `grace` easystack, see https://github.com/EESSI/software-layer/blob/main/easystacks/software.eessi.io/2023.06/grace/eessi-2023.06-eb-4.9.4-2023a.yml#L141. Added the remaining ones, except R-bundle-CRAN, which was already done.

Let's see how far we get... :crossed_fingers: 