### PR TITLE
{2025.06}[2025a] SciPy-bundle 2025.06

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2025a.yml
@@ -29,3 +29,4 @@ easyconfigs:
   - PyYAML-6.0.2-GCCcore-14.2.0.eb
   - Z3-4.13.4-GCCcore-14.2.0.eb
   - libglvnd-1.7.0-GCCcore-14.2.0.eb
+  - SciPy-bundle-2025.06-gfbf-2025a.eb


### PR DESCRIPTION
```
10 out of 62 required modules missing:

* ICU/76.1-GCCcore-14.2.0 (ICU-76.1-GCCcore-14.2.0.eb)
* Boost/1.88.0-GCC-14.2.0 (Boost-1.88.0-GCC-14.2.0.eb)
* Eigen/3.4.0-GCCcore-14.2.0 (Eigen-3.4.0-GCCcore-14.2.0.eb)
* Catch2/2.13.10-GCCcore-14.2.0 (Catch2-2.13.10-GCCcore-14.2.0.eb)
* meson-python/0.18.0-GCCcore-14.2.0 (meson-python-0.18.0-GCCcore-14.2.0.eb)
* pybind11/2.13.6-GCC-14.2.0 (pybind11-2.13.6-GCC-14.2.0.eb)
* spin/0.14-GCCcore-14.2.0 (spin-0.14-GCCcore-14.2.0.eb)
* hypothesis/6.133.2-GCCcore-14.2.0 (hypothesis-6.133.2-GCCcore-14.2.0.eb)
* gfbf/2025a (gfbf-2025a.eb)
* SciPy-bundle/2025.06-gfbf-2025a (SciPy-bundle-2025.06-gfbf-2025a.eb)
```