### PR TITLE
{2025.06}[GCCcore/14.2.0] CPU-only dependencies for HIP and RCCL

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -22,18 +22,18 @@ easyconfigs:
   - glog-0.7.1-GCCcore-14.2.0.eb
   - zlib-1.3.1-GCCcore-14.2.0.eb
   - rocm-smi-7.6.0-GCCcore-14.2.0-ROCm-6.4.1.eb:
-    options:
-        # See https://github.com/easybuilders/easybuild-easyconfigs/pull/23280
-        from-commit: a9674bb1adb471eac49d076a71bf00ae8a598d61
+      options:
+            # See https://github.com/easybuilders/easybuild-easyconfigs/pull/23280
+            from-commit: a9674bb1adb471eac49d076a71bf00ae8a598d61
   - CppHeaderParser-2.7.4-GCCcore-14.2.0.eb:
-    options:
-        # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
-        from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1
+      options:
+          # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
+          from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1
   - rocprofiler-register-0.4.0-GCCcore-14.2.0-ROCm-6.4.1.eb:
-    options:
-        # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
-        from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1
+      options:
+          # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
+          from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1
   - rocm-core-6.4.0-GCCcore-14.2.0-ROCm-6.4.1.eb:
-    options:
-        # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
-        from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1
+      options:
+          # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
+          from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -17,3 +17,8 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyblocks/pull/4066
         include-easyblocks-from-commit: 4ec63c949166ae19ee3e329e8ab5fc8358926384
   - Octave-10.3.0-foss-2025a.eb
+  - CppHeaderParser-2.7.4-GCCcore-14.2.0.eb
+  - fmt-11.2.0-GCCcore-14.2.0.eb
+  - gflags-2.2.2-GCCcore-14.2.0.eb
+  - glog-0.7.1-GCCcore-14.2.0.eb
+  - rocprofiler-register-0.4.0-GCCcore-14.2.0-ROCm-6.4.1.eb

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -35,5 +35,5 @@ easyconfigs:
         from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1
   - rocm-core-6.4.0-GCCcore-14.2.0-ROCm-6.4.1.eb:
     options:
-          # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
-          from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1
+        # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
+        from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -33,7 +33,7 @@ easyconfigs:
     options:
         # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
         from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1
-  - rocm-core-GCCcore-14.2.0-ROCm-6.4.1.eb:
+  - rocm-core-6.4.0-GCCcore-14.2.0-ROCm-6.4.1.eb:
     options:
           # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
           from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -17,8 +17,23 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyblocks/pull/4066
         include-easyblocks-from-commit: 4ec63c949166ae19ee3e329e8ab5fc8358926384
   - Octave-10.3.0-foss-2025a.eb
-  - CppHeaderParser-2.7.4-GCCcore-14.2.0.eb
   - fmt-11.2.0-GCCcore-14.2.0.eb
   - gflags-2.2.2-GCCcore-14.2.0.eb
   - glog-0.7.1-GCCcore-14.2.0.eb
-  - rocprofiler-register-0.4.0-GCCcore-14.2.0-ROCm-6.4.1.eb
+  - zlib-1.3.1-GCCcore-14.2.0.eb
+  - rocm-smi-7.6.0-GCCcore-14.2.0-ROCm-6.4.1.eb:
+    options:
+        # See https://github.com/easybuilders/easybuild-easyconfigs/pull/23280
+        from-commit: a9674bb1adb471eac49d076a71bf00ae8a598d61
+  - CppHeaderParser-2.7.4-GCCcore-14.2.0.eb:
+    options:
+        # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
+        from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1
+  - rocprofiler-register-0.4.0-GCCcore-14.2.0-ROCm-6.4.1.eb:
+    options:
+        # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
+        from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1
+  - rocm-core-GCCcore-14.2.0-ROCm-6.4.1.eb:
+    options:
+          # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
+          from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -20,7 +20,6 @@ easyconfigs:
   - fmt-11.2.0-GCCcore-14.2.0.eb
   - gflags-2.2.2-GCCcore-14.2.0.eb
   - glog-0.7.1-GCCcore-14.2.0.eb
-  - zlib-1.3.1-GCCcore-14.2.0.eb
   - rocm-smi-7.6.0-GCCcore-14.2.0-ROCm-6.4.1.eb:
       options:
             # See https://github.com/easybuilders/easybuild-easyconfigs/pull/23280

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -17,22 +17,3 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyblocks/pull/4066
         include-easyblocks-from-commit: 4ec63c949166ae19ee3e329e8ab5fc8358926384
   - Octave-10.3.0-foss-2025a.eb
-  - fmt-11.2.0-GCCcore-14.2.0.eb
-  - gflags-2.2.2-GCCcore-14.2.0.eb
-  - glog-0.7.1-GCCcore-14.2.0.eb
-  - rocm-smi-7.6.0-GCCcore-14.2.0-ROCm-6.4.1.eb:
-      options:
-            # See https://github.com/easybuilders/easybuild-easyconfigs/pull/23280
-            from-commit: a9674bb1adb471eac49d076a71bf00ae8a598d61
-  - CppHeaderParser-2.7.4-GCCcore-14.2.0.eb:
-      options:
-          # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
-          from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1
-  - rocprofiler-register-0.4.0-GCCcore-14.2.0-ROCm-6.4.1.eb:
-      options:
-          # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
-          from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1
-  - rocm-core-6.4.0-GCCcore-14.2.0-ROCm-6.4.1.eb:
-      options:
-          # See https://github.com/easybuilders/easybuild-easyconfigs/pull/25576
-          from-commit: 6a000bf508fe5406a184c652f2fde31e6176fff1

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025a.yml
@@ -1,0 +1,8 @@
+easyconfigs:
+  - fmt-11.2.0-GCCcore-14.2.0.eb
+  - gflags-2.2.2-GCCcore-14.2.0.eb
+  - glog-0.7.1-GCCcore-14.2.0.eb
+  - rocm-smi-7.6.0-GCCcore-14.2.0-ROCm-6.4.1.eb
+  - CppHeaderParser-2.7.4-GCCcore-14.2.0.eb
+  - rocprofiler-register-0.4.0-GCCcore-14.2.0-ROCm-6.4.1.eb
+  - rocm-core-6.4.0-GCCcore-14.2.0-ROCm-6.4.1.eb

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025a.yml
@@ -5,4 +5,7 @@ easyconfigs:
   - rocm-smi-7.6.0-GCCcore-14.2.0-ROCm-6.4.1.eb
   - CppHeaderParser-2.7.4-GCCcore-14.2.0.eb
   - rocprofiler-register-0.4.0-GCCcore-14.2.0-ROCm-6.4.1.eb
-  - rocm-core-6.4.0-GCCcore-14.2.0-ROCm-6.4.1.eb
+  - rocm-core-6.4.1-GCCcore-14.2.0-ROCm-6.4.1.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26407
+        from-commit: 87cd5a2451ab7de14dd1463cec5b2f874ad0e9fd


### PR DESCRIPTION
Add CPU dependencies for HIP and RCCL #1526 