### PR TITLE
{2025.06}[2025a] GetOrganelle 1.7.7.1

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2025a.yml
@@ -38,7 +38,7 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24161
         from-commit: 04b8829e730bc35a4654441297fb39a7d8d4b4dc
-  - OSU-Micro-Benchmarks-7.5-gompi-2025a.eb    
+  - OSU-Micro-Benchmarks-7.5-gompi-2025a.eb
   - json-fortran-9.0.5-GCC-14.2.0.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24095
@@ -86,3 +86,11 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24438
         from-commit: 32d6d1bddd57248651e39afb42eca9852ac2823f
+  - Qt6-6.9.3-GCCcore-14.2.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24356
+        from-commit: c057c3242d4a947ae30358ea283659ff0d1a3d17
+  - GetOrganelle-1.7.7.1-foss-2025a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24461
+        from-commit: 755f553a71e40f7098cfc0d4329640a46f525181


### PR DESCRIPTION
```
8 out of 154 required modules missing:

* Bowtie2/2.5.4-GCC-14.2.0 (Bowtie2-2.5.4-GCC-14.2.0.eb)
* MPFR/4.2.2-GCCcore-14.2.0 (MPFR-4.2.2-GCCcore-14.2.0.eb)
* MPC/1.3.1-GCCcore-14.2.0 (MPC-1.3.1-GCCcore-14.2.0.eb)
* SPAdes/4.2.0-GCC-14.2.0 (SPAdes-4.2.0-GCC-14.2.0.eb)
* gmpy2/2.2.0-GCCcore-14.2.0 (gmpy2-2.2.0-GCCcore-14.2.0.eb)
* sympy/1.14.0-gfbf-2025a (sympy-1.14.0-gfbf-2025a.eb)
* Bandage/0.9.0-GCCcore-14.2.0 (Bandage-0.9.0-GCCcore-14.2.0.eb)
* GetOrganelle/1.7.7.1-foss-2025a (GetOrganelle-1.7.7.1-foss-2025a.eb)
```
Needs:
- https://github.com/EESSI/software-layer/pull/1341