### PR TITLE
{2025.06}[2024a+2025a] Rebuild UCX 1.16.0 + 1.18.0 without `--with-sysroot` 

### DIFF
--- a/easystacks/software.eessi.io/2025.06/rebuilds/20251120-eb-5.1.2-UCX-without-sysroot.yml
+++ b/easystacks/software.eessi.io/2025.06/rebuilds/20251120-eb-5.1.2-UCX-without-sysroot.yml
@@ -1,0 +1,14 @@
+# The --with-sysroot flag for UCX was causing weird issues with
+# library paths in .la files being prefixed with a = sign, e.g. "=/cvmfs/.....".
+# The option was removed from our hooks, see:
+# https://github.com/EESSI/software-layer-scripts/pull/133
+# Due to this, all UCX versions have to be rebuilt.
+easyconfigs:
+  - UCX-1.16.0-GCCcore-13.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24388
+        from-commit: d438adc699f5ff35d866d9045f0aae663a0913cb
+  - UCX-1.18.0-GCCcore-14.2.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24388
+        from-commit: d438adc699f5ff35d866d9045f0aae663a0913cb


### PR DESCRIPTION
See https://github.com/EESSI/software-layer-scripts/pull/133. Rebuilds the 2024a+2025a versions for all CPU targets, using the commit that was used for the current build (with the bistro fix).