### PR TITLE
{2025.06}[2024a] matplotlib 3.9.2

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
@@ -59,3 +59,4 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24287
         from-commit: 131a6fecdf26796f85c26a392f511f86078291c6
   - ParaView-5.13.2-foss-2024a.eb
+  - matplotlib-3.9.2-gfbf-2024a.eb


### PR DESCRIPTION
```
7 out of 81 required modules missing:

* cppy/1.2.1-GCCcore-13.3.0 (cppy-1.2.1-GCCcore-13.3.0.eb)
* Qhull/2020.2-GCCcore-13.3.0 (Qhull-2020.2-GCCcore-13.3.0.eb)
* OpenJPEG/2.5.2-GCCcore-13.3.0 (OpenJPEG-2.5.2-GCCcore-13.3.0.eb)
* LittleCMS/2.16-GCCcore-13.3.0 (LittleCMS-2.16-GCCcore-13.3.0.eb)
* Pillow/10.4.0-GCCcore-13.3.0 (Pillow-10.4.0-GCCcore-13.3.0.eb)
* Tkinter/3.12.3-GCCcore-13.3.0 (Tkinter-3.12.3-GCCcore-13.3.0.eb)
* matplotlib/3.9.2-gfbf-2024a (matplotlib-3.9.2-gfbf-2024a.eb)
```