### PR TITLE
{2023.06}[2022b] Rebuild Ruby 3.2.2 to fix segfaults

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20251025-eb-5.1.2-Ruby-3.2.2-fix-segfaults-aarch64.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20251025-eb-5.1.2-Ruby-3.2.2-fix-segfaults-aarch64.yml
@@ -1,0 +1,17 @@
+# 2025.10.25
+# Some Ruby 3.2.2 installations for NVIDIA Grace (built on JURECA which has not
+# enabled PAC+BTI CPU features) and for Neoverse V1 (built on AWS) segfault on
+# some NVIDIA Grace systems (SURF-ETP, Olivia, eX3) which have PAC+BTI CPU
+# features enabled.
+# 
+# See https://gitlab.com/eessi/support/-/issues/197 for details.
+#
+# Also version 3.3.0 had the same problem, but is being rebuilt in a separate PR
+# because for 'zen4' there is only a dummy module (for all modules based on
+# foss/2022b)
+#
+easyconfigs:
+  - Ruby-3.2.2-GCCcore-12.2.0:
+      options:
+        # See https://github.com/easybuilders/easybuild-easyconfigs/pull/24368
+        from-commit: 9e2517e90e7e30b2427bd0259dab73bf3a5391bc


### PR DESCRIPTION
Should fix segfaults when running simple `ruby --version`. Do not rebuild for `zen4` (no need, because it only includes dummy modules for `foss/2022b`). See PR-sibling #1264

See https://gitlab.com/eessi/support/-/issues/197 for details