### PR TITLE
{2023.06}[foss-2023a] octave-kernel 0.36.0

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.3.1-2023a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.3.1-2023a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - octave-kernel-0.36.0-foss-2023a.eb


### PR DESCRIPTION
```
[5](https://github.com/EESSI/software-layer/actions/runs/28665865572/job/85017346919?pr=1540#step:6:376)
2 out of 156 required modules missing:

* metakernel/0.30.4-GCC-12.3.0 (metakernel-0.30.4-GCC-12.3.0.eb)
* octave-kernel/0.36.0-foss-2023a (octave-kernel-0.36.0-foss-2023a.eb)
```