### PR TITLE
{2025.06}[foss/2025a] imageio v2.37.0

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -1,0 +1,2 @@
+easycofigs:
+  - imageio-2.37.0-gfbf-2025a.eb

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -1,2 +1,2 @@
-easycofigs:
+easyconfigs:
   - imageio-2.37.0-gfbf-2025a.eb


### PR DESCRIPTION
missing packages:
```
imageio/2.37.0-gfbf-2025a
```