### PR TITLE
{2023.06}[2023a] matplotlib 2.2.5

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
@@ -7,3 +7,4 @@ easyconfigs:
         from-commit: 3f59104cfd0aeedc261e2bf7ca18b8ae5efdca0a 
   - ESMF-8.6.0-foss-2023a.eb
   - xESMF-0.8.6-foss-2023a.eb
+  - matplotlib-2.2.5-foss-2023a-Python-2.7.18.eb


### PR DESCRIPTION
```
8 out of 58 required modules missing:

* Python/2.7.18-GCCcore-12.3.0 (Python-2.7.18-GCCcore-12.3.0.eb)
* hypothesis/4.57.1-GCCcore-12.3.0-Python-2.7.18 (hypothesis-4.57.1-GCCcore-12.3.0-Python-2.7.18.eb)
* pytest/4.6.11-GCCcore-12.3.0-Python-2.7.18 (pytest-4.6.11-GCCcore-12.3.0-Python-2.7.18.eb)
* pybind11/2.9.2-GCCcore-12.3.0-Python-2.7.18 (pybind11-2.9.2-GCCcore-12.3.0-Python-2.7.18.eb)
* Tkinter/2.7.18-GCCcore-12.3.0-Python-2.7.18 (Tkinter-2.7.18-GCCcore-12.3.0-Python-2.7.18.eb)
* numpy/1.16.6-foss-2023a-Python-2.7.18 (numpy-1.16.6-foss-2023a-Python-2.7.18.eb)
* SciPy-bundle/2024.06-foss-2023a-Python-2.7.18 (SciPy-bundle-2024.06-foss-2023a-Python-2.7.18.eb)
* matplotlib/2.2.5-foss-2023a-Python-2.7.18 (matplotlib-2.2.5-foss-2023a-Python-2.7.18.eb)
```
The build fails for me under EESSI:
```
gcc -fno-strict-aliasing -O2 -ftree-vectorize -march=native -fno-math-errno -fPIC -DNDEBUG -g -fwrapv -O3 -Wall -O2 -ftree-vectorize -march=native -fno-math-errno -I/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/z
en4/software/FFTW.MPI/3.3.10-gompi-2023a/include -I/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4/software/FFTW/3.3.10-GCC-12.3.0/include -I/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/ze
n4/software/FlexiBLAS/3.3.1-GCC-12.3.0/include -I/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4/software/OpenMPI/4.1.5-GCC-12.3.0/include -I/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/ze
n4/software/freetype/2.13.0-GCCcore-12.3.0/include/freetype2 -I/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4/software/libpng/1.6.39-GCCcore-12.3.0/include -I/user/gent/453/vsc45304/eessi/versions/2023.06/softw
are/linux/x86_64/amd/zen4/software/Python/2.7.18-GCCcore-12.3.0/include -I/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4/software/pkgconf/1.9.5-GCCcore-12.3.0/include -I/cvmfs/software.eessi.io/versions/2023.06
/software/linux/x86_64/amd/zen4/software/GCCcore/12.3.0/include -I/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4/software/FlexiBLAS/3.3.1-GCC-12.3.0/include -I/cvmfs/software.eessi.io/versions/2023.06/software/
linux/x86_64/amd/zen4/software/FlexiBLAS/3.3.1-GCC-12.3.0/include/flexiblas -fPIC -DFREETYPE_BUILD_TYPE=system -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ft2font_ARRAY_API -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -D__STDC_FORMAT_MACROS=
1 -I/user/gent/453/vsc45304/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/software/numpy/1.16.6-foss-2023a-Python-2.7.18/lib/python2.7/site-packages/numpy/core/include -I/cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86
_64/usr/include -I/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4/software/libpng/1.6.39-GCCcore-12.3.0/include/libpng16 -I/usr/local/include -I/usr/include -I. -I/user/gent/453/vsc45304/eessi/versions/2023.06/s
oftware/linux/x86_64/amd/zen4/software/Python/2.7.18-GCCcore-12.3.0/include/python2.7 -c src/ft2font.cpp -o build/temp.linux-x86_64-2.7/src/ft2font.o
  In file included from /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4/software/GCCcore/12.3.0/include/c++/12.3.0/cstdlib:75,
                   from /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_algo.h:69,
                   from /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4/software/GCCcore/12.3.0/include/c++/12.3.0/algorithm:61,
                   from src/ft2font.cpp:5:
  /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/usr/include/stdlib.h:606:35: error: expected initializer before ‘__attribute_alloc_align__’
    606 |      __THROW __attribute_malloc__ __attribute_alloc_align__ ((1))
        |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~
  /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4/software/GCCcore/12.3.0/include/c++/12.3.0/cstdlib:132:11: error: ‘aligned_alloc’ has not been declared in ‘::’
    132 |   using ::aligned_alloc;
        |           ^~~~~~~~~~~~~
  In file included from /user/gent/453/vsc45304/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/software/Python/2.7.18-GCCcore-12.3.0/include/python2.7/Python.h:88,
                   from src/mplutils.h:34,
                   from src/ft2font.cpp:10:
  /user/gent/453/vsc45304/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/software/Python/2.7.18-GCCcore-12.3.0/include/python2.7/unicodeobject.h:534:24: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
    534 |     register PyObject *obj,     /* Object */
        |                        ^~~
  /user/gent/453/vsc45304/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/software/Python/2.7.18-GCCcore-12.3.0/include/python2.7/unicodeobject.h:553:24: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
    553 |     register PyObject *obj      /* Object */
        |                        ^~~
  /user/gent/453/vsc45304/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/software/Python/2.7.18-GCCcore-12.3.0/include/python2.7/unicodeobject.h:575:29: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
    575 |     register const wchar_t *w,  /* wchar_t buffer */
        |                             ^
  /user/gent/453/vsc45304/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/software/Python/2.7.18-GCCcore-12.3.0/include/python2.7/unicodeobject.h:593:23: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
    593 |     register wchar_t *w,        /* wchar_t buffer */
        |                       ^
  In file included from /user/gent/453/vsc45304/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/software/Python/2.7.18-GCCcore-12.3.0/include/python2.7/Python.h:97:
  /user/gent/453/vsc45304/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/software/Python/2.7.18-GCCcore-12.3.0/include/python2.7/stringobject.h:173:24: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
    173 |     register PyObject *obj,     /* string or Unicode object */
        |                        ^~~
  /user/gent/453/vsc45304/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/software/Python/2.7.18-GCCcore-12.3.0/include/python2.7/stringobject.h:174:21: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
    174 |     register char **s,          /* pointer to buffer variable */
        |                     ^
  /user/gent/453/vsc45304/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/software/Python/2.7.18-GCCcore-12.3.0/include/python2.7/stringobject.h:175:26: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
    175 |     register Py_ssize_t *len    /* pointer to length variable or NULL
        |                          ^~~
  error: command 'gcc' failed with exit status 1

```