### PR TITLE
{2025.06}[2025b] mpi4py 4.1.0

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - Dyninst-13.0.0-GCC-14.3.0.eb
+  - mpi4py-4.1.0-gompi-2025b.eb

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
@@ -1,7 +1,4 @@
 easyconfigs:
   - Dyninst-13.0.0-GCC-14.3.0.eb
-<<<<<<< mpi4py_2025b
-  - mpi4py-4.1.0-gompi-2025b.eb
-=======
   - googletest-1.17.0-GCCcore-14.3.0.eb
->>>>>>> main
+  - mpi4py-4.1.0-gompi-2025b.eb


### PR DESCRIPTION
```
1 out of 36 required modules missing:

* mpi4py/4.1.0-gompi-2025b (mpi4py-4.1.0-gompi-2025b.eb)
```