### PR TITLE
{2026.06}[foss/2026.1] First easystack for 2026.01: `GCCcore/15.2.0`

### DIFF
--- a/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-2026.1.yml
+++ b/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-2026.1.yml
@@ -1,0 +1,19 @@
+easyconfigs:
+  # initially used the following commit for GCCcore, but that's part of 5.3.1 now:
+  # from-commit: 94aeb90638583b8153b8c3dce5f9fc2046c7795e
+  - GCCcore-15.2.0.eb
+  - Perl-5.42.0-GCCcore-15.2.0.eb:
+      options:
+        max-parallel: "1"
+  - Perl-5.38.0.eb:
+      options:
+        max-parallel: "1"
+  - hwloc-2.13.0-GCCcore-15.2.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26344
+        from-commit: 608229129d057b3abfd475b5e5f22eba6b711801
+  - libunistring-1.4.1-GCCcore-15.2.0.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26351
+        from-commit: f3faa6b1d73a6988e1fc2083778d1b7144c5c7d3
+  - foss-2026.1.eb

--- a/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-2026.1.yml
+++ b/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-2026.1.yml
@@ -2,18 +2,18 @@ easyconfigs:
   # initially used the following commit for GCCcore, but that's part of 5.3.1 now:
   # from-commit: 94aeb90638583b8153b8c3dce5f9fc2046c7795e
   - GCCcore-15.2.0.eb
-  - Perl-5.42.0-GCCcore-15.2.0.eb:
-      options:
-        max-parallel: "1"
-  - Perl-5.38.0.eb:
-      options:
-        max-parallel: "1"
-  - hwloc-2.13.0-GCCcore-15.2.0.eb:
-      options:
-        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26344
-        from-commit: 608229129d057b3abfd475b5e5f22eba6b711801
-  - libunistring-1.4.1-GCCcore-15.2.0.eb:
-      options:
-        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26351
-        from-commit: f3faa6b1d73a6988e1fc2083778d1b7144c5c7d3
-  - foss-2026.1.eb
+#  - Perl-5.42.0-GCCcore-15.2.0.eb:
+#      options:
+#        max-parallel: "1"
+#  - Perl-5.38.0.eb:
+#      options:
+#        max-parallel: "1"
+#  - hwloc-2.13.0-GCCcore-15.2.0.eb:
+#      options:
+#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26344
+#        from-commit: 608229129d057b3abfd475b5e5f22eba6b711801
+#  - libunistring-1.4.1-GCCcore-15.2.0.eb:
+#      options:
+#        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26351
+#        from-commit: f3faa6b1d73a6988e1fc2083778d1b7144c5c7d3
+#  - foss-2026.1.eb

--- a/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-2026.1.yml
+++ b/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-2026.1.yml
@@ -1,6 +1,4 @@
 easyconfigs:
-  # initially used the following commit for GCCcore, but that's part of 5.3.1 now:
-  # from-commit: 94aeb90638583b8153b8c3dce5f9fc2046c7795e
   - GCCcore-15.2.0.eb
 #  - Perl-5.42.0-GCCcore-15.2.0.eb:
 #      options:


### PR DESCRIPTION
See how far this gets. It'll need

- [x] Probably: a `2026.06` [module](https://github.com/EESSI/software-layer-scripts/pull/266) to be made available through `software-layer-scripts`.
- [x] Definitely: build bot instances need to be made `2026.06` aware 

Based on Bob's easystack from https://gitlab.com/eessi/support/-/work_items/220#note_3478647043

Edit: It seems it doesn't need https://github.com/EESSI/software-layer-scripts/pull/266 since that only provides a symlink. It should generate the module in the `/version` specific directory itself, I suppose? Let's see... First, we need bot instances that are `2026.06`-aware.