### PR TITLE
{2025.06}[foss/2025a] R-bundle-CRAN 2025.10

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025a.yml
@@ -10,3 +10,6 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26407
         from-commit: 87cd5a2451ab7de14dd1463cec5b2f874ad0e9fd
   - googletest-1.17.0-GCCcore-14.2.0.eb
+  - R-bundle-CRAN-2025.10-foss-2025a.eb:
+      options:
+        parallel-extensions-install: true

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025a.yml
@@ -12,4 +12,6 @@ easyconfigs:
   - googletest-1.17.0-GCCcore-14.2.0.eb
   - R-bundle-CRAN-2025.10-foss-2025a.eb:
       options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26573
+        from-commit: cf51f1327ae849bc23990669abdd435bfb6e05fb
         parallel-extensions-install: true

--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025a.yml
@@ -13,5 +13,5 @@ easyconfigs:
   - R-bundle-CRAN-2025.10-foss-2025a.eb:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26573
-        from-commit: cf51f1327ae849bc23990669abdd435bfb6e05fb
+        from-commit: c2d5dcaecee1ab9abfee143b87243c44ca305273
         parallel-extensions-install: true


### PR DESCRIPTION
```
19 out of 170 required modules missing:

* nettle/3.10.1-GCCcore-14.2.0 (nettle-3.10.1-GCCcore-14.2.0.eb)
* UDUNITS/2.2.28-GCCcore-14.2.0 (UDUNITS-2.2.28-GCCcore-14.2.0.eb)
* PostgreSQL/17.5-GCCcore-14.2.0 (PostgreSQL-17.5-GCCcore-14.2.0.eb)
* GEOS/3.13.1-GCC-14.2.0 (GEOS-3.13.1-GCC-14.2.0.eb)
* ImageMagick/7.1.1-47-GCCcore-14.2.0 (ImageMagick-7.1.1-47-GCCcore-14.2.0.eb)
* nlohmann_json/3.12.0-GCCcore-14.2.0 (nlohmann_json-3.12.0-GCCcore-14.2.0.eb)
* PROJ/9.6.2-GCCcore-14.2.0 (PROJ-9.6.2-GCCcore-14.2.0.eb)
* libgeotiff/1.7.4-GCCcore-14.2.0 (libgeotiff-1.7.4-GCCcore-14.2.0.eb)
* Xvfb/21.1.18-GCCcore-14.2.0 (Xvfb-21.1.18-GCCcore-14.2.0.eb)
* libtirpc/1.3.6-GCCcore-14.2.0 (libtirpc-1.3.6-GCCcore-14.2.0.eb)
* HDF/4.3.1-GCCcore-14.2.0 (HDF-4.3.1-GCCcore-14.2.0.eb)
* CFITSIO/4.6.2-GCCcore-14.2.0 (CFITSIO-4.6.2-GCCcore-14.2.0.eb)
* Armadillo/14.6.0-foss-2025a (Armadillo-14.6.0-foss-2025a.eb)
* json-c/0.18-GCCcore-14.2.0 (json-c-0.18-GCCcore-14.2.0.eb)
* Xerces-C++/3.3.0-GCCcore-14.2.0 (Xerces-C++-3.3.0-GCCcore-14.2.0.eb)
* Brunsli/0.1-GCCcore-14.2.0 (Brunsli-0.1-GCCcore-14.2.0.eb)
* LERC/4.0.0-GCCcore-14.2.0 (LERC-4.0.0-GCCcore-14.2.0.eb)
* GDAL/3.11.1-foss-2025a (GDAL-3.11.1-foss-2025a.eb)
* R-bundle-CRAN/2025.10-foss-2025a (R-bundle-CRAN-2025.10-foss-2025a.eb)
```

requires:
- https://github.com/easybuilders/easybuild-easyconfigs/pull/26573