### PR TITLE
{2025.06}[foss/2025a] BioPerl v1.7.8

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -3,3 +3,4 @@ easyconfigs:
   - scikit-image-0.25.0-foss-2025a.eb
   - elfutils-0.193-GCCcore-14.2.0.eb
   - scikit-bio-0.7.1.post1-foss-2025a.eb
+  - BioPerl-1.7.8-GCCcore-14.2.0.eb


### PR DESCRIPTION
missing packages:
```
BioPerl/1.7.8-GCCcore-14.2.0
DB/18.1.40-GCCcore-14.2.0
DB_File/1.859-GCCcore-14.2.0
XML-LibXML/2.0210-GCCcore-14.2.0
```