### PR TITLE
Typo in `test-software.eessi.io.yml`

### DIFF
--- a/.github/workflows/test-software.eessi.io.yml
+++ b/.github/workflows/test-software.eessi.io.yml
@@ -326,7 +326,7 @@ jobs:
 
                 module --force purge
                 export EESSI_SOFTWARE_SUBDIR_OVERRIDE="$cpu"
-                module load EESSI//${{matrix.EESSI_VERSION}}
+                module load EESSI/${{matrix.EESSI_VERSION}}
 
                 env | grep ^EESSI | sort
 


### PR DESCRIPTION
Seems to have no consequence but still