### PR TITLE
{2023.06} Rebuild Python 3.10.8 for ctypes fix

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20251016-eb-5.1.2-Python-ctypes-improved-patch.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20251016-eb-5.1.2-Python-ctypes-improved-patch.yml
@@ -1,0 +1,24 @@
+# 2025.10.16
+# Python ctypes relies on LD_LIBRARY_PATH and doesn't respect rpath linking. A prior workaround
+# was implemented in EasyBuild in https://github.com/easybuilders/easybuild-easyblocks/pull/3352.
+# However, while this fixed ctypes.util.find_library(), a similar issue popped up in ctypes.CLL
+# and ctypes.cdll.LoadLibrary https://gitlab.com/eessi/support/-/issues/154
+# An easyblock change and patch were implemented for Python.
+#
+# This rebuild ensures this fix is available for all Python versions shipped with EESSI that are supported on
+# all architectures, including zen4.
+easyconfigs:
+  - Python-3.11.3-GCCcore-12.3.0:
+      options:
+        # See https://github.com/easybuilders/easybuild-easyblocks/pull/3860
+        # and https://github.com/easybuilders/easybuild-easyblocks/pull/3965
+        include-easyblocks-from-commit: 3fa0df7414d7d8415fe34f7758649f966322472e
+        # See https://github.com/easybuilders/easybuild-easyconfigs/pull/23499
+        from-commit: 08aa521b52c9f83d8df345d083e46d6f304d5641
+  - Python-3.11.5-GCCcore-13.2.0:
+      options:
+        # See https://github.com/easybuilders/easybuild-easyblocks/pull/3860
+        # and https://github.com/easybuilders/easybuild-easyblocks/pull/3965
+        include-easyblocks-from-commit: 3fa0df7414d7d8415fe34f7758649f966322472e
+        # See https://github.com/easybuilders/easybuild-easyconfigs/pull/23499
+        from-commit: 08aa521b52c9f83d8df345d083e46d6f304d5641


### PR DESCRIPTION
This should be rebuild on all archs except `zen4`, where GCCcore-12.2.0 isn't supported (and where the `--module-only` rebuild for some reason gives issues, see https://github.com/EESSI/software-layer/pull/1238#issuecomment-3422629864).