### PR TITLE
{2025.06}[2025b] foss 2025b

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.2.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.2.0-2025b.yml
@@ -1,6 +1,6 @@
 easyconfigs:
-  - FlexiBLAS-3.4.5-GCC-14.3.0.eb
-  - foss-2025b.eb:
+  - FlexiBLAS-3.4.5-GCC-14.3.0.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyblocks/pull/4031
         include-easyblocks-from-commit: 64173059ec68ff74f68e08115ededa308b2af19a
+  - foss-2025b.eb


### PR DESCRIPTION
```
14 out of 53 required modules missing:

* FFTW/3.3.10-GCC-14.3.0 (FFTW-3.3.10-GCC-14.3.0.eb)
* NVPL/25.5 (NVPL-25.5.eb)
* libidn2/2.3.8-GCCcore-14.3.0 (libidn2-2.3.8-GCCcore-14.3.0.eb)
* libunistring/1.3-GCCcore-14.3.0 (libunistring-1.3-GCCcore-14.3.0.eb)
* make/4.4.1-GCCcore-14.3.0 (make-4.4.1-GCCcore-14.3.0.eb)
* libpsl/0.21.5-GCCcore-14.3.0 (libpsl-0.21.5-GCCcore-14.3.0.eb)
* OpenBLAS/0.3.30-GCC-14.3.0 (OpenBLAS-0.3.30-GCC-14.3.0.eb)
* cURL/8.14.1-GCCcore-14.3.0 (cURL-8.14.1-GCCcore-14.3.0.eb)
* CMake/4.0.3-GCCcore-14.3.0 (CMake-4.0.3-GCCcore-14.3.0.eb)
* FlexiBLAS/3.4.5-GCC-14.3.0 (FlexiBLAS-3.4.5-GCC-14.3.0.eb)
* gompi/2025b (gompi-2025b.eb)
* FFTW.MPI/3.3.10-gompi-2025b (FFTW.MPI-3.3.10-gompi-2025b.eb)
* ScaLAPACK/2.2.2-gompi-2025b-fb (ScaLAPACK-2.2.2-gompi-2025b-fb.eb)
* foss/2025b (foss-2025b.eb)
```