### PR TITLE
{2025.06}[GCCcore/14.3.0] modkit v0.6.4

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025b.yml
@@ -1,3 +1,7 @@
 easyconfigs:
   - multicharge-0.5.0-gfbf-2025b.eb
   - LAMMPS-22Jul2025_update4-foss-2025b-kokkos.eb
+  - modkit-0.6.4-GCCcore-14.3.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26379
+        from-commit: 850d6f9060556744c8d3b38c7879c5196a81d499 

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025b.yml
@@ -1,7 +1,7 @@
 easyconfigs:
   - multicharge-0.5.0-gfbf-2025b.eb
   - LAMMPS-22Jul2025_update4-foss-2025b-kokkos.eb
- - SMC++-1.15.4-gfbf-2025b.eb
+  - SMC++-1.15.4-gfbf-2025b.eb
   - cling-kernel-1.2-GCCcore-14.3.0.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26428


### PR DESCRIPTION
missing packages:
```
modkit/0.6.4-GCCcore-14.3.0
Perl-bundle-CPAN/5.40.2-GCCcore-14.3.0
``` 