### PR TITLE
{2025.06}[2024a] RStudio-Server 2024.12.0+467

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
@@ -78,3 +78,7 @@ easyconfigs:
         from-commit: 1546f454c1a0b0c6483d8a0aaad2157ca1f770e8
         # install extensions in parallel
         parallel-extensions-install: True
+  - RStudio-Server-2024.12.0+467-foss-2024a-R-4.4.2.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24542
+        from-commit: c1fc31398e705be39f8dbdf2e2671d38adda1faf


### PR DESCRIPTION
Requires #1297 before we can build.
```
4 out of 163 required modules missing:

* ant/1.10.12-Java-17 (ant-1.10.12-Java-17.eb)
* yaml-cpp/0.8.0-GCCcore-13.3.0 (yaml-cpp-0.8.0-GCCcore-13.3.0.eb)
* SOCI/4.0.3-GCC-13.3.0 (SOCI-4.0.3-GCC-13.3.0.eb)
* RStudio-Server/2024.12.0+467-foss-2024a-R-4.4.2 (RStudio-Server-2024.12.0+467-foss-2024a-R-4.4.2.eb)
```