### PR TITLE
{2025.06}[2024a] TurboVNC and remote desktop tools

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
@@ -29,6 +29,10 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24280
         from-commit: cef31b32459a296e95447f89ff17a15371deacef
+  - Rust-1.83.0-GCCcore-13.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24331
+        from-commit: fb71f0be42a1e65b9f0aa669f7d2ced3708ca634
   - tint2-17.0.2-GCCcore-13.3.0.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24280


### PR DESCRIPTION
Lot's of things missing here:
```
ocaisa@~/EESSI/software-layer(vnc_stuff)$ eb --missing --experimental --easystack easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml | grep '*' | sort | uniq
* ATK/2.38.0-GCCcore-13.3.0 (ATK-2.38.0-GCCcore-13.3.0.eb)
* GTK3/3.24.42-GCCcore-13.3.0 (GTK3-3.24.42-GCCcore-13.3.0.eb)
* Imlib2/1.12.3-GCCcore-13.3.0 (Imlib2-1.12.3-GCCcore-13.3.0.eb)
* Openbox/3.6.1-GCCcore-13.3.0 (Openbox-3.6.1-GCCcore-13.3.0.eb)
* Pango/1.54.0-GCCcore-13.3.0 (Pango-1.54.0-GCCcore-13.3.0.eb)
* Rust/1.83.0-GCCcore-13.3.0 (Rust-1.83.0-GCCcore-13.3.0.eb)
* at-spi2-atk/2.38.0-GCCcore-13.3.0 (at-spi2-atk-2.38.0-GCCcore-13.3.0.eb)
* at-spi2-core/2.54.0-GCCcore-13.3.0 (at-spi2-core-2.54.0-GCCcore-13.3.0.eb)
* cargo-c/0.9.32-GCCcore-13.3.0 (cargo-c-0.9.32-GCCcore-13.3.0.eb)
* feh/3.10.3-GCCcore-13.3.0 (feh-3.10.3-GCCcore-13.3.0.eb)
* jgmenu/4.5.0-GCCcore-13.3.0 (jgmenu-4.5.0-GCCcore-13.3.0.eb)
* libepoxy/1.5.10-GCCcore-13.3.0 (libepoxy-1.5.10-GCCcore-13.3.0.eb)
* librsvg/2.60.0-GCCcore-13.3.0 (librsvg-2.60.0-GCCcore-13.3.0.eb)
* tint2/17.0.2-GCCcore-13.3.0 (tint2-17.0.2-GCCcore-13.3.0.eb)
* xterm/402-GCCcore-13.3.0 (xterm-402-GCCcore-13.3.0.eb)
```
and TurboVNC (which I had installed locally)