### PR TITLE
{2023.06}[2023b] rebuild FFmpeg 6.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/rebuilds/20260428-eb-5.3.0-FFmpeg.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20260428-eb-5.3.0-FFmpeg.yml
@@ -1,0 +1,4 @@
+# rebuild FFmpeg to pick up on additional dependencies that were added,
+# see https://github.com/easybuilders/easybuild-easyconfigs/pull/24901
+easyconfigs:
+  - FFmpeg-6.0-GCCcore-13.2.0.eb


### PR DESCRIPTION
Similar to https://github.com/EESSI/software-layer/pull/1422, doing the same for the FFmpeg in 2023.06 to solve the issues we're seeing in https://github.com/EESSI/software-layer/pull/1454#issuecomment-4335419496.

Requires:
 - https://github.com/EESSI/software-layer/pull/1489.