### PR TITLE
{2023.06}[foss-2023a] Siesta 5.4.2

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.3.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.3.0-2023a.yml
@@ -1,5 +1,5 @@
 easyconfigs:
   # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26240
   - Siesta-5.4.2-foss-2023a.eb:
-    options:
-      from-commit: 6ed961daac38293265e3a952be732ae9244fc01c
+      options:
+        from-commit: 6ed961daac38293265e3a952be732ae9244fc01c

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.3.0-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.3.0-2023a.yml
@@ -1,0 +1,5 @@
+easyconfigs:
+  # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26240
+  - Siesta-5.4.2-foss-2023a.eb:
+    options:
+      from-commit: 6ed961daac38293265e3a952be732ae9244fc01c


### PR DESCRIPTION
Adding Siesta 5.4.2 to EESSI 2023.06.

If this is ok, can we include the latest version of Siesta 5.4.2 instead of rebuild Siesta 5.2.2? #1535 