### PR TITLE
{2025.06}[foss/2025b] gnuplot 6.0.3

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
@@ -30,3 +30,4 @@ easyconfigs:
           from-commit: 960bb9bbf98f11ac376f43a3d36d5cf1cedc96f1
   - QuantumESPRESSO-7.5-foss-2025b.eb
   - SentencePiece-0.2.1-GCC-14.3.0.eb
+  - gnuplot-6.0.3-GCCcore-14.3.0.eb


### PR DESCRIPTION
```
3 out of 128 required modules missing:

* Lua/5.4.8-GCCcore-14.3.0 (Lua-5.4.8-GCCcore-14.3.0.eb)
* libcerf/3.0-GCCcore-14.3.0 (libcerf-3.0-GCCcore-14.3.0.eb)
* gnuplot/6.0.3-GCCcore-14.3.0 (gnuplot-6.0.3-GCCcore-14.3.0.eb)
```