### PR TITLE
{2025.06}[foss/2025b] Octave 11.1.0

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025b.yml
@@ -40,3 +40,4 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26224
         from-commit: 802b20b7210d43fe19a1bc67c0b8e764f41bb2a4
+  - Octave-11.1.0-foss-2025b.eb


### PR DESCRIPTION
```
18 out of 174 required modules missing:

* gawk/5.3.2-GCCcore-14.3.0 (gawk-5.3.2-GCCcore-14.3.0.eb)
* GLPK/5.0-GCCcore-14.3.0 (GLPK-5.0-GCCcore-14.3.0.eb)
* xprop/1.2.8-GCCcore-14.3.0 (xprop-1.2.8-GCCcore-14.3.0.eb)
* qrupdate/1.1.2-GCCcore-14.3.0 (qrupdate-1.1.2-GCCcore-14.3.0.eb)
* PLY/3.11-GCCcore-14.3.0 (PLY-3.11-GCCcore-14.3.0.eb)
* SuiteSparse/7.11.0-gfbf-2025b (SuiteSparse-7.11.0-gfbf-2025b.eb)
* SUNDIALS/7.6.0-foss-2025b (SUNDIALS-7.6.0-foss-2025b.eb)
* Ghostscript/10.05.1-GCCcore-14.3.0 (Ghostscript-10.05.1-GCCcore-14.3.0.eb)
* GraphicsMagick/1.3.45-GCCcore-14.3.0 (GraphicsMagick-1.3.45-GCCcore-14.3.0.eb)
* RapidJSON/1.1.0-20250205-GCCcore-14.3.0 
(RapidJSON-1.1.0-20250205-GCCcore-14.3.0.eb)
* libsndfile/1.2.2-GCCcore-14.3.0 (libsndfile-1.2.2-GCCcore-14.3.0.eb)
* SIP/6.13.1-GCCcore-14.3.0 (SIP-6.13.1-GCCcore-14.3.0.eb)
* PyQt-builder/1.19.0-GCCcore-14.3.0 (PyQt-builder-1.19.0-GCCcore-14.3.0.eb)
* FLTK/1.4.4-GCCcore-14.3.0 (FLTK-1.4.4-GCCcore-14.3.0.eb)
* GL2PS/1.4.2-GCCcore-14.3.0 (GL2PS-1.4.2-GCCcore-14.3.0.eb)
* PyQt6/6.9.1-GCCcore-14.3.0 (PyQt6-6.9.1-GCCcore-14.3.0.eb)
* QScintilla/2.14.1-GCCcore-14.3.0 (QScintilla-2.14.1-GCCcore-14.3.0.eb)
* Octave/11.1.0-foss-2025b (Octave-11.1.0-foss-2025b.eb)
```