### PR TITLE
{2025.06}[2024a] websockify 0.13.0

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
@@ -54,3 +54,7 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24356
         from-commit: c057c3242d4a947ae30358ea283659ff0d1a3d17
   - SciPy-bundle-2024.05-gfbf-2024a.eb
+  - websockify-0.13.0-gfbf-2024a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24287
+        from-commit: 131a6fecdf26796f85c26a392f511f86078291c6


### PR DESCRIPTION
```
4 out of 60 required modules missing:

* Redis/7.4.1-GCCcore-13.3.0 (Redis-7.4.1-GCCcore-13.3.0.eb)
* typing-extensions/4.11.0-GCCcore-13.3.0 (typing-extensions-4.11.0-GCCcore-13.3.0.eb)
* redis-py/5.1.1-GCCcore-13.3.0 (redis-py-5.1.1-GCCcore-13.3.0.eb)
* websockify/0.13.0-gfbf-2024a (websockify-0.13.0-gfbf-2024a.eb)
```