### PR TITLE
{2025.06}[2024a] Various dependencies for Qt6

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
@@ -14,3 +14,12 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24186
         from-commit: 7b34eae4ec75e83e13c069203ab6be709da97a96
+  - re2c-3.1-GCCcore-13.3.0.eb 
+  - libwebp-1.4.0-GCCcore-13.3.0.eb
+  - graphite2-1.3.14-GCCcore-13.3.0.eb
+  - assimp-5.4.3-GCCcore-13.3.0.eb
+  - FFmpeg-7.0.2-GCCcore-13.3.0.eb
+  - JasPer-4.2.4-GCCcore-13.3.0.eb
+  - snappy-1.2.1-GCCcore-13.3.0.eb
+  - NSS-3.104-GCCcore-13.3.0.eb
+  - nodejs-20.13.1-GCCcore-13.3.0.eb


### PR DESCRIPTION
```
21 out of 70 required modules missing:

* ffnvcodec/12.2.72.0 (ffnvcodec-12.2.72.0.eb)
* NSPR/4.35-GCCcore-13.3.0 (NSPR-4.35-GCCcore-13.3.0.eb)
* x264/20240513-GCCcore-13.3.0 (x264-20240513-GCCcore-13.3.0.eb)
* NSS/3.104-GCCcore-13.3.0 (NSS-3.104-GCCcore-13.3.0.eb)
* giflib/5.2.1-GCCcore-13.3.0 (giflib-5.2.1-GCCcore-13.3.0.eb)
* re2c/3.1-GCCcore-13.3.0 (re2c-3.1-GCCcore-13.3.0.eb)
* nodejs/20.13.1-GCCcore-13.3.0 (nodejs-20.13.1-GCCcore-13.3.0.eb)
* Yasm/1.3.0-GCCcore-13.3.0 (Yasm-1.3.0-GCCcore-13.3.0.eb)
* libde265/1.0.15-GCCcore-13.3.0 (libde265-1.0.15-GCCcore-13.3.0.eb)
* x265/3.6-GCCcore-13.3.0 (x265-3.6-GCCcore-13.3.0.eb)
* graphite2/1.3.14-GCCcore-13.3.0 (graphite2-1.3.14-GCCcore-13.3.0.eb)
* assimp/5.4.3-GCCcore-13.3.0 (assimp-5.4.3-GCCcore-13.3.0.eb)
* snappy/1.2.1-GCCcore-13.3.0 (snappy-1.2.1-GCCcore-13.3.0.eb)
* double-conversion/3.3.0-GCCcore-13.3.0 (double-conversion-3.3.0-GCCcore-13.3.0.eb)
* libwebp/1.4.0-GCCcore-13.3.0 (libwebp-1.4.0-GCCcore-13.3.0.eb)
* LAME/3.100-GCCcore-13.3.0 (LAME-3.100-GCCcore-13.3.0.eb)
* SDL2/2.30.6-GCCcore-13.3.0 (SDL2-2.30.6-GCCcore-13.3.0.eb)
* FFmpeg/7.0.2-GCCcore-13.3.0 (FFmpeg-7.0.2-GCCcore-13.3.0.eb)
* Gdk-Pixbuf/2.42.11-GCCcore-13.3.0 (Gdk-Pixbuf-2.42.11-GCCcore-13.3.0.eb)
* libheif/1.19.5-GCCcore-13.3.0 (libheif-1.19.5-GCCcore-13.3.0.eb)
* JasPer/4.2.4-GCCcore-13.3.0 (JasPer-4.2.4-GCCcore-13.3.0.eb)
```