### PR TITLE
{2025.06}[SYSTEM] Cuda 12.6.0, 12.8.0, cuDNN 9.5.0.50

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -3,7 +3,7 @@
 # give up as soon as any error occurs
 set -e
 
-git clone -b cuda_host_injections_202506 https://github.com/casparvl/software-layer-scripts
+git clone https://github.com/EESSI/software-layer-scripts
 
 # symlink everything, except for:
 # - common files like LICENSE and README.md


### PR DESCRIPTION
I think we should deploy the script from https://github.com/EESSI/software-layer-scripts/pull/120 through this current PR, then change the `build.sh` back to it's original form. The issue is that https://github.com/EESSI/software-layer-scripts/pull/120 can't be deployed there, because no software is built, and thus no "no missing installations" message is printed. This causes the bot to consider the build step a 'failure'.