### PR TITLE
{2023.06}[foss/2023a] NEST v3.9

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
@@ -1,3 +1,7 @@
 easyconfigs:
   - GRASS-8.4.0-foss-2023a.eb
   - parallel-20230722-GCCcore-12.3.0.eb
+  - NEST-3.9-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24259
+        from-commit: 3f59104cfd0aeedc261e2bf7ca18b8ae5efdca0a 


### PR DESCRIPTION
missing packages:
```
NEST/3.9-foss-2023a
```