### PR TITLE
{2025.06}[2024a] VTK 9.3.1

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
@@ -61,3 +61,4 @@ easyconfigs:
   - ParaView-5.13.2-foss-2024a.eb
   - matplotlib-3.9.2-gfbf-2024a.eb
   - tensorboard-2.18.0-gfbf-2024a.eb
+  - VTK-9.3.1-foss-2024a.eb


### PR DESCRIPTION
```
1 out of 124 required modules missing:

* VTK/9.3.1-foss-2024a (VTK-9.3.1-foss-2024a.eb)
```