### PR TITLE
{2023.06}[2022b] Rebuild UCX 1.13.1 without `--with-sysroot`

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20251120-eb-5.1.2-UCX-1.13.1-foss-2022b-without-sysroot.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20251120-eb-5.1.2-UCX-1.13.1-foss-2022b-without-sysroot.yml
@@ -1,0 +1,10 @@
+# The --with-sysroot flag for UCX was causing weird issues with
+# library paths in .la files being prefixed with a = sign, e.g. "=/cvmfs/.....".
+# The option was removed from our hooks, see:
+# https://github.com/EESSI/software-layer-scripts/pull/133
+# Due to this, all UCX versions have to be rebuilt.
+easyconfigs:
+  - UCX-1.13.1-GCCcore-12.2.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24388
+        from-commit: d438adc699f5ff35d866d9045f0aae663a0913cb


### PR DESCRIPTION
See https://github.com/EESSI/software-layer-scripts/pull/133. Rebuilds the 2022b version for all CPU targets except zen4, using the commit that was used for the current build (with the bistro fix).