### PR TITLE
rebuild `LAMMPS/22Jul2025-foss-2024a-kokkos` for `sapphirerapids`

### DIFF
--- a/easystacks/software.eessi.io/2025.06/rebuilds/20260402-eb-5.2.1-LAMMPS-sapphirerapids.yml
+++ b/easystacks/software.eessi.io/2025.06/rebuilds/20260402-eb-5.2.1-LAMMPS-sapphirerapids.yml
@@ -1,0 +1,8 @@
+# rebuild LAMMPS for sapphirerapids, because build that was deployed was done with
+# an older commit that is missing a patch for a unit test,
+# see also https://github.com/EESSI/software-layer/pull/1335#issuecomment-4175706456
+easyconfigs:
+  - LAMMPS-22Jul2025-foss-2024a-kokkos.eb:
+      options:
+          # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25593
+          from-commit: e2dedae93022d7e3f10bf2983ca8a03b03b0dca0


### PR DESCRIPTION
Follow-up for:
- https://github.com/EESSI/software-layer/pull/1335

Build for `sapphirerapids` was done with commit `c484c12aaad5da0e27cd9269d59b4ecaa89927ab`, which corresponds to https://github.com/easybuilders/easybuild-easyconfigs/pull/25133, while other builds were done with commit `e2dedae93022d7e3f10bf2983ca8a03b03b0dca0` which corresponds with https://github.com/easybuilders/easybuild-easyconfigs/pull/25593.

The latter adds an extra patch to `LAMMPS-22Jul2025-foss-2024a-kokkos.eb` to fix an issue with one of the tests, so it doesn't actually affect the build itself, but we should do a rebuild for `sapphirerapids` in a follow-up to make sure that things are consistent.