### PR TITLE
{2025.06} rocm-compilers/19.0.0-ROCm-6.4.1

### DIFF
--- a/easystacks/software.eessi.io/2025.06/accel/amd/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/accel/amd/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -7,8 +7,3 @@ easyconfigs:
       options:
         # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
         from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1
-  - HIP-6.4.1-rocm-compilers-19.0.0-ROCm-6.4.1.eb:
-      options:
-        # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
-        from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1
-        

--- a/easystacks/software.eessi.io/2025.06/accel/amd/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/accel/amd/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -11,3 +11,4 @@ easyconfigs:
       options:
         # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
         from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1
+        

--- a/easystacks/software.eessi.io/2025.06/accel/amd/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/accel/amd/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -3,3 +3,11 @@ easyconfigs:
       options:
         # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25873
         from-commit: 69821ba47c0666e3cf1a3a159ddacfef5ee7f34d
+  - rocm-compilers-19.0.0-ROCm-6.4.1.eb:
+      options:
+        # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
+        from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1
+  - HIP-6.4.1-rocm-compilers-19.0.0-ROCm-6.4.1.eb:
+      options:
+        # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
+        from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1


### PR DESCRIPTION
Prioritize the components from https://github.com/easybuilders/easybuild-easyconfigs/pull/25576 we need for [GROMACS-SYCL](https://github.com/easybuilders/easybuild-easyconfigs/pull/25871/changes#diff-572661f863418371326205d90c5fd988ae2bcb32ab6dca6d3155ef140193343f)