### PR TITLE
{2025.06}[foss/2025b] snakemake 9.22.0

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.4.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.4.0-2025b.yml
@@ -12,3 +12,4 @@ easyconfigs:
   - RDKit-2026.03.4-foss-2025b.eb
   - cutadapt-5.2-GCCcore-14.3.0.eb
   - napari-0.6.6-foss-2025b.eb
+  - snakemake-9.22.0-foss-2025b.eb


### PR DESCRIPTION
First contribution: Snakemake version 9.22.0.

Licence: MIT https://snakemake.readthedocs.io/en/stable/project_info/license.html