### PR TITLE
{2025.06}[2025b] Dyninst 13.0.0

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
@@ -1,5 +1,2 @@
 easyconfigs:
-  - Dyninst-13.0.0-GCC-14.3.0.eb:
-      options:
-        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25798
-        from-commit: a62e2485218203c9e8dc1e90284781f115b39e2f
+  - Dyninst-13.0.0-GCC-14.3.0.eb

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
@@ -1,2 +1,5 @@
 easyconfigs:
-  - Dyninst-13.0.0-GCC-14.3.0.eb
+  - Dyninst-13.0.0-GCC-14.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25798
+        from-commit: a62e2485218203c9e8dc1e90284781f115b39e2f

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - Dyninst-13.0.0-GCC-14.3.0.eb


### PR DESCRIPTION
Probably requires https://github.com/EESSI/software-layer-scripts/pull/203, but let's build it without that hook first.