### PR TITLE
{2025.06}[foss/2025a] scikit-image v0.25.0

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - imageio-2.37.0-gfbf-2025a.eb
+  - scikit-image-0.25.0-foss-2025a.eb


### PR DESCRIPTION
missing packages:
```
bokeh/3.7.3-gfbf-2025a
dask/2025.5.1-gfbf-2025a
PyWavelets/1.9.0-foss-2025a
scikit-image/0.25.0-foss-2025a
```