### PR TITLE
{2025.06}[2025a] Bunch of dependencies for Mesa 25.1.3

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2025a.yml
@@ -26,3 +26,6 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24331
         from-commit: b6adb815305bd199f1ade69194e2ca9faaf87e07
   - Python-bundle-PyPI-2025.04-GCCcore-14.2.0.eb
+  - PyYAML-6.0.2-GCCcore-14.2.0.eb
+  - Z3-4.13.4-GCCcore-14.2.0.eb
+  - libglvnd-1.7.0-GCCcore-14.2.0.eb


### PR DESCRIPTION
Mesa 25.1.3 (#1257) hassome issues with LLVM. This PR adds some other dependencies, so we don't have to rebuild those every time.

```
3 out of 47 required modules missing:

* libyaml/0.2.5-GCCcore-14.2.0 (libyaml-0.2.5-GCCcore-14.2.0.eb)
* Cython/3.1.1-GCCcore-14.2.0 (Cython-3.1.1-GCCcore-14.2.0.eb)
* PyYAML/6.0.2-GCCcore-14.2.0 (PyYAML-6.0.2-GCCcore-14.2.0.eb)


2 out of 30 required modules missing:

* GMP/6.3.0-GCCcore-14.2.0 (GMP-6.3.0-GCCcore-14.2.0.eb)
* Z3/4.13.4-GCCcore-14.2.0 (Z3-4.13.4-GCCcore-14.2.0.eb)


8 out of 41 required modules missing:

* Bison/3.8.2-GCCcore-14.2.0 (Bison-3.8.2-GCCcore-14.2.0.eb)
* libpng/1.6.48-GCCcore-14.2.0 (libpng-1.6.48-GCCcore-14.2.0.eb)
* Brotli/1.1.0-GCCcore-14.2.0 (Brotli-1.1.0-GCCcore-14.2.0.eb)
* Doxygen/1.14.0-GCCcore-14.2.0 (Doxygen-1.14.0-GCCcore-14.2.0.eb)
* freetype/2.13.3-GCCcore-14.2.0 (freetype-2.13.3-GCCcore-14.2.0.eb)
* fontconfig/2.16.2-GCCcore-14.2.0 (fontconfig-2.16.2-GCCcore-14.2.0.eb)
* X11/20250521-GCCcore-14.2.0 (X11-20250521-GCCcore-14.2.0.eb)
* libglvnd/1.7.0-GCCcore-14.2.0 (libglvnd-1.7.0-GCCcore-14.2.0.eb)

```