### PR TITLE
{2025.06}[2025b] waLBerla 7.2

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.4.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.4.0-2025b.yml
@@ -9,3 +9,4 @@ easyconfigs:
   - Jellyfish-2.3.1-GCC-14.3.0.eb
   - prodigal-2.6.3-GCCcore-14.3.0.eb
   - slepc4py-3.24.0-foss-2025b.eb
+  - waLBerla-7.2-foss-2025b.eb


### PR DESCRIPTION
```
2 out of 56 required modules missing:

* Boost.MPI/1.88.0-gompi-2025b (Boost.MPI-1.88.0-gompi-2025b.eb)
* waLBerla/7.2-foss-2025b (waLBerla-7.2-foss-2025b.eb)
```