### PR TITLE
{2025.06}[GCC/14.3.0] BEDTools 2.31.1

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.4.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.4.0-2025b.yml
@@ -1,3 +1,4 @@
 easyconfigs:
   - IRkernel-1.3.2-gfbf-2025b-R-4.5.2.eb
   - buildenv-default-lfoss-2025b.eb
+  - BEDTools-2.31.1-GCC-14.3.0.eb


### PR DESCRIPTION
Our local CI is now fully functional, we're now starting with build efforts. This is first small one.