### PR TITLE
{2023.06}[2023a] yacrd 1.0.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
@@ -12,3 +12,4 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24703
         from-commit: 67de6dc47ed49fabea09da17849b35bb2a7a9618
   - NCO-5.1.9-foss-2023a.eb
+  - yacrd-1.0.0-foss-2023a.eb


### PR DESCRIPTION
```
1 out of 41 required modules missing:

* yacrd/1.0.0-foss-2023a (yacrd-1.0.0-foss-2023a.eb)
```