### PR TITLE
{2025.06}[foss/2025b] QuantumESPRESSO 7.5

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
@@ -28,3 +28,4 @@ easyconfigs:
       options:
           # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25999
           from-commit: 960bb9bbf98f11ac376f43a3d36d5cf1cedc96f1
+  - QuantumESPRESSO-7.5-foss-2025b.eb


### PR DESCRIPTION
```
3 out of 59 required modules missing:

* libxc/7.0.0-GCC-14.3.0 (libxc-7.0.0-GCC-14.3.0.eb)
* ELPA/2025.06.002-foss-2025b (ELPA-2025.06.002-foss-2025b.eb)
* QuantumESPRESSO/7.5-foss-2025b (QuantumESPRESSO-7.5-foss-2025b.eb)
```