### PR TITLE
{2023.06}[2023b] Ruby 3.4.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023b.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - tblite-0.4.0-gfbf-2023b.eb
+  - Ruby-3.4.2-GCCcore-13.2.0.eb


### PR DESCRIPTION
Main motivation for this is checking whether we see the same segfault problem as with older Ruby versions for `aarch64/*` CPU targets, see https://gitlab.com/eessi/support/-/issues/197