### PR TITLE
rebuild `Rust/1.91.1-GCCcore-14.3.0` to fix RPATH linking

### DIFF
--- a/easystacks/software.eessi.io/2025.06/rebuilds/20260621-eb-5.3.1-rebuild-Rust-1.91.yml
+++ b/easystacks/software.eessi.io/2025.06/rebuilds/20260621-eb-5.3.1-rebuild-Rust-1.91.yml
@@ -1,0 +1,5 @@
+# rebuild Rust/1.91.1-GCCcore-14.3.0, to fix RPATH linking
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/26232
+# fixed in EasyBuild v5.3.1, see https://github.com/easybuilders/easybuild-easyblocks/pull/4156
+easyconfigs:
+  - Rust-1.91.1-GCCcore-14.3.0.eb


### PR DESCRIPTION
fixes #1523