### PR TITLE
Fix API lookup for GH action that updates software_layer_scripts_commit

### DIFF
--- a/.github/workflows/update_software_layer_scripts_commit.yml
+++ b/.github/workflows/update_software_layer_scripts_commit.yml
@@ -71,8 +71,8 @@ jobs:
 
           # main is behind latest, but an open PR from a previous run may already pin it.
           BRANCH_SHA=""
-          if CONTENT=$(gh api "repos/${{ github.repository }}/contents/bot/software_layer_scripts_commit" \
-                          -f ref=gh_action_update_software_layer_commit_sha --jq -r .content 2>/dev/null); then
+          if CONTENT=$(gh api "repos/${{ github.repository }}/contents/bot/software_layer_scripts_commit?ref=gh_action_update_software_layer_commit_sha" \
+                          --jq -r .content 2>/dev/null); then
             BRANCH_SHA=$(printf '%s' "$CONTENT" | base64 -d | tr -d '[:space:]')
           fi
 


### PR DESCRIPTION
The gh api infers POST when -f/-F parameters are passed without an explicit --method, so "-f ref=<branch>" turned the read into an invalid POST and the API 404'd. This leaves BRANCH_SHA empty and deafetes the skip-if-already-pinned check added in 3ed57bc9. 

Fix: Pass ref as a GET query parameter on the URL instead. Verified against the live repo with curl: the POST form 404s, the query-param form returns 200 with the expected content.