### PR TITLE
{2025.06}[2024a] JupyterLab 4.2.5

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
@@ -98,3 +98,4 @@ easyconfigs:
   - sympy-1.13.3-gfbf-2024a.eb
   - PuLP-2.8.0-foss-2024a.eb
   - R-bundle-Bioconductor-3.20-foss-2024a-R-4.4.2.eb
+  - JupyterLab-4.2.5-GCCcore-13.3.0.eb


### PR DESCRIPTION
```
7 out of 56 required modules missing:

* tornado/6.4.1-GCCcore-13.3.0 (tornado-6.4.1-GCCcore-13.3.0.eb)
* hatch-jupyter-builder/0.9.1-GCCcore-13.3.0 (hatch-jupyter-builder-0.9.1-GCCcore-13.3.0.eb)
* BeautifulSoup/4.12.3-GCCcore-13.3.0 (BeautifulSoup-4.12.3-GCCcore-13.3.0.eb)
* scikit-build-core/0.10.6-GCCcore-13.3.0 (scikit-build-core-0.10.6-GCCcore-13.3.0.eb)
* PyZMQ/26.2.0-GCCcore-13.3.0 (PyZMQ-26.2.0-GCCcore-13.3.0.eb)
* jupyter-server/2.14.2-GCCcore-13.3.0 (jupyter-server-2.14.2-GCCcore-13.3.0.eb)
* JupyterLab/4.2.5-GCCcore-13.3.0 (JupyterLab-4.2.5-GCCcore-13.3.0.eb)
```