### PR TITLE
{2025.06}[2024a] Visit 3.4.2

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2024a.yml
@@ -5,4 +5,7 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyblocks/pull/4149
         include-easyblocks-from-commit: ebcd874f5317e18ddf0f90cb14903a633e013a6e
-
+  - Visit-3.4.2-foss-2024a.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/25820
+        from-commit: 9dc8955e94bf914e992c9a43a4b0dd6710a36c7c


### PR DESCRIPTION
```
2 out of 136 required modules missing:

* Qwt/6.3.0-GCCcore-13.3.0 (Qwt-6.3.0-GCCcore-13.3.0.eb)
* Visit/3.4.2-foss-2024a (Visit-3.4.2-foss-2024a.eb)
```

edit: ~~needs a fix in our EasyBuild hooks, similar to https://github.com/EESSI/software-layer-scripts/pull/274/~~, done, see:
- https://github.com/EESSI/software-layer-scripts/pull/305