### PR TITLE
{2025.06}[foss-2024a] Siesta 5.4.2

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2024a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - Siesta-5.4.2-foss-2024a.eb


### PR DESCRIPTION
Following the tutorial from https://www.eessi.io/docs/adding_software/opening_pr/

edit:
```
14 out of 86 required modules missing:

* test-drive/0.5.0-GCC-13.3.0 (test-drive-0.5.0-GCC-13.3.0.eb)
* libxc/6.2.2-GCC-13.3.0 (libxc-6.2.2-GCC-13.3.0.eb)
* json-fortran/9.0.3-GCC-13.3.0 (json-fortran-9.0.3-GCC-13.3.0.eb)
* flook/0.8.4-GCC-13.3.0 (flook-0.8.4-GCC-13.3.0.eb)
* mctc-lib/0.3.1-GCC-13.3.0 (mctc-lib-0.3.1-GCC-13.3.0.eb)
* mstore/0.3.0-GCC-13.3.0 (mstore-0.3.0-GCC-13.3.0.eb)
* libfdf/0.5.1-GCC-13.3.0 (libfdf-0.5.1-GCC-13.3.0.eb)
* TOML-Fortran/0.4.2-GCC-13.3.0 (TOML-Fortran-0.4.2-GCC-13.3.0.eb)
* ruamel.yaml/0.18.6-GCCcore-13.3.0 (ruamel.yaml-0.18.6-GCCcore-13.3.0.eb)
* xmlf90/1.6.3-GCC-13.3.0 (xmlf90-1.6.3-GCC-13.3.0.eb)
* libPSML/2.1.0-GCC-13.3.0 (libPSML-2.1.0-GCC-13.3.0.eb)
* Simple-DFTD3/1.2.1-gfbf-2024a (Simple-DFTD3-1.2.1-gfbf-2024a.eb)
* libGridXC/2.0.2-gompi-2024a (libGridXC-2.0.2-gompi-2024a.eb)
* Siesta/5.4.2-foss-2024a (Siesta-5.4.2-foss-2024a.eb)
```