### PR TITLE
{2023.06}[2023a] LST-AI 1.1.0-20250324

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2023a.yml
@@ -4,7 +4,11 @@ easyconfigs:
   - NEST-3.9-foss-2023a.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24259
-        from-commit: 3f59104cfd0aeedc261e2bf7ca18b8ae5efdca0a 
+        from-commit: 3f59104cfd0aeedc261e2bf7ca18b8ae5efdca0a
+  - SimpleITK-2.3.1-foss-2023a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24908
+        from-commit: 5799bfafda2bcb94c0e59a35b85649b8095fda77
   - ESMF-8.6.0-foss-2023a.eb
   - xESMF-0.8.6-foss-2023a.eb
   - LPC3D-0.1.2-foss-2023a.eb:
@@ -17,3 +21,4 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24176
         from-commit: 107ea0ea250d1fd145c92f1d265d372e0ea3e685
+  - LST-AI-1.1.0-20250324-foss-2023a.eb


### PR DESCRIPTION
```
10 out of 169 required modules missing:

* pydicom/2.4.4-GCCcore-12.3.0 (pydicom-2.4.4-GCCcore-12.3.0.eb)
* NiBabel/5.2.0-gfbf-2023a (NiBabel-5.2.0-gfbf-2023a.eb)
* imageio/2.33.1-gfbf-2023a (imageio-2.33.1-gfbf-2023a.eb)
* scikit-image/0.22.0-foss-2023a (scikit-image-0.22.0-foss-2023a.eb)
* batchgenerators/0.25.1-foss-2023a (batchgenerators-0.25.1-foss-2023a.eb)
* ITK/5.3.0-foss-2023a (ITK-5.3.0-foss-2023a.eb)
* greedy/20250320-foss-2023a (greedy-20250320-foss-2023a.eb)
* SimpleITK/2.3.1-foss-2023a (SimpleITK-2.3.1-foss-2023a.eb)
* HD-BET/20230809-foss-2023a (HD-BET-20230809-foss-2023a.eb)
* LST-AI/1.1.0-20250324-foss-2023a (LST-AI-1.1.0-20250324-foss-2023a.eb)
```
Needs:
- https://github.com/EESSI/software-layer/pull/1322