### PR TITLE
{2026.06}[2026.1] Some dependencies of LLVM and R

### DIFF
--- a/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.4.0-2026.1.yml
+++ b/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.4.0-2026.1.yml
@@ -4,3 +4,10 @@ easyconfigs:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26641
         from-commit: 66cb2c304ddb84721de82f09c02f44617354c01e
   - foss-2026.1.eb
+  - GObject-Introspection-1.86.0-GCCcore-15.2.0.eb
+  - HarfBuzz-14.2.0-GCCcore-15.2.0.eb
+  - GMP-6.3.0-GCCcore-15.2.0.eb
+  - lit-18.1.8-GCCcore-15.2.0.eb
+  - git-2.52.0-GCCcore-15.2.0.eb
+  - Z3-4.15.4-GCCcore-15.2.0.eb
+


### PR DESCRIPTION
Trying to work towards an installation of R-4.6.1-gfbf-2026.1.eb, which requires LLVM-21.1.8-GCCcore-15.2.0.eb. This PR adds some dependencies. If successful, we can try LLVM.

```
12 out of 53 required modules missing:

* GMP/6.3.0-GCCcore-15.2.0 (GMP-6.3.0-GCCcore-15.2.0.eb)
* PCRE2/10.47-GCCcore-15.2.0 (PCRE2-10.47-GCCcore-15.2.0.eb)
* fonttools/4.63.0-GCCcore-15.2.0 (fonttools-4.63.0-GCCcore-15.2.0.eb)
* ICU/78.3-GCCcore-15.2.0 (ICU-78.3-GCCcore-15.2.0.eb)
* lit/18.1.8-GCCcore-15.2.0 (lit-18.1.8-GCCcore-15.2.0.eb)
* GLib/2.89.0-GCCcore-15.2.0 (GLib-2.89.0-GCCcore-15.2.0.eb)
* git/2.52.0-GCCcore-15.2.0 (git-2.52.0-GCCcore-15.2.0.eb)
* Z3/4.15.4-GCCcore-15.2.0 (Z3-4.15.4-GCCcore-15.2.0.eb)
* pixman/0.46.4-GCCcore-15.2.0 (pixman-0.46.4-GCCcore-15.2.0.eb)
* cairo/1.18.4-GCCcore-15.2.0 (cairo-1.18.4-GCCcore-15.2.0.eb)
* GObject-Introspection/1.86.0-GCCcore-15.2.0 (GObject-Introspection-1.86.0-GCCcore-15.2.0.eb)
* HarfBuzz/14.2.0-GCCcore-15.2.0 (HarfBuzz-14.2.0-GCCcore-15.2.0.eb)
```