### PR TITLE
{2025.06}[2025b] Arrow 22.0.0

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025b.yml
@@ -11,3 +11,7 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26421
         from-commit: 538776cf616f8eeeca9e96c8110c065f5256932c
   - R-4.5.2-gfbf-2025b.eb
+  - Arrow-22.0.0-gfbf-2025b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26569
+        from-commit: b9729dd1eeef12cc2b347b3f94508b12c724520a


### PR DESCRIPTION
dependency for `R-bundle-Bioconductor` (along with `R-bundle-CRAN` being tackled in #1550), which needs a fix from https://github.com/easybuilders/easybuild-easyconfigs/pull/26569 so handling this one in a dedicated PR...

```
5 out of 74 required modules missing:

* utf8proc/2.10.0-GCCcore-14.3.0 (utf8proc-2.10.0-GCCcore-14.3.0.eb)
* googlebenchmark/1.9.4-GCCcore-14.3.0 (googlebenchmark-1.9.4-GCCcore-14.3.0.eb)
* Abseil/20250512.1-GCCcore-14.3.0 (Abseil-20250512.1-GCCcore-14.3.0.eb)
* RE2/2025-07-22-GCCcore-14.3.0 (RE2-2025-07-22-GCCcore-14.3.0.eb)
* Arrow/22.0.0-gfbf-2025b (Arrow-22.0.0-gfbf-2025b.eb)
```