### PR TITLE
{2025.06}[2024a,aarch64] ArmComputeLibrary 25.02

### DIFF
--- a/easystacks/software.eessi.io/2025.06/arch_specific/aarch64/eessi-2025.06-eb-5.4.0-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/arch_specific/aarch64/eessi-2025.06-eb-5.4.0-2024a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - ArmComputeLibrary-25.02-GCCcore-13.3.0.eb

--- a/easystacks/software.eessi.io/2025.06/arch_specific/aarch64/eessi-2025.06-eb-5.4.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/arch_specific/aarch64/eessi-2025.06-eb-5.4.0-2025a.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - ArmComputeLibrary-25.02-GCCcore-14.2.0.eb

--- a/easystacks/software.eessi.io/2025.06/arch_specific/aarch64/eessi-2025.06-eb-5.4.0-2025b.yml
+++ b/easystacks/software.eessi.io/2025.06/arch_specific/aarch64/eessi-2025.06-eb-5.4.0-2025b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - ArmComputeLibrary-25.02-GCCcore-14.3.0.eb


### PR DESCRIPTION
Dependency of PyTorch on Arm64, see https://github.com/EESSI/software-layer/pull/1389.