### PR TITLE
{2025.06}[2025b] amdahl 0.4.1

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
@@ -24,3 +24,7 @@ easyconfigs:
       options:
           # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25901
           from-commit: b0e5483e1d8e951a75d714d461155547e74ec218
+  - amdahl-0.4.1-gompi-2025b.eb:
+      options:
+          # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25999
+          from-commit: 960bb9bbf98f11ac376f43a3d36d5cf1cedc96f1


### PR DESCRIPTION
Requires https://github.com/easybuilders/easybuild-easyconfigs/pull/25999

```
1 out of 37 required modules missing:

* amdahl/0.4.1-gompi-2025b (amdahl-0.4.1-gompi-2025b.eb)
```