### PR TITLE
{2025.06}[2024a] ESPResSo 4.2.2 with CUDA 12.6.0

### DIFF
--- a/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.4.0-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.4.0-2024a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - ESPResSo-4.2.2-foss-2024a-CUDA-12.6.0.eb


### PR DESCRIPTION
Needs some CPU-only deps to be installed first: 
```
3 out of 102 required modules missing:

* Pint/0.24.4-GCCcore-13.3.0 (Pint-0.24.4-GCCcore-13.3.0.eb)
* Boost.MPI/1.85.0-gompi-2024a (Boost.MPI-1.85.0-gompi-2024a.eb)
* ESPResSo/4.2.2-foss-2024a-CUDA-12.6.0 (ESPResSo-4.2.2-foss-2024a-CUDA-12.6.0.eb)
```

See https://github.com/EESSI/software-layer/pull/1566.