### PR TITLE
{2023.06}[foss/2023b] OpenLB 1.8.1

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.4.0-2023b.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.4.0-2023b.yml
@@ -1,0 +1,5 @@
+easyconfigs:
+  - OpenLB-1.8.1-foss-2023b.eb:
+      options:
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26836
+        from-commit: e0be4b23a0030e2541b4033f75617a153335e9d5


### PR DESCRIPTION
```
2 out of 39 required modules missing:

* tinyxml2/10.0.0-GCCcore-13.2.0 (tinyxml2-10.0.0-GCCcore-13.2.0.eb)
* OpenLB/1.8.1-foss-2023b (OpenLB-1.8.1-foss-2023b.eb)
```