### PR TITLE
{2023.06} Fix toolchain prepare bug in EB 5.1.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20251027-eb-5.1.2-EasyBuild-5.1.2-pass_deps_to_toolchain_prep.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20251027-eb-5.1.2-EasyBuild-5.1.2-pass_deps_to_toolchain_prep.yml
@@ -8,4 +8,4 @@ easyconfigs:
   - EasyBuild-5.1.2.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24376
-        from-commit: d617330dc7652032f0bedbc9e36da16e247b71ec
+        from-commit: 80f00063d4896474e46fdd8958b0471735d7ea65


### PR DESCRIPTION
For consistency, rebuilding also for 2023.06