### PR TITLE
{2025.06}[2025b] LAMMPS 22Jul2025 update4

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025b.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - multicharge-0.5.0-gfbf-2025b.eb
+  - LAMMPS-22Jul2025_update4-foss-2025b-kokkos.eb


### PR DESCRIPTION
```
9 out of 172 required modules missing:

* PCRE/8.45-GCCcore-14.3.0 (PCRE-8.45-GCCcore-14.3.0.eb)
* Voro++/0.4.6-GCCcore-14.3.0 (Voro++-0.4.6-GCCcore-14.3.0.eb)
* archspec/0.2.5-GCCcore-14.3.0 (archspec-0.2.5-GCCcore-14.3.0.eb)
* kim-api/2.4.1-GCC-14.3.0 (kim-api-2.4.1-GCC-14.3.0.eb)
* xxd/9.1.1775-GCCcore-14.3.0 (xxd-9.1.1775-GCCcore-14.3.0.eb)
* MDI/1.4.35-gompi-2025b (MDI-1.4.35-gompi-2025b.eb)
* PLUMED/2.9.4-foss-2025b (PLUMED-2.9.4-foss-2025b.eb)
* VTK/9.5.2-foss-2025b (VTK-9.5.2-foss-2025b.eb)
* LAMMPS/22Jul2025_update4-foss-2025b-kokkos (LAMMPS-22Jul2025_update4-foss-2025b-kokkos.eb)
```