### PR TITLE
{2025.06}[foss/2025b] SentencePiece v0.2.1

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
@@ -29,3 +29,4 @@ easyconfigs:
           # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25999
           from-commit: 960bb9bbf98f11ac376f43a3d36d5cf1cedc96f1
   - QuantumESPRESSO-7.5-foss-2025b.eb
+  - SentencePiece-0.2.1-GCC-14.3.0.eb


### PR DESCRIPTION
missing packages:
```
gperftools/2.17.2-GCCcore-14.3.0
SentencePiece/0.2.1-GCC-14.3.0
```