### PR TITLE
{2023.06}[2023a] QIIME2 2024.2.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
@@ -5,4 +5,8 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24259
         from-commit: 3f59104cfd0aeedc261e2bf7ca18b8ae5efdca0a 
+  - Bowtie2-2.5.1-GCC-12.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24791
+        from-commit: 686ed52641b27c2ea15a9ff0afa6fd5e67e22d45
   - QIIME2-2024.2.0-foss-2023a-amplicon.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
@@ -5,3 +5,4 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24259
         from-commit: 3f59104cfd0aeedc261e2bf7ca18b8ae5efdca0a 
+  - QIIME2-2024.2.0-foss-2023a-amplicon.eb


### PR DESCRIPTION
```
23 out of 234 required modules missing:

* alsa-lib/1.2.9-GCCcore-12.3.0 (alsa-lib-1.2.9-GCCcore-12.3.0.eb)
* Bowtie2/2.5.1-GCC-12.3.0 (Bowtie2-2.5.1-GCC-12.3.0.eb)
* bcrypt/4.0.1-GCCcore-12.3.0 (bcrypt-4.0.1-GCCcore-12.3.0.eb)
* paramiko/3.2.0-GCCcore-12.3.0 (paramiko-3.2.0-GCCcore-12.3.0.eb)
* Parsl/2024.4.22-GCCcore-12.3.0 (Parsl-2024.4.22-GCCcore-12.3.0.eb)
* pigz/2.8-GCCcore-12.3.0 (pigz-2.8-GCCcore-12.3.0.eb)
* FastTree/2.1.11-GCCcore-12.3.0 (FastTree-2.1.11-GCCcore-12.3.0.eb)
* cutadapt/4.9-GCCcore-12.3.0 (cutadapt-4.9-GCCcore-12.3.0.eb)
* VSEARCH/2.25.0-GCC-12.3.0 (VSEARCH-2.25.0-GCC-12.3.0.eb)
* attr/2.5.1-GCCcore-12.3.0 (attr-2.5.1-GCCcore-12.3.0.eb)
* UniFrac/1.4-foss-2023a (UniFrac-1.4-foss-2023a.eb)
* Brotli-python/1.0.9-GCCcore-12.3.0 (Brotli-python-1.0.9-GCCcore-12.3.0.eb)
* coverage/7.2.3-GCCcore-12.3.0 (coverage-7.2.3-GCCcore-12.3.0.eb)
* nose3/1.3.8-GCCcore-12.3.0 (nose3-1.3.8-GCCcore-12.3.0.eb)
* Cython/3.0.7-GCCcore-12.3.0 (Cython-3.0.7-GCCcore-12.3.0.eb)
* psutil/5.9.8-GCCcore-12.3.0 (psutil-5.9.8-GCCcore-12.3.0.eb)
* PyHMMER/0.10.6-gompi-2023a (PyHMMER-0.10.6-gompi-2023a.eb)
* Biopython/1.83-gfbf-2023a (Biopython-1.83-gfbf-2023a.eb)
* BamTools/2.5.2-GCC-12.3.0 (BamTools-2.5.2-GCC-12.3.0.eb)
* BEDTools/2.31.0-GCC-12.3.0 (BEDTools-2.31.0-GCC-12.3.0.eb)
* pybedtools/0.9.1-foss-2023a (pybedtools-0.9.1-foss-2023a.eb)
* gffutils/0.13-foss-2023a (gffutils-0.13-foss-2023a.eb)
* QIIME2/2024.2.0-foss-2023a-amplicon (QIIME2-2024.2.0-foss-2023a-amplicon.eb)
```