### PR TITLE
{2025.06} imkl 2024.2.0

### DIFF
--- a/.github/workflows/test-software.eessi.io.yml
+++ b/.github/workflows/test-software.eessi.io.yml
@@ -345,9 +345,9 @@ jobs:
                   eb_version=$(echo ${easystack_file} | sed 's/.*eb-\([0-9.]*\).*.yml/\1/g')
                   echo "checking ${easystack_file} with EasyBuild ${eb_version}..."
 
-                  if [[ "$easystack_file" == */additional_arch/* ]]; then
+                  if [[ "$easystack_file" =~ /(additional_arch|arch_specific)/ ]]; then
                     if [[ "$easystack_file" != *"/$EESSI_CPU_FAMILY/"* ]]; then
-                      echo "Detected an additional arch with CPU family not matching host ($EESSI_CPU_FAMILY), skipping CI for $easystack_file"
+                      echo "Detected an additional arch or arch-specific easystack with CPU family not matching host ($EESSI_CPU_FAMILY), skipping CI for $easystack_file"
                       continue
                     fi
                   fi

--- a/easystacks/software.eessi.io/2025.06/arch_specific/x86_64/eessi-2025.06-eb-5.4.0-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/arch_specific/x86_64/eessi-2025.06-eb-5.4.0-2024a.yml
@@ -1,0 +1,6 @@
+easyconfigs:
+  - imkl-2024.2.0.eb:
+      options:
+        # Redistribution is allowed,
+        # see https://www.intel.com/content/www/us/en/developer/articles/tool/onemkl-license-faq.html
+        accept-eula-for: Intel-oneAPI


### PR DESCRIPTION
Required for #1389.

Added it in a arch-specific subdir to prevent the check missing installations CI from complaining that this software is not available on other CPU families.

edit (by @boegel): re-distribution of Intel oneMKL is allowed according to , 
see also https://www.intel.com/content/www/us/en/developer/articles/tool/onemkl-license-faq.html and https://www.intel.com/content/www/us/en/developer/articles/license/end-user-license-agreement.html

<img width="787" height="900" alt="Screenshot 2026-09-08 at 16 23 50" src="https://github.com/user-attachments/assets/b402af8d-11fe-48e5-ad8f-91eb412aa121" />