### PR TITLE
{2025.06}[2025a] ollama 0.24.0 w/ CUDA 12.8.0

### DIFF
--- a/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.3.1-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.3.1-2025a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - ollama-0.24.0-GCCcore-14.2.0-CUDA-12.8.0.eb


### PR DESCRIPTION
```
1 out of 25 required modules missing:

* ollama/0.24.0-GCCcore-14.2.0-CUDA-12.8.0 (ollama-0.24.0-GCCcore-14.2.0-CUDA-12.8.0.eb)

```