### PR TITLE
{2023.06}[foss/2023a] NCO v5.1.9

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
@@ -11,3 +11,4 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24703
         from-commit: 67de6dc47ed49fabea09da17849b35bb2a7a9618
+  - NCO-5.1.9-foss-2023a.eb


### PR DESCRIPTION
missing packages:
```
ANTLR/2.7.7-GCCcore-12.3.0-Java-11
libdap/3.20.11-GCCcore-12.3.0
NCO/5.1.9-foss-2023a
```