### PR TITLE
{2025.06}[gompi/2025b] CGNS 4.5.0

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.4.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.4.0-2025b.yml
@@ -12,3 +12,4 @@ easyconfigs:
   - RDKit-2026.03.4-foss-2025b.eb
   - cutadapt-5.2-GCCcore-14.3.0.eb
   - napari-0.6.6-foss-2025b.eb
+  - CGNS-4.5.0-gompi-2025b.eb


### PR DESCRIPTION
Adding a new package to EESSI.

License information at https://github.com/CGNS/cgns.github.io/blob/v4.5.0/source/license.rst