### PR TITLE
{2023.06}[2023b,a64fx] networkx 3.2.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.9.4-2023b.yml
@@ -99,7 +99,8 @@ easyconfigs:
 #      options:
 #        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/20522
 #        from-commit: a0a467a88506c765a93a96b20d7a8fcb01d46b24
-# SOME TEST FAILED, so we skip it here
+# SOME TEST FAILED, so we skip it here, do build its dependency networkx
+  - networkx-3.2.1-gfbf-2023b.eb
 #  - GROMACS-2024.1-foss-2023b.eb
   - NLTK-3.8.1-foss-2023b.eb
 # originally built with EB 4.9.1, PR 20792 was included since EB 4.9.2


### PR DESCRIPTION
Dependency of the GROMACS installations (which are still missing due to failing test(s)).