### PR TITLE
{2023.06}[2023b] RStudio-Server 2024.09.0+375

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023b.yml
@@ -47,4 +47,7 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/23155
         from-commit: b35081d4454f54996108088780f6554739dc4891
   - ESMF-8.6.1-foss-2023b.eb
-  - RStudio-Server-2024.09.0+375-foss-2023b-Java-11-R-4.4.1.eb
+  - RStudio-Server-2024.09.0+375-foss-2023b-Java-11-R-4.4.1.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24490
+        from-commit: c9c20b479dc9220724f0c38f980a372413d0c5ed


### PR DESCRIPTION
```
3 out of 158 required modules missing:

* yaml-cpp/0.8.0-GCCcore-13.2.0 (yaml-cpp-0.8.0-GCCcore-13.2.0.eb)
* SOCI/4.0.3-GCC-13.2.0 (SOCI-4.0.3-GCC-13.2.0.eb)
* RStudio-Server/2024.09.0+375-foss-2023b-Java-11-R-4.4.1 (RStudio-Server-2024.09.0+375-foss-2023b-Java-11-R-4.4.1.eb)
```