### PR TITLE
{2023.06}[foss/2023b] ESMF v8.6.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023b.yml
@@ -46,3 +46,4 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/23155
         from-commit: b35081d4454f54996108088780f6554739dc4891
+  - ESMF-8.6.1-foss-2023b.eb


### PR DESCRIPTION
missing packages:
```
ESMF/8.6.1-foss-2023b
netCDF-C++4/4.3.1-gompi-2023b
netCDF-Fortran/4.6.1-gompi-2023b
```