### PR TITLE
{2026.06}[2026.1] Dependencies of R-bundle-CRAN 2026.07

### DIFF
--- a/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.4.0-2026.1.yml
+++ b/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.4.0-2026.1.yml
@@ -28,3 +28,12 @@ easyconfigs:
       options:
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/26818
         from-commit: 9ca4fd80740b7a78b5c62a173c698e613293bbad
+  - Arrow-24.0.0-gfbf-2026.1.eb
+  - ImageMagick-7.1.2-26-GCCcore-15.2.0.eb
+  - MPFR-4.2.2-GCCcore-15.2.0.eb
+  - Xvfb-21.1.23-GCCcore-15.2.0.eb
+  - GLPK-5.0-GCCcore-15.2.0.eb
+  - libsndfile-1.2.2-GCCcore-15.2.0.eb
+  - NLopt-2.10.1-GCCcore-15.2.0.eb
+  - UDUNITS-2.2.28-GCCcore-15.2.0.eb
+  - GSL-2.8-GCC-15.2.0.eb


### PR DESCRIPTION
Provides the missing dependencies for R-bundle-CRAN 2026.07
```
14 out of 140 required modules missing:

* FLAC/1.5.0-GCCcore-15.2.0 (FLAC-1.5.0-GCCcore-15.2.0.eb)
* UDUNITS/2.2.28-GCCcore-15.2.0 (UDUNITS-2.2.28-GCCcore-15.2.0.eb)
* GSL/2.8-GCC-15.2.0 (GSL-2.8-GCC-15.2.0.eb)
* MPFR/4.2.2-GCCcore-15.2.0 (MPFR-4.2.2-GCCcore-15.2.0.eb)
* GLPK/5.0-GCCcore-15.2.0 (GLPK-5.0-GCCcore-15.2.0.eb)
* LittleCMS/2.19.1-GCCcore-15.2.0 (LittleCMS-2.19.1-GCCcore-15.2.0.eb)
* libsndfile/1.2.2-GCCcore-15.2.0 (libsndfile-1.2.2-GCCcore-15.2.0.eb)
* NLopt/2.10.1-GCCcore-15.2.0 (NLopt-2.10.1-GCCcore-15.2.0.eb)
* RapidJSON/1.1.0-20250205-GCCcore-15.2.0 
(RapidJSON-1.1.0-20250205-GCCcore-15.2.0.eb)
* Ghostscript/10.07.1-GCCcore-15.2.0 (Ghostscript-10.07.1-GCCcore-15.2.0.eb)
* utf8proc/2.11.3-GCCcore-15.2.0 (utf8proc-2.11.3-GCCcore-15.2.0.eb)
* Xvfb/21.1.23-GCCcore-15.2.0 (Xvfb-21.1.23-GCCcore-15.2.0.eb)
* ImageMagick/7.1.2-26-GCCcore-15.2.0 (ImageMagick-7.1.2-26-GCCcore-15.2.0.eb)
* Arrow/24.0.0-gfbf-2026.1 (Arrow-24.0.0-gfbf-2026.1.eb)
```