### PR TITLE
{2026.06}[2026.1,riscv64/generic] LLVM 21.1.8

### DIFF
--- a/easystacks/software.eessi.io/2026.06/riscv/eessi-2026.06-eb-5.4.0-2026.1.yml
+++ b/easystacks/software.eessi.io/2026.06/riscv/eessi-2026.06-eb-5.4.0-2026.1.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - LLVM-21.1.8-GCCcore-15.2.0.eb


### PR DESCRIPTION
Try to get LLVM 21.1.8 built for RISC-V, as we skipped it in #1583.

