### PR TITLE
{2025.06}[2025a] Scalasca 2.6.2

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2025a.yml
@@ -38,3 +38,4 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24161
         from-commit: 04b8829e730bc35a4654441297fb39a7d8d4b4dc
+  - Scalasca-2.6.2-gompi-2025a.eb


### PR DESCRIPTION
An older version for 2023.06 failed to build due to Qt6 issues (see #800), but we do already have Qt6 for 2025a, so let's try this one instead.