### PR TITLE
{2025.06}[2025a] OpenFOAM v2506

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.4.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.4.0-2025a.yml
@@ -1,2 +1,3 @@
 easyconfigs:
   - MEME-5.5.9-gompi-2025a.eb
+  - OpenFOAM-v2506-foss-2025a.eb


### PR DESCRIPTION
```
4 out of 170 required modules missing:

* GKlib-METIS/5.1.1-GCC-14.2.0 (GKlib-METIS-5.1.1-GCC-14.2.0.eb)
* gperftools/2.16-GCCcore-14.2.0 (gperftools-2.16-GCCcore-14.2.0.eb)
* KaHIP/3.19-gompi-2025a (KaHIP-3.19-gompi-2025a.eb)
* OpenFOAM/v2506-foss-2025a (OpenFOAM-v2506-foss-2025a.eb)
```