### PR TITLE
{2025.06}[lfoss/2025b] PETSc 3.24.0

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.4.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.4.0-2025b.yml
@@ -9,3 +9,4 @@ easyconfigs:
   - Jellyfish-2.3.1-GCC-14.3.0.eb
   - prodigal-2.6.3-GCCcore-14.3.0.eb
   - slepc4py-3.24.0-foss-2025b.eb
+  - PETSc-3.24.0-lfoss-2025b.eb


### PR DESCRIPTION
```
14 out of 103 required modules missing:

* Boost/1.88.0-llvm-compilers-20.1.8 (Boost-1.88.0-llvm-compilers-20.1.8.eb)
* lfbf/2025b (lfbf-2025b.eb)
* SuiteSparse/7.11.0-lfbf-2025b (SuiteSparse-7.11.0-lfbf-2025b.eb)
* pybind11/3.0.0-llvm-compilers-20.1.8 (pybind11-3.0.0-llvm-compilers-20.1.8.eb)
* SciPy-bundle/2025.07-lfbf-2025b (SciPy-bundle-2025.07-lfbf-2025b.eb)
* mpi4py/4.1.0-lompi-2025b (mpi4py-4.1.0-lompi-2025b.eb)
* HDF5/1.14.6-lompi-2025b (HDF5-1.14.6-lompi-2025b.eb)
* netCDF/4.9.3-lompi-2025b (netCDF-4.9.3-lompi-2025b.eb)
* PnetCDF/1.14.1-lompi-2025b (PnetCDF-1.14.1-lompi-2025b.eb)
* SCOTCH/7.0.10-lompi-2025b (SCOTCH-7.0.10-lompi-2025b.eb)
* Hypre/2.33.0-lfoss-2025b (Hypre-2.33.0-lfoss-2025b.eb)
* SuperLU_DIST/9.1.0-lfoss-2025b (SuperLU_DIST-9.1.0-lfoss-2025b.eb)
* MUMPS/5.8.1-lfoss-2025b-metis (MUMPS-5.8.1-lfoss-2025b-metis.eb)
* PETSc/3.24.0-lfoss-2025b (PETSc-3.24.0-lfoss-2025b.eb)
```