### PR TITLE
{2025.06}[foss/2025b] R-bundle-Bioconductor 3.22

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.2.1-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.2.1-2025b.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - R-bundle-Bioconductor-3.22-foss-2025b-R-4.5.2.eb:
+      options:
+        parallel-extensions-install: true


### PR DESCRIPTION
```
49 out of 185 required modules missing:

* GSL/2.8-GCC-14.3.0 (GSL-2.8-GCC-14.3.0.eb)
* Boost/1.88.0-GCC-14.3.0 (Boost-1.88.0-GCC-14.3.0.eb)
* NLopt/2.10.0-GCCcore-14.3.0 (NLopt-2.10.0-GCCcore-14.3.0.eb)
* snappy/1.2.2-GCCcore-14.3.0 (snappy-1.2.2-GCCcore-14.3.0.eb)
* RapidJSON/1.1.0-20250205-GCCcore-14.3.0 (RapidJSON-1.1.0-20250205-GCCcore-14.3.0.eb)
* libgit2/1.9.1-GCCcore-14.3.0 (libgit2-1.9.1-GCCcore-14.3.0.eb)
* UDUNITS/2.2.28-GCCcore-14.3.0 (UDUNITS-2.2.28-GCCcore-14.3.0.eb)
* utf8proc/2.10.0-GCCcore-14.3.0 (utf8proc-2.10.0-GCCcore-14.3.0.eb)
* googletest/1.17.0-GCCcore-14.3.0 (googletest-1.17.0-GCCcore-14.3.0.eb)
* GLPK/5.0-GCCcore-14.3.0 (GLPK-5.0-GCCcore-14.3.0.eb)
* gfbf/2025b (gfbf-2025b.eb)
* googlebenchmark/1.9.4-GCCcore-14.3.0 (googlebenchmark-1.9.4-GCCcore-14.3.0.eb)
* Catch2/2.13.10-GCCcore-14.3.0 (Catch2-2.13.10-GCCcore-14.3.0.eb)
* Zip/3.0-GCCcore-14.3.0 (Zip-3.0-GCCcore-14.3.0.eb)
* Ghostscript/10.05.1-GCCcore-14.3.0 (Ghostscript-10.05.1-GCCcore-14.3.0.eb)
* libsndfile/1.2.2-GCCcore-14.3.0 (libsndfile-1.2.2-GCCcore-14.3.0.eb)
* Tk/9.0.1-GCCcore-14.3.0 (Tk-9.0.1-GCCcore-14.3.0.eb)
* nodejs/22.17.1-GCCcore-14.3.0 (nodejs-22.17.1-GCCcore-14.3.0.eb)
* Abseil/20250512.1-GCCcore-14.3.0 (Abseil-20250512.1-GCCcore-14.3.0.eb)
* RE2/2025-07-22-GCCcore-14.3.0 (RE2-2025-07-22-GCCcore-14.3.0.eb)
* GEOS/3.13.1-GCC-14.3.0 (GEOS-3.13.1-GCC-14.3.0.eb)
* PostgreSQL/17.5-GCCcore-14.3.0 (PostgreSQL-17.5-GCCcore-14.3.0.eb)
* PCRE/8.45-GCCcore-14.3.0 (PCRE-8.45-GCCcore-14.3.0.eb)
* hypothesis/6.136.6-GCCcore-14.3.0 (hypothesis-6.136.6-GCCcore-14.3.0.eb)
* pybind11/3.0.0-GCC-14.3.0 (pybind11-3.0.0-GCC-14.3.0.eb)
* spin/0.14-GCCcore-14.3.0 (spin-0.14-GCCcore-14.3.0.eb)
* SciPy-bundle/2025.07-gfbf-2025b (SciPy-bundle-2025.07-gfbf-2025b.eb)
* Arrow/22.0.0-gfbf-2025b (Arrow-22.0.0-gfbf-2025b.eb)
* freeglut/3.6.0-GCCcore-14.3.0 (freeglut-3.6.0-GCCcore-14.3.0.eb)
* R/4.5.2-gfbf-2025b (R-4.5.2-gfbf-2025b.eb)
* nlohmann_json/3.12.0-GCCcore-14.3.0 (nlohmann_json-3.12.0-GCCcore-14.3.0.eb)
* PROJ/9.6.2-GCCcore-14.3.0 (PROJ-9.6.2-GCCcore-14.3.0.eb)
* libgeotiff/1.7.4-GCCcore-14.3.0 (libgeotiff-1.7.4-GCCcore-14.3.0.eb)
* libheif/1.20.2-GCCcore-14.3.0 (libheif-1.20.2-GCCcore-14.3.0.eb)
* JasPer/4.2.8-GCCcore-14.3.0 (JasPer-4.2.8-GCCcore-14.3.0.eb)
* ImageMagick/7.1.2-7-GCCcore-14.3.0 (ImageMagick-7.1.2-7-GCCcore-14.3.0.eb)
* Szip/2.1.1-GCCcore-14.3.0 (Szip-2.1.1-GCCcore-14.3.0.eb)
* CFITSIO/4.6.2-GCCcore-14.3.0 (CFITSIO-4.6.2-GCCcore-14.3.0.eb)
* HDF/4.3.1-GCCcore-14.3.0 (HDF-4.3.1-GCCcore-14.3.0.eb)
* json-c/0.18-GCCcore-14.3.0 (json-c-0.18-GCCcore-14.3.0.eb)
* Xerces-C++/3.3.0-GCCcore-14.3.0 (Xerces-C++-3.3.0-GCCcore-14.3.0.eb)
* Brunsli/0.1-GCCcore-14.3.0 (Brunsli-0.1-GCCcore-14.3.0.eb)
* Qhull/2020.2-GCCcore-14.3.0 (Qhull-2020.2-GCCcore-14.3.0.eb)
* LERC/4.0.0-GCCcore-14.3.0 (LERC-4.0.0-GCCcore-14.3.0.eb)
* netCDF/4.9.3-gompi-2025b (netCDF-4.9.3-gompi-2025b.eb)
* GDAL/3.11.3-foss-2025b (GDAL-3.11.3-foss-2025b.eb)
* R-bundle-CRAN/2025.11-foss-2025b (R-bundle-CRAN-2025.11-foss-2025b.eb)
* arrow-R/22.0.0-foss-2025b-R-4.5.2 (arrow-R-22.0.0-foss-2025b-R-4.5.2.eb)
* R-bundle-Bioconductor/3.22-foss-2025b-R-4.5.2 (R-bundle-Bioconductor-3.22-foss-2025b-R-4.5.2.eb)
```