### PR TITLE
{2025.06}[2025a] Flye 2.9.6, MrBayes 3.2.7

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2025a.yml
@@ -51,11 +51,11 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24548
         from-commit: 091da705ab376a530a2368c0690e7dd44fbc7404
-  - Flye-2.9.6-GCC-14.2.0.eb
+  - Flye-2.9.6-GCC-14.2.0.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24543
         from-commit: 36ede4967688b0ad308121fc77f12bd337cb08e1
-  - MrBayes-3.2.7-gompi-2025a.eb
+  - MrBayes-3.2.7-gompi-2025a.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24552
         from-commit: d92743f799fc859c472edccd78cf558e0a91ba86


### PR DESCRIPTION
```
1 out of 13 required modules missing:

* Flye/2.9.6-GCC-14.2.0 (Flye-2.9.6-GCC-14.2.0.eb)
```
```
4 out of 47 required modules missing:

* Java/21.0.8 (Java-21.0.8.eb)
* Java/21 (Java-21.eb)
* beagle-lib/4.0.1-GCC-14.2.0 (beagle-lib-4.0.1-GCC-14.2.0.eb)
* MrBayes/3.2.7-gompi-2025a (MrBayes-3.2.7-gompi-2025a.eb)
```