### PR TITLE
{2025.06}[2024a] PETSc 3.23.5

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.4.0-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.4.0-2024a.yml
@@ -1,3 +1,4 @@
 easyconfigs:
   - Pint-0.24.4-GCCcore-13.3.0.eb
   - Boost.MPI-1.85.0-gompi-2024a.eb
+  - PETSc-3.23.5-foss-2024a.eb


### PR DESCRIPTION
```
4 out of 83 required modules missing:

* Hypre/2.32.0-foss-2024a (Hypre-2.32.0-foss-2024a.eb)
* SuperLU_DIST/9.1.0-foss-2024a (SuperLU_DIST-9.1.0-foss-2024a.eb)
* SuiteSparse/7.10.1-foss-2024a (SuiteSparse-7.10.1-foss-2024a.eb)
* PETSc/3.23.5-foss-2024a (PETSc-3.23.5-foss-2024a.eb)
```