### PR TITLE
{2025.06}[SYSTEM] CUDA 12.6.0,12.8.0, cuDNN 9.5.0.50,9.10.1.4

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -3,7 +3,7 @@
 # give up as soon as any error occurs
 set -e
 
-git clone --single-branch --branch CUDA_cuDNN_hooks_202506 https://github.com/casparvl/software-layer-scripts
+git clone https://github.com/EESSI/software-layer-scripts
 
 # symlink everything, except for:
 # - common files like LICENSE and README.md

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -3,7 +3,7 @@
 # give up as soon as any error occurs
 set -e
 
-git clone https://github.com/EESSI/software-layer-scripts
+git clone --single-branch --branch CUDA_cuDNN_hooks_202506 https://github.com/casparvl/software-layer-scripts
 
 # symlink everything, except for:
 # - common files like LICENSE and README.md

--- a/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.2.0-001-system.yml
+++ b/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.2.0-001-system.yml
@@ -1,0 +1,15 @@
+easyconfigs:
+  - CUDA-12.6.0.eb:
+      options:
+        accept-eula-for: CUDA
+  - CUDA-12.8.0.eb:
+      options:
+        accept-eula-for: CUDA
+  - cuDNN-9.5.0.50-CUDA-12.6.0.eb:
+      options:
+        accept-eula-for: cuDNN
+        cuda-sanity-check-accept-missing-ptx: True
+  - cuDNN-9.10.1.4-CUDA-12.8.0.eb:
+      options:
+        accept-eula-for: cuDNN
+        cuda-sanity-check-accept-missing-ptx: True


### PR DESCRIPTION
Many things still need to be done... The software-layer-scripts PR should make sure to

- Run CUDA 12.6-based builds with `--module-only` if they target CC100 or above
- Change the requested CUDA compute capabilities for cuDNN where-ever that is needed. E.g. cuDNN `9.5.0` comes, I think, only with `9.0` device code, not `9.0a`. Thus, we should change the requested CC to `9.0` for that particular software name & version. For cuDNN 9.10.1.4, I _think_ `9.0a` is supported, but `10.0f` is not and it should be changed to `10.0`. I'd prefer to make those changes in hooks to avoid having to open multiple different software-layer PR, each with custom `options` for the build. Added advantage is that by doing it in the hooks, it also fixes things for `EESSI-extend`-based installations.

Edit 08-01: 
- `cuDNN-9.5.0.50` indeed contains device code for `7.0`, `8.0` and `9.0`, but not for `9.0a`, which causes the sanity check to fail. So we should make a conversion from 9.0a to 9.0 (in a hook?) for this version.
- `cuDNN-9.10.1.4` contains device code for `7.0`, `8.0`, `9.0a`, `10.0`, `12.0`, but not for `10.0f` and `12.0f`, so needs stripping of the suffix for those as well.

This PR _should_ replace https://github.com/EESSI/software-layer/pull/1278 , https://github.com/EESSI/software-layer/pull/1286 and https://github.com/EESSI/software-layer/pull/1287