### PR TITLE
{2025.06}[foss/2025a] R-bundle-Bioconductor 3.22

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.2.1-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.2.1-2025a.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - R-bundle-Bioconductor-3.22-foss-2025a-R-4.5.1.eb:
+      options:
+        parallel-extensions-install: true


### PR DESCRIPTION
```
41 out of 179 required modules missing:

* nettle/3.10.1-GCCcore-14.2.0 (nettle-3.10.1-GCCcore-14.2.0.eb)
* RapidJSON/1.1.0-20250205-GCCcore-14.2.0 (RapidJSON-1.1.0-20250205-GCCcore-14.2.0.eb)
* UDUNITS/2.2.28-GCCcore-14.2.0 (UDUNITS-2.2.28-GCCcore-14.2.0.eb)
* libogg/1.3.6-GCCcore-14.2.0 (libogg-1.3.6-GCCcore-14.2.0.eb)
* FLAC/1.5.0-GCCcore-14.2.0 (FLAC-1.5.0-GCCcore-14.2.0.eb)
* libvorbis/1.3.7-GCCcore-14.2.0 (libvorbis-1.3.7-GCCcore-14.2.0.eb)
* utf8proc/2.10.0-GCCcore-14.2.0 (utf8proc-2.10.0-GCCcore-14.2.0.eb)
* libopus/1.5.2-GCCcore-14.2.0 (libopus-1.5.2-GCCcore-14.2.0.eb)
* googletest/1.17.0-GCCcore-14.2.0 (googletest-1.17.0-GCCcore-14.2.0.eb)
* GLPK/5.0-GCCcore-14.2.0 (GLPK-5.0-GCCcore-14.2.0.eb)
* googlebenchmark/1.9.4-GCCcore-14.2.0 (googlebenchmark-1.9.4-GCCcore-14.2.0.eb)
* Ghostscript/10.05.1-GCCcore-14.2.0 (Ghostscript-10.05.1-GCCcore-14.2.0.eb)
* libsndfile/1.2.2-GCCcore-14.2.0 (libsndfile-1.2.2-GCCcore-14.2.0.eb)
* Abseil/20250512.1-GCCcore-14.2.0 (Abseil-20250512.1-GCCcore-14.2.0.eb)
* RE2/2024-07-02-GCCcore-14.2.0 (RE2-2024-07-02-GCCcore-14.2.0.eb)
* GEOS/3.13.1-GCC-14.2.0 (GEOS-3.13.1-GCC-14.2.0.eb)
* Pango/1.56.3-GCCcore-14.2.0 (Pango-1.56.3-GCCcore-14.2.0.eb)
* PostgreSQL/17.5-GCCcore-14.2.0 (PostgreSQL-17.5-GCCcore-14.2.0.eb)
* Xvfb/21.1.18-GCCcore-14.2.0 (Xvfb-21.1.18-GCCcore-14.2.0.eb)
* Arrow/22.0.0-gfbf-2025a (Arrow-22.0.0-gfbf-2025a.eb)
* ImageMagick/7.1.1-47-GCCcore-14.2.0 (ImageMagick-7.1.1-47-GCCcore-14.2.0.eb)
* nlohmann_json/3.12.0-GCCcore-14.2.0 (nlohmann_json-3.12.0-GCCcore-14.2.0.eb)
* PROJ/9.6.2-GCCcore-14.2.0 (PROJ-9.6.2-GCCcore-14.2.0.eb)
* libgeotiff/1.7.4-GCCcore-14.2.0 (libgeotiff-1.7.4-GCCcore-14.2.0.eb)
* libtirpc/1.3.6-GCCcore-14.2.0 (libtirpc-1.3.6-GCCcore-14.2.0.eb)
* HDF/4.3.1-GCCcore-14.2.0 (HDF-4.3.1-GCCcore-14.2.0.eb)
* CFITSIO/4.6.2-GCCcore-14.2.0 (CFITSIO-4.6.2-GCCcore-14.2.0.eb)
* arpack-ng/3.9.1-foss-2025a (arpack-ng-3.9.1-foss-2025a.eb)
* Armadillo/14.6.0-foss-2025a (Armadillo-14.6.0-foss-2025a.eb)
* json-c/0.18-GCCcore-14.2.0 (json-c-0.18-GCCcore-14.2.0.eb)
* Xerces-C++/3.3.0-GCCcore-14.2.0 (Xerces-C++-3.3.0-GCCcore-14.2.0.eb)
* Brunsli/0.1-GCCcore-14.2.0 (Brunsli-0.1-GCCcore-14.2.0.eb)
* Imath/3.1.12-GCCcore-14.2.0 (Imath-3.1.12-GCCcore-14.2.0.eb)
* OpenEXR/3.3.4-GCCcore-14.2.0 (OpenEXR-3.3.4-GCCcore-14.2.0.eb)
* LERC/4.0.0-GCCcore-14.2.0 (LERC-4.0.0-GCCcore-14.2.0.eb)
* SWIG/4.3.1-GCCcore-14.2.0 (SWIG-4.3.1-GCCcore-14.2.0.eb)
* netCDF/4.9.3-gompi-2025a (netCDF-4.9.3-gompi-2025a.eb)
* GDAL/3.11.1-foss-2025a (GDAL-3.11.1-foss-2025a.eb)
* R-bundle-CRAN/2025.10-foss-2025a (R-bundle-CRAN-2025.10-foss-2025a.eb)
* arrow-R/22.0.0-foss-2025a-R-4.5.1 (arrow-R-22.0.0-foss-2025a-R-4.5.1.eb)
* R-bundle-Bioconductor/3.22-foss-2025a-R-4.5.1 (R-bundle-Bioconductor-3.22-foss-2025a-R-4.5.1.eb)
```