### PR TITLE
{2025.06}[SYSTEM] caddy 2.10.2

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-001-system.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-001-system.yml
@@ -1,2 +1,6 @@
 easyconfigs:
   - ReFrame-4.7.4.eb
+  - caddy-2.10.2.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24402
+        from-commit: b83c437b11d31e2b8bb6ac8eb683a1b24e0dc810


### PR DESCRIPTION
```
2 out of 2 required modules missing:

* Go/1.25.0 (Go-1.25.0.eb)
* caddy/2.10.2 (caddy-2.10.2.eb)
```