### PR TITLE
{2025.06}[2025b] GROMACS 2025.4 with CUDA-12.9.1

### DIFF
--- a/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.3.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.3.0-2025b.yml
@@ -1,0 +1,5 @@
+easyconfigs:
+  - GROMACS-2025.3-foss-2025b-CUDA-12.9.1.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25215
+        from-commit: 03c7f74a35a6af26a410df4d393c59b2f9d9d97d

--- a/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.3.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.3.0-2025b.yml
@@ -1,5 +1,5 @@
 easyconfigs:
-  - GROMACS-2025.3-foss-2025b-CUDA-12.9.1.eb:
+  - GROMACS-2025.4-foss-2025b-CUDA-12.9.1.eb:
       options:
-        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25215
-        from-commit: 03c7f74a35a6af26a410df4d393c59b2f9d9d97d
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25837
+        from-commit: 23228c21d24b49a10bd5a51f09e14f5484d7b67d

--- a/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.3.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.3.0-2025b.yml
@@ -2,4 +2,4 @@ easyconfigs:
   - GROMACS-2025.4-foss-2025b-CUDA-12.9.1.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25837
-        from-commit: 23228c21d24b49a10bd5a51f09e14f5484d7b67d
+        from-commit: ab55b8136429dafb60f35aa27c137bde7b77dc2b


### PR DESCRIPTION
Requires:
- [x] #1479 
- [x] #1480 
- [x] #1481 

```
9 out of 87 required modules missing:

* Catch2/2.13.10-GCCcore-14.3.0 (Catch2-2.13.10-GCCcore-14.3.0.eb)
* gfbf/2025b (gfbf-2025b.eb)
* hypothesis/6.136.6-GCCcore-14.3.0 (hypothesis-6.136.6-GCCcore-14.3.0.eb)
* spin/0.14-GCCcore-14.3.0 (spin-0.14-GCCcore-14.3.0.eb)
* pybind11/3.0.0-GCC-14.3.0 (pybind11-3.0.0-GCC-14.3.0.eb)
* SciPy-bundle/2025.07-gfbf-2025b (SciPy-bundle-2025.07-gfbf-2025b.eb)
* networkx/3.5-gfbf-2025b (networkx-3.5-gfbf-2025b.eb)
* mpi4py/4.1.0-gompi-2025b (mpi4py-4.1.0-gompi-2025b.eb)
* GROMACS/2025.3-foss-2025b-CUDA-12.9.1 (GROMACS-2025.3-foss-2025b-CUDA-12.9.1.eb)
```