### PR TITLE
{2025.06}[2025b] OpenMPI 5.0.8 and libarchive 3.8.1

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2025b.yml
@@ -12,7 +12,3 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24203
         from-commit: 237970c5b712196f4d01feab8b913591cc6c772f
-  - foss-2025b.eb:
-      options:
-        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24127
-        from-commit: 70d12dc46c5bd88f40fb3b553ec75dc9cf6de3a1


### PR DESCRIPTION
```
14 out of 33 required modules missing:

* libxml2/2.14.3-GCCcore-14.3.0 (libxml2-2.14.3-GCCcore-14.3.0.eb)
* numactl/2.0.19-GCCcore-14.3.0 (numactl-2.0.19-GCCcore-14.3.0.eb)
* UCX/1.19.0-GCCcore-14.3.0 (UCX-1.19.0-GCCcore-14.3.0.eb)
* libfabric/2.1.0-GCCcore-14.3.0 (libfabric-2.1.0-GCCcore-14.3.0.eb)
* xorg-macros/1.20.2-GCCcore-14.3.0 (xorg-macros-1.20.2-GCCcore-14.3.0.eb)
* libevent/2.1.12-GCCcore-14.3.0 (libevent-2.1.12-GCCcore-14.3.0.eb)
* UCC/1.4.4-GCCcore-14.3.0 (UCC-1.4.4-GCCcore-14.3.0.eb)
* Ninja/1.13.0-GCCcore-14.3.0 (Ninja-1.13.0-GCCcore-14.3.0.eb)
* Meson/1.8.2-GCCcore-14.3.0 (Meson-1.8.2-GCCcore-14.3.0.eb)
* libpciaccess/0.18.1-GCCcore-14.3.0 (libpciaccess-0.18.1-GCCcore-14.3.0.eb)
* hwloc/2.12.1-GCCcore-14.3.0 (hwloc-2.12.1-GCCcore-14.3.0.eb)
* PMIx/5.0.8-GCCcore-14.3.0 (PMIx-5.0.8-GCCcore-14.3.0.eb)
* PRRTE/3.0.11-GCCcore-14.3.0 (PRRTE-3.0.11-GCCcore-14.3.0.eb)
* OpenMPI/5.0.8-GCC-14.3.0 (OpenMPI-5.0.8-GCC-14.3.0.eb)

6 out of 11 required modules missing:

* libiconv/1.18-GCCcore-14.3.0 (libiconv-1.18-GCCcore-14.3.0.eb)
* libxml2/2.14.3-GCCcore-14.3.0 (libxml2-2.14.3-GCCcore-14.3.0.eb)
* lz4/1.10.0-GCCcore-14.3.0 (lz4-1.10.0-GCCcore-14.3.0.eb)
* gzip/1.14-GCCcore-14.3.0 (gzip-1.14-GCCcore-14.3.0.eb)
* zstd/1.5.7-GCCcore-14.3.0 (zstd-1.5.7-GCCcore-14.3.0.eb)
* libarchive/3.8.1-GCCcore-14.3.0 (libarchive-3.8.1-GCCcore-14.3.0.eb)
```