### PR TITLE
{2025.06}[foss/2025b] R-bundle-CRAN 2025.11

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025b.yml
@@ -11,3 +11,6 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26421
         from-commit: 538776cf616f8eeeca9e96c8110c065f5256932c
   - R-4.5.2-gfbf-2025b.eb
+  - R-bundle-CRAN-2025.11-foss-2025b.eb:
+      options:
+        parallel-extensions-install: true


### PR DESCRIPTION
```
16 out of 178 required modules missing:

* NLopt/2.10.0-GCCcore-14.3.0 (NLopt-2.10.0-GCCcore-14.3.0.eb)
* UDUNITS/2.2.28-GCCcore-14.3.0 (UDUNITS-2.2.28-GCCcore-14.3.0.eb)
* PostgreSQL/17.5-GCCcore-14.3.0 (PostgreSQL-17.5-GCCcore-14.3.0.eb)
* GEOS/3.13.1-GCC-14.3.0 (GEOS-3.13.1-GCC-14.3.0.eb)
* ImageMagick/7.1.2-7-GCCcore-14.3.0 (ImageMagick-7.1.2-7-GCCcore-14.3.0.eb)
* nlohmann_json/3.12.0-GCCcore-14.3.0 (nlohmann_json-3.12.0-GCCcore-14.3.0.eb)
* PROJ/9.6.2-GCCcore-14.3.0 (PROJ-9.6.2-GCCcore-14.3.0.eb)
* libgeotiff/1.7.4-GCCcore-14.3.0 (libgeotiff-1.7.4-GCCcore-14.3.0.eb)
* CFITSIO/4.6.2-GCCcore-14.3.0 (CFITSIO-4.6.2-GCCcore-14.3.0.eb)
* HDF/4.3.1-GCCcore-14.3.0 (HDF-4.3.1-GCCcore-14.3.0.eb)
* json-c/0.18-GCCcore-14.3.0 (json-c-0.18-GCCcore-14.3.0.eb)
* Xerces-C++/3.3.0-GCCcore-14.3.0 (Xerces-C++-3.3.0-GCCcore-14.3.0.eb)
* Brunsli/0.1-GCCcore-14.3.0 (Brunsli-0.1-GCCcore-14.3.0.eb)
* LERC/4.0.0-GCCcore-14.3.0 (LERC-4.0.0-GCCcore-14.3.0.eb)
* GDAL/3.11.3-foss-2025b (GDAL-3.11.3-foss-2025b.eb)
* R-bundle-CRAN/2025.11-foss-2025b (R-bundle-CRAN-2025.11-foss-2025b.eb)
```