### PR TITLE
{2023.06}[2023a,a64fx] add apps built with EB 5.1.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-5.1.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-5.1.0-2023a.yml
@@ -4,6 +4,8 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/23068
         from-commit: 644b17f1b42bbf8eb4ad56d9e8f125b8c52d7258
+        # use the same list of filtered dependencies as was used for other CPU targets (in particular: without ParMETIS)
+        filter-deps: Autoconf,Automake,Autotools,binutils,bzip2,DBus,flex,gettext,gperf,help2man,intltool,libreadline,libtool,M4,makeinfo,ncurses,util-linux,XZ,zlib,Yasm
   - OpenFOAM-12-foss-2023a.eb
   - MEGAHIT-1.2.9-GCCcore-12.3.0.eb:
       options:


### PR DESCRIPTION
```
1 out of 38 required modules missing:

* Zoltan/3.901-foss-2023a (Zoltan-3.901-foss-2023a.eb)


2 out of 115 required modules missing:

* Zoltan/3.901-foss-2023a (Zoltan-3.901-foss-2023a.eb)
* OpenFOAM/12-foss-2023a (OpenFOAM-12-foss-2023a.eb)


1 out of 14 required modules missing:

* MEGAHIT/1.2.9-GCCcore-12.3.0 (MEGAHIT-1.2.9-GCCcore-12.3.0.eb)


9 out of 198 required modules missing:

* dm-tree/0.1.8-GCCcore-12.3.0 (dm-tree-0.1.8-GCCcore-12.3.0.eb)
* biom-format/2.1.15-foss-2023a (biom-format-2.1.15-foss-2023a.eb)
* umap-learn/0.5.5-foss-2023a (umap-learn-0.5.5-foss-2023a.eb)
* anndata/0.10.5.post1-foss-2023a (anndata-0.10.5.post1-foss-2023a.eb)
* scikit-bio/0.6.0-foss-2023a (scikit-bio-0.6.0-foss-2023a.eb)
* ArviZ/0.16.1-foss-2023a (ArviZ-0.16.1-foss-2023a.eb)
* scanpy/1.9.8-foss-2023a (scanpy-1.9.8-foss-2023a.eb)
* tensorflow-probability/0.20.0-foss-2023a (tensorflow-probability-0.20.0-foss-2023a.eb)
* scCODA/0.1.9-foss-2023a (scCODA-0.1.9-foss-2023a.eb)


1 out of 13 required modules missing:

* Bazel/6.1.0-GCCcore-12.3.0 (Bazel-6.1.0-GCCcore-12.3.0.eb)


1 out of 42 required modules missing:

* ml_dtypes/0.3.2-gfbf-2023a (ml_dtypes-0.3.2-gfbf-2023a.eb)


1 out of 47 required modules missing:

* tensorboard/2.15.1-gfbf-2023a (tensorboard-2.15.1-gfbf-2023a.eb)
```