### PR TITLE
{2023.06}[2023b] Boost.Python-NumPy v1.83.0, LoSoTo v2.5.0, PyTables v3.9.2, RMextract v0.5.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023b.yml
@@ -37,10 +37,7 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/23155
         from-commit: b35081d4454f54996108088780f6554739dc4891
-  - PyTables-3.9.2-foss-2023b.eb:
-      options:
-        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/23155
-        from-commit: b35081d4454f54996108088780f6554739dc4891
+  - PyTables-3.9.2-foss-2023b.eb
   - RMextract-0.5.1-foss-2023b.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/23155


### PR DESCRIPTION
Needs https://github.com/EESSI/software-layer/pull/1238 first so that PyTables will build correctly