### PR TITLE
{2023.06}[2023b,a64fx] GROMACS 2024.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-5.1.2-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-5.1.2-2023b.yml
@@ -7,3 +7,7 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24548
         from-commit: 2a45a80a9b50adc8954150a1101c81e692598b98
+  - GROMACS-2024.1-foss-2023b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24602
+        from-commit: 70637e8c01ff57e28044a629da983d7715fb8067


### PR DESCRIPTION
The very last one, this should close the gap (lets celebrate later). #1221 can be rerun and merged when this is ingested.