### PR TITLE
{2023.06}[foss/2023b] SPH-EXA-0.96.2 CUDA-12.4.0 

### DIFF
--- a/easystacks/software.eessi.io/2023.06/accel/nvidia/eessi-2023.06-eb-5.2.1-2023b-CUDA.yml
+++ b/easystacks/software.eessi.io/2023.06/accel/nvidia/eessi-2023.06-eb-5.2.1-2023b-CUDA.yml
@@ -1,0 +1,5 @@
+easyconfigs:
+  - SPH-EXA-0.96.1-foss-2023b-CUDA-12.4.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25584
+        from-commit: e9bdc50b5d5663640a9adc47f6aa033e76adf4b7

--- a/easystacks/software.eessi.io/2023.06/accel/nvidia/eessi-2023.06-eb-5.2.1-2023b-CUDA.yml
+++ b/easystacks/software.eessi.io/2023.06/accel/nvidia/eessi-2023.06-eb-5.2.1-2023b-CUDA.yml
@@ -1,5 +1,5 @@
 easyconfigs:
-  - SPH-EXA-0.96.1-foss-2023b-CUDA-12.4.0.eb:
+  - SPH-EXA-0.96.2-foss-2023b-CUDA-12.4.0.eb:
       options:
-        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25584
-        from-commit: e9bdc50b5d5663640a9adc47f6aa033e76adf4b7
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25693
+        from-commit: 171442f904bd4cef3aed146ae70bbcebf089c3b7

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.2.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.2.0-2023b.yml
@@ -6,4 +6,5 @@ easyconfigs:
         from-commit: 2ef62609e3e40785dfb28bcb91db143cee5924a5
   - SPH-EXA-0.96.1-foss-2023b-CUDA-12.4.0.eb:
       options:
-        from-pr: 25584
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25584
+        from-commit: e9bdc50b5d5663640a9adc47f6aa033e76adf4b7

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.2.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.2.0-2023b.yml
@@ -4,7 +4,3 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25004
         from-commit: 2ef62609e3e40785dfb28bcb91db143cee5924a5
-  - SPH-EXA-0.96.1-foss-2023b-CUDA-12.4.0.eb:
-      options:
-        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25584
-        from-commit: e9bdc50b5d5663640a9adc47f6aa033e76adf4b7

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.2.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.2.0-2023b.yml
@@ -4,3 +4,6 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25004
         from-commit: 2ef62609e3e40785dfb28bcb91db143cee5924a5
+  - SPH-EXA-0.96.1-foss-2023b-CUDA-12.4.0.eb:
+      options:
+        from-pr: 25584


### PR DESCRIPTION
adding SPH-EXA-0.96.1-foss-2023b-CUDA-12.4.0.eb for 2023.6

@ocaisa not sure if `from-commit` is preferred over `from-pr` ?

not sure why my editor did something weird with the newline characters in the file and github shows some weird diff