### PR TITLE
{2025.06}[2025b] dependencies for Qt6/6.9.3-GCCcore-14.3.0

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
@@ -2,3 +2,7 @@ easyconfigs:
   - Dyninst-13.0.0-GCC-14.3.0.eb
   - googletest-1.17.0-GCCcore-14.3.0.eb
   - SciPy-bundle-2025.07-gfbf-2025b.eb
+  - NSS-3.114-GCCcore-14.3.0.eb
+  - FFmpeg-7.1.2-GCCcore-14.3.0.eb
+  - JasPer-4.2.8-GCCcore-14.3.0.eb
+  - nodejs-22.17.1-GCCcore-14.3.0.eb


### PR DESCRIPTION
Helper PR for #1486 

```
10 out of 110 required modules missing:

* NSPR/4.37-GCCcore-14.3.0 (NSPR-4.37-GCCcore-14.3.0.eb)
* x264/20250831-GCCcore-14.3.0 (x264-20250831-GCCcore-14.3.0.eb)
* NSS/3.114-GCCcore-14.3.0 (NSS-3.114-GCCcore-14.3.0.eb)
* nodejs/22.17.1-GCCcore-14.3.0 (nodejs-22.17.1-GCCcore-14.3.0.eb)
* dav1d/1.5.2-GCCcore-14.3.0 (dav1d-1.5.2-GCCcore-14.3.0.eb)
* libheif/1.20.2-GCCcore-14.3.0 (libheif-1.20.2-GCCcore-14.3.0.eb)
* SDL2/2.32.10-GCCcore-14.3.0 (SDL2-2.32.10-GCCcore-14.3.0.eb)
* FFmpeg/7.1.2-GCCcore-14.3.0 (FFmpeg-7.1.2-GCCcore-14.3.0.eb)
* freeglut/3.6.0-GCCcore-14.3.0 (freeglut-3.6.0-GCCcore-14.3.0.eb)
* JasPer/4.2.8-GCCcore-14.3.0 (JasPer-4.2.8-GCCcore-14.3.0.eb)
```