### PR TITLE
{2025.06}[SYSTEM] cuDNN 9.10.1.4 for CC80/100/120

### DIFF
--- a/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.1.2-001-system.yml
+++ b/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.1.2-001-system.yml
@@ -1,0 +1,5 @@
+easyconfigs:
+  - cuDNN-9.10.1.4-CUDA-12.8.0.eb:
+      options:
+        accept-eula-for: cuDNN
+        cuda-sanity-check-accept-missing-ptx: True


### PR DESCRIPTION
Accompanies https://github.com/EESSI/software-layer/pull/1286 , in which the sanity check had to be disabled for CC90 (see https://gitlab.com/eessi/support/-/issues/210#note_2865904820 ).

NOTE: this PR should _only_ be built for CC70/CC80/CC100/CC120 targets. The other targets will be provided by https://github.com/EESSI/software-layer/pull/1286