### PR TITLE
{2023.06}[2023a] SimpleITK 2.3.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
@@ -5,3 +5,4 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24259
         from-commit: 3f59104cfd0aeedc261e2bf7ca18b8ae5efdca0a 
+  - SimpleITK-2.3.1-foss-2023a.eb

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
@@ -5,7 +5,10 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24259
         from-commit: 3f59104cfd0aeedc261e2bf7ca18b8ae5efdca0a 
-  - SimpleITK-2.3.1-foss-2023a.eb
+  - SimpleITK-2.3.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24908
+        from-commit: 5799bfafda2bcb94c0e59a35b85649b8095fda77
   - ESMF-8.6.0-foss-2023a.eb
   - xESMF-0.8.6-foss-2023a.eb
   - LPC3D-0.1.2-foss-2023a.eb:


### PR DESCRIPTION
```
2 out of 108 required modules missing:

* ITK/5.3.0-foss-2023a (ITK-5.3.0-foss-2023a.eb)
* SimpleITK/2.3.1-foss-2023a (SimpleITK-2.3.1-foss-2023a.eb)
```