### PR TITLE
{2025.06}[2024a] R-bundle-CRAN 2024.11

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
@@ -76,3 +76,5 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24524
         from-commit: 1546f454c1a0b0c6483d8a0aaad2157ca1f770e8
+        # install extensions in parallel
+        parallel-extensions-install: True


### PR DESCRIPTION
```
33 out of 159 required modules missing:

* NLopt/2.7.1-GCCcore-13.3.0 (NLopt-2.7.1-GCCcore-13.3.0.eb)
* libogg/1.3.5-GCCcore-13.3.0 (libogg-1.3.5-GCCcore-13.3.0.eb)
* FLAC/1.4.3-GCCcore-13.3.0 (FLAC-1.4.3-GCCcore-13.3.0.eb)
* libvorbis/1.3.7-GCCcore-13.3.0 (libvorbis-1.3.7-GCCcore-13.3.0.eb)
* UDUNITS/2.2.28-GCCcore-13.3.0 (UDUNITS-2.2.28-GCCcore-13.3.0.eb)
* libopus/1.5.2-GCCcore-13.3.0 (libopus-1.5.2-GCCcore-13.3.0.eb)
* GSL/2.8-GCC-13.3.0 (GSL-2.8-GCC-13.3.0.eb)
* libsndfile/1.2.2-GCCcore-13.3.0 (libsndfile-1.2.2-GCCcore-13.3.0.eb)
* GLPK/5.0-GCCcore-13.3.0 (GLPK-5.0-GCCcore-13.3.0.eb)
* Ghostscript/10.03.1-GCCcore-13.3.0 (Ghostscript-10.03.1-GCCcore-13.3.0.eb)
* MPFR/4.2.1-GCCcore-13.3.0 (MPFR-4.2.1-GCCcore-13.3.0.eb)
* PostgreSQL/16.4-GCCcore-13.3.0 (PostgreSQL-16.4-GCCcore-13.3.0.eb)
* GEOS/3.12.2-GCC-13.3.0 (GEOS-3.12.2-GCC-13.3.0.eb)
* PCRE/8.45-GCCcore-13.3.0 (PCRE-8.45-GCCcore-13.3.0.eb)
* ImageMagick/7.1.1-38-GCCcore-13.3.0 (ImageMagick-7.1.1-38-GCCcore-13.3.0.eb)
* googletest/1.15.2-GCCcore-13.3.0 (googletest-1.15.2-GCCcore-13.3.0.eb)
* nlohmann_json/3.11.3-GCCcore-13.3.0 (nlohmann_json-3.11.3-GCCcore-13.3.0.eb)
* PROJ/9.4.1-GCCcore-13.3.0 (PROJ-9.4.1-GCCcore-13.3.0.eb)
* libgeotiff/1.7.3-GCCcore-13.3.0 (libgeotiff-1.7.3-GCCcore-13.3.0.eb)
* libtirpc/1.3.5-GCCcore-13.3.0 (libtirpc-1.3.5-GCCcore-13.3.0.eb)
* HDF/4.3.0-GCCcore-13.3.0 (HDF-4.3.0-GCCcore-13.3.0.eb)
* CFITSIO/4.4.1-GCCcore-13.3.0 (CFITSIO-4.4.1-GCCcore-13.3.0.eb)
* arpack-ng/3.9.1-foss-2024a (arpack-ng-3.9.1-foss-2024a.eb)
* Armadillo/14.0.3-foss-2024a (Armadillo-14.0.3-foss-2024a.eb)
* json-c/0.17-GCCcore-13.3.0 (json-c-0.17-GCCcore-13.3.0.eb)
* Xerces-C++/3.2.5-GCCcore-13.3.0 (Xerces-C++-3.2.5-GCCcore-13.3.0.eb)
* Brunsli/0.1-GCCcore-13.3.0 (Brunsli-0.1-GCCcore-13.3.0.eb)
* Imath/3.1.11-GCCcore-13.3.0 (Imath-3.1.11-GCCcore-13.3.0.eb)
* OpenEXR/3.2.4-GCCcore-13.3.0 (OpenEXR-3.2.4-GCCcore-13.3.0.eb)
* LERC/4.0.0-GCCcore-13.3.0 (LERC-4.0.0-GCCcore-13.3.0.eb)
* SWIG/4.2.1-GCCcore-13.3.0 (SWIG-4.2.1-GCCcore-13.3.0.eb)
* GDAL/3.10.0-foss-2024a (GDAL-3.10.0-foss-2024a.eb)
* R-bundle-CRAN/2024.11-foss-2024a (R-bundle-CRAN-2024.11-foss-2024a.eb)
```