### PR TITLE
{2025.06}[foss/2025a] OpenFOAM 13

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -8,3 +8,4 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25981
         from-commit: df78eb85f1e5f2b42c1feba2e93f4dc822a02474
+  - OpenFOAM-13-foss-2025a.eb


### PR DESCRIPTION
```
[2](https://github.com/EESSI/software-layer/actions/runs/27188897626/job/80264116258?pr=1515#step:6:1263)
9 out of 164 required modules missing:

* CGAL/6.0.1-GCCcore-14.2.0 (CGAL-6.0.1-GCCcore-14.2.0.eb)
* libgd/2.3.3-GCCcore-14.2.0 (libgd-2.3.3-GCCcore-14.2.0.eb)
* libcerf/3.0-GCCcore-14.2.0 (libcerf-3.0-GCCcore-14.2.0.eb)
* Lua/5.4.8-GCCcore-14.2.0 (Lua-5.4.8-GCCcore-14.2.0.eb)
* Zoltan/3.901-foss-2025a (Zoltan-3.901-foss-2025a.eb)
* Pango/1.56.3-GCCcore-14.2.0 (Pango-1.56.3-GCCcore-14.2.0.eb)
* ParaView/6.0.1-foss-2025a (ParaView-6.0.1-foss-2025a.eb)
* gnuplot/6.0.3-GCCcore-14.2.0 (gnuplot-6.0.3-GCCcore-14.2.0.eb)
* OpenFOAM/13-foss-2025a (OpenFOAM-13-foss-2025a.eb)
```

requires:
- https://github.com/EESSI/software-layer-scripts/pull/242